### PR TITLE
docs: add blank line so first demo video embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Your browsing data stays on your device. ego lite only records whether you opted
 ## Demo
 
 Introduce ego lite
+
 https://github.com/user-attachments/assets/f48099f2-00dc-45ac-b3f3-f7f074ff55fa
 
 Find and apply to jobs automatically


### PR DESCRIPTION
Separates the "Introduce ego lite" label from its video URL with a blank line, matching the format of the other two demos. Without the blank line, GitHub renders the URL as plain text on the same paragraph instead of an embedded video player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)