### PR TITLE
Split fetch helpers by runtime

### DIFF
--- a/package/ego-browser/README.md
+++ b/package/ego-browser/README.md
@@ -72,7 +72,7 @@ src/
     load.ts              waitForLoad and load orchestration
     waits.ts             waitForElement, waitForNetworkIdle, wait
     files.ts             uploadFile
-  http.ts                httpGet
+  http.ts                serverFetch, browserFetch
   cdp-eval.ts            cdp() and js() raw eval
   learning/              site-learnings discovery and manifest validation
 scripts/

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -11,7 +11,7 @@ import * as nav from "./driver/nav.js";
 import * as observe from "./driver/observe.js";
 import * as waits from "./driver/waits.js";
 import * as files from "./driver/files.js";
-import { httpGet } from "./http.js";
+import { browserFetch, serverFetch } from "./http.js";
 import {
   loadBrowserToolSource,
   loadLearnedContext,
@@ -39,7 +39,7 @@ export {
 export { snapshot, snapshotRaw, snapshotText, captureScreenshot, elementEval, elementCenter, drainEvents } from "./driver/observe.js";
 export { wait, waitForLoad, waitForElement, waitForNetworkIdle } from "./driver/waits.js";
 export { uploadFile } from "./driver/files.js";
-export { httpGet } from "./http.js";
+export { browserFetch, serverFetch } from "./http.js";
 
 /**
  * List all task spaces.
@@ -345,7 +345,8 @@ export function helperContext(extra: any = {}) {
     ...files,
     cdp,
     js,
-    httpGet,
+    serverFetch,
+    browserFetch,
     gotoUrl,
     siteSkills,
     siteSkillsForUrl,

--- a/package/ego-browser/src/http.ts
+++ b/package/ego-browser/src/http.ts
@@ -1,16 +1,45 @@
+import { js } from "./cdp-eval.js";
+
 /**
- * Fetch text over HTTP with a browser-like User-Agent.
+ * Fetch text from Node with a browser-like User-Agent.
  * @param {string} url URL to fetch.
- * @param {{headers?: Record<string,string>, timeout?: number}} [options]
+ * @param {{headers?: Record<string,string>, timeout?: number, method?: string, body?: any}} [options]
  * @returns {Promise<string>} Response body text.
  */
-export async function httpGet(url, options: any = {}) {
+export async function serverFetch(url, options: any = {}) {
+  const { timeout = 20.0, headers = {}, ...fetchOptions } = options;
   const response = await fetch(url, {
-    headers: { "User-Agent": "Mozilla/5.0", ...(options.headers || {}) },
-    signal: AbortSignal.timeout((options.timeout ?? 20.0) * 1000)
+    ...fetchOptions,
+    headers: { "User-Agent": "Mozilla/5.0", ...headers },
+    signal: AbortSignal.timeout(timeout * 1000)
   });
   if (!response.ok) {
-    throw new Error(`GET ${url} failed: HTTP ${response.status}`);
+    throw new Error(`${fetchOptions.method || "GET"} ${url} failed: HTTP ${response.status}`);
   }
   return response.text();
+}
+
+/**
+ * Fetch text in the current browser page context.
+ * @param {string} url URL to fetch. Relative URLs resolve against the current page.
+ * @param {{headers?: Record<string,string>, timeout?: number, method?: string, body?: any}} [options]
+ * @returns {Promise<string>} Response body text.
+ */
+export async function browserFetch(url, options: any = {}) {
+  const { timeout = 20.0, ...fetchOptions } = options;
+  const payload = JSON.stringify({ url, options: fetchOptions, timeout });
+  return js(`(async () => {
+    const { url, options, timeout } = ${payload};
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout * 1000);
+    try {
+      const response = await fetch(url, { ...options, signal: controller.signal });
+      if (!response.ok) {
+        throw new Error(\`\${options.method || "GET"} \${url} failed: HTTP \${response.status}\`);
+      }
+      return await response.text();
+    } finally {
+      clearTimeout(timer);
+    }
+  })()`);
 }

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -35,7 +35,7 @@ The heredoc body runs in a Node.js process with direct access to all ego-browser
 - Keyboard & input: `typeText`, `fillInput`, `pressKey`, `dispatchKey`
 - File: `uploadFile`
 - Wait: `wait`, `waitForLoad`, `waitForElement`, `waitForNetworkIdle`
-- Fetch: `httpGet`
+- Fetch: `serverFetch`, `browserFetch`
 - CDP / evaluate: `js`, `elementEval`, `cdp`
 - Output: `cliLog`, `help`
 
@@ -44,7 +44,8 @@ Notes:
 - `pageInfo()` — returns the current tab's `url`, `title`, and other basic metadata.
 - `ensureRealTab()` — ensures a real tab exists (a freshly created task space may have none).
 - `drainEvents()` — consumes and returns the async event queue produced by the page (navigation events, network events, etc.).
-- `httpGet(url)` — issues a GET request in the browser context and returns the response body.
+- `serverFetch(url, options)` — issues a request from Node and returns the response body.
+- `browserFetch(url, options)` — issues a request from the current browser page context and returns the response body.
 - `help(name)` — prints usage for a given helper, e.g. `cliLog(help('click'))`.
 
 


### PR DESCRIPTION
## Summary
- replace httpGet with serverFetch for Node-side requests
- add browserFetch for requests from the current page context
- update ego-browser docs to expose the new helper names

## Verification
- npm test
- local ego-browser nodejs check: serverFetch=function, browserFetch=function, httpGet=undefined
- local HTTP echo test confirmed serverFetch does not send page cookies while browserFetch does