### PR TITLE
Refine taskspace helpers

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - feat
+        - feature
+        - enhancement
+    - title: Fixes
+      labels:
+        - fix
+        - bug
+        - bugfix
+    - title: Documentation
+      labels:
+        - docs
+        - documentation
+    - title: Maintenance
+      labels:
+        - chore
+        - ci
+        - refactor
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,10 @@ name: CI
 on:
   push:
     branches:
+      - dev
       - main
     tags:
-      - "*"
-      - "!last"
-      - "!latest"
+      - "v*.*.*"
   pull_request:
 
 jobs:
@@ -28,13 +27,14 @@ jobs:
       - run: npm run validate:site-skills
 
   release:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.ref_name != 'last' && github.ref_name != 'latest'
+    if: github.event_name == 'push' && (github.ref_name == 'dev' || startsWith(github.ref, 'refs/tags/v'))
     needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: write
     defaults:
       run:
+        shell: bash
         working-directory: package/ego-browser
     steps:
       - uses: actions/checkout@v4
@@ -47,34 +47,113 @@ jobs:
           cache-dependency-path: package/ego-browser/package-lock.json
       - run: npm ci
       - run: npm run build
-      - name: Package release payload
+      - name: Resolve release channel
+        id: release
         run: |
-          version_tag="${GITHUB_REF_NAME}"
+          ref_name="${GITHUB_REF_NAME}"
+          short_sha="$(git rev-parse --short HEAD)"
+          supported="true"
+          previous_tag=""
+
+          if [ "$ref_name" = "dev" ]; then
+            version_tag="nightly-$(date -u +%Y%m%d)-$short_sha"
+            release_tag="$version_tag"
+            title="Nightly $version_tag"
+            prerelease="true"
+            latest="false"
+            previous_tag="$(git tag --merged HEAD --sort=-creatordate --list 'nightly-*' | grep -v "^$release_tag$" | head -1 || true)"
+          elif [[ "$ref_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$ ]]; then
+            release_tag="$ref_name"
+            version_tag="$ref_name"
+            title="Beta $ref_name"
+            prerelease="true"
+            latest="false"
+            previous_tag="$(git tag --merged HEAD --sort=-creatordate --list 'v*.*.*-beta.*' | grep -v "^$release_tag$" | head -1 || true)"
+          elif [[ "$ref_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            release_tag="$ref_name"
+            version_tag="$ref_name"
+            title="ego lite $ref_name"
+            prerelease="false"
+            latest="true"
+            previous_tag="$(git tag --merged HEAD --sort=-creatordate --list 'v*.*.*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^$release_tag$" | head -1 || true)"
+          else
+            echo "Unsupported release ref: $ref_name"
+            supported="false"
+          fi
+
+          {
+            echo "supported=$supported"
+            echo "release_tag=$release_tag"
+            echo "version_tag=$version_tag"
+            echo "title=$title"
+            echo "prerelease=$prerelease"
+            echo "latest=$latest"
+            echo "previous_tag=$previous_tag"
+          } >> "$GITHUB_OUTPUT"
+      - name: Package release payload
+        if: steps.release.outputs.supported == 'true'
+        run: |
+          version_tag="${{ steps.release.outputs.version_tag }}"
           cd dist/out
           zip -r "../ego-browser-${version_tag}.zip" .
-      - name: Create tag release
+      - name: Create release
+        if: steps.release.outputs.supported == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           cd "$GITHUB_WORKSPACE"
 
-          version_tag="${GITHUB_REF_NAME}"
+          release_tag="${{ steps.release.outputs.release_tag }}"
+          version_tag="${{ steps.release.outputs.version_tag }}"
+          title="${{ steps.release.outputs.title }}"
+          prerelease="${{ steps.release.outputs.prerelease }}"
+          latest="${{ steps.release.outputs.latest }}"
+          previous_tag="${{ steps.release.outputs.previous_tag }}"
           commit_sha="$(git rev-parse HEAD)"
-          short_sha="$(git rev-parse --short HEAD)"
           artifact="package/ego-browser/dist/ego-browser-${version_tag}.zip"
+          notes_file="$(mktemp)"
+          release_args=()
+          notes_args=()
 
-          if ! git merge-base --is-ancestor "$commit_sha" origin/main; then
-            echo "Release tags must point to commits reachable from main."
+          if [[ "$release_tag" == nightly-* ]]; then
+            git tag -f "$release_tag" "$commit_sha"
+            git push -f origin "refs/tags/$release_tag"
+          elif [ "$prerelease" = "false" ] && ! git merge-base --is-ancestor "$commit_sha" origin/main; then
+            echo "Stable release tags must point to commits reachable from main."
             exit 1
           fi
 
-          if gh release view "$version_tag" >/dev/null 2>&1; then
-            echo "Release $version_tag already exists; leaving it unchanged."
+          if [ "$prerelease" = "true" ]; then
+            release_args+=(--prerelease)
+          fi
+
+          if [ "$latest" = "true" ]; then
+            release_args+=(--latest)
           else
-            gh release create "$version_tag" \
-              --title "$version_tag" \
-              --notes "Auto-built from $version_tag ($short_sha)" \
+            release_args+=(--latest=false)
+          fi
+
+          if [ -n "$previous_tag" ]; then
+            notes_args+=(-f "previous_tag_name=$previous_tag")
+          fi
+
+          gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="$release_tag" \
+            -f target_commitish="$commit_sha" \
+            "${notes_args[@]}" \
+            --jq .body > "$notes_file"
+
+          if gh release view "$release_tag" >/dev/null 2>&1; then
+            gh release edit "$release_tag" \
+              --title "$title" \
+              --notes-file "$notes_file" \
+              "${release_args[@]}"
+            gh release upload "$release_tag" "$artifact" --clobber
+          else
+            gh release create "$release_tag" \
+              --title "$title" \
+              --notes-file "$notes_file" \
               --verify-tag \
-              --latest=false \
+              "${release_args[@]}" \
               "$artifact"
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -298,6 +298,9 @@ A PR description should include at minimum:
 3. **How to verify** — repro / verification steps; attach screenshots or heredoc examples for UI behavior
 4. Impact callout (does it touch the helper surface? does the agent side need updates?)
 
+Add at least one release-note label so generated releases are grouped correctly:
+`feat` / `fix` / `docs` / `chore` / `ci` / `refactor`.
+
 ### Review Checklist
 
 - [ ] `npm test` is green
@@ -313,8 +316,11 @@ A PR description should include at minimum:
 
 - CI config: `.github/workflows/ci.yml`
   - Every push / PR: on Node 22 + ubuntu-latest, runs `npm ci` → `npm test` → `npm run validate:site-skills`
-  - After push to `main`: the `release` job rebuilds `artifacts/ego-browser/index.js` and **force-updates** the GitHub Release tagged `latest`
-- So "releasing" = merging to `main`. Release through PRs — do not hand-push tags.
+  - After push to `dev`: the `release` job builds a `nightly-YYYYMMDD-SHA` prerelease
+  - Tags matching `vX.Y.Z-beta.N`: build a beta prerelease
+  - Tags matching `vX.Y.Z`: build a stable release and mark it as latest
+- Release notes are generated automatically from merged PRs and grouped by `.github/release.yml` labels: Features, Fixes, Documentation, Maintenance, and Other Changes.
+- Normal flow: merge features into `dev` for nightly, cut beta tags from `dev`, then merge `dev` to `main` and cut stable `vX.Y.Z` tags from `main`.
 - The build script `scripts/build.mjs` uses `.build.lock` to prevent concurrent builds.
 
 ---

--- a/package/ego-browser/src/driver/pointer.test.mjs
+++ b/package/ego-browser/src/driver/pointer.test.mjs
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { setOverrides } from "../../dist/src/state.js";
+import { scroll } from "../../dist/src/driver/pointer.js";
+
+test("scroll falls back to DOM scrolling when mouseWheel dispatch fails", async () => {
+  const calls = [];
+  const restore = setOverrides({
+    cdpOverride(method, params, sessionId) {
+      calls.push({ method, params, sessionId });
+      if (method === "Input.dispatchMouseEvent") {
+        throw new Error("CDP request timed out: Input.dispatchMouseEvent");
+      }
+      if (method === "Runtime.evaluate") {
+        return { result: { value: { x: 0, y: 450 } } };
+      }
+      return {};
+    }
+  });
+  try {
+    const result = await scroll({ x: 50, y: 60, dx: 10, dy: 450 });
+    assert.deepEqual(result, { x: 0, y: 450 });
+  } finally {
+    restore();
+  }
+
+  assert.equal(calls[0].method, "Input.dispatchMouseEvent");
+  assert.deepEqual(calls[0].params, {
+    type: "mouseWheel",
+    x: 50,
+    y: 60,
+    deltaX: 10,
+    deltaY: 450
+  });
+  assert.equal(calls[1].method, "Runtime.evaluate");
+  assert.match(calls[1].params.expression, /window\.scrollBy/);
+});

--- a/package/ego-browser/src/driver/pointer.ts
+++ b/package/ego-browser/src/driver/pointer.ts
@@ -1,4 +1,5 @@
 import { cdp, js } from "../cdp-eval.js";
+import { browserCdp } from "../browser-runtime.js";
 import { elementCenter, elementEval } from "./observe.js";
 
 type MouseButton = "left" | "middle" | "right";
@@ -178,13 +179,18 @@ export async function scroll(x: number | ScrollOptions = 0, y: number | ScrollOp
     options = y;
     y = 0;
   }
-  await cdp("Input.dispatchMouseEvent", {
+  const params = {
     type: "mouseWheel",
     x: Number(x) || 0,
     y: Number(y) || 0,
     deltaX: options.dx ?? 0,
     deltaY: options.dy ?? -300
-  });
+  };
+  try {
+    await browserCdp("Input.dispatchMouseEvent", params, undefined, 1000);
+  } catch {
+    return scrollBy({ dx: params.deltaX, dy: params.deltaY });
+  }
 }
 
 /**

--- a/package/ego-browser/src/helpers.test.mjs
+++ b/package/ego-browser/src/helpers.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  completeTaskSpace,
   newTaskSpace,
   helperContext,
   listTaskSpaces,
@@ -110,7 +111,7 @@ test("switchTaskSpace selects a matching task space", async () => {
       ownership: "agent"
     });
   });
-  assert.deepEqual(calls, [["useTaskSpace", "checkout-flow"]]);
+  assert.deepEqual(calls, [["useTaskSpace", 7]]);
 });
 
 test("switchTaskSpace rejects non-agent-owned task spaces", async () => {
@@ -118,7 +119,7 @@ test("switchTaskSpace rejects non-agent-owned task spaces", async () => {
     async listTaskSpaces() {
       return {
         taskSpaces: [
-          { taskId: "checkout-flow", id: "checkout-flow", name: "checkout-flow", ownership: "user" }
+          { taskId: "checkout-flow", id: 7, name: "checkout-flow", ownership: "user" }
         ]
       };
     },
@@ -136,7 +137,7 @@ test("newTaskSpace creates and selects an agent task space", async () => {
   await withEgo({
     async createTaskSpace(name) {
       calls.push(["createTaskSpace", name]);
-      return { taskId: name, id: name, name, ownership: "agent" };
+      return { taskId: name, id: 7, name, ownership: "agent" };
     },
     useTaskSpace(taskId) {
       calls.push(["useTaskSpace", taskId]);
@@ -145,15 +146,42 @@ test("newTaskSpace creates and selects an agent task space", async () => {
   }, async () => {
     assert.deepEqual(await newTaskSpace("checkout-flow"), {
       taskId: "checkout-flow",
-      id: "checkout-flow",
+      id: 7,
       name: "checkout-flow",
       ownership: "agent"
     });
   });
   assert.deepEqual(calls, [
     ["createTaskSpace", "checkout-flow"],
-    ["useTaskSpace", "checkout-flow"]
+    ["useTaskSpace", 7]
   ]);
+});
+
+test("newTaskSpace rejects results without a numeric id", async () => {
+  const calls = [];
+  await withEgo({
+    async createTaskSpace(name) {
+      calls.push(["createTaskSpace", name]);
+      return { taskId: name, id: name, name };
+    },
+    async listTaskSpaces() {
+      calls.push(["listTaskSpaces"]);
+      return {
+        taskSpaces: [
+          { taskId: "checkout-flow", id: 7, name: "checkout-flow", ownership: "agent" }
+        ]
+      };
+    },
+    useTaskSpace(id) {
+      calls.push(["useTaskSpace", id]);
+    }
+  }, async () => {
+    await assert.rejects(
+      () => newTaskSpace("checkout-flow"),
+      /newTaskSpace requires a numeric task space id/
+    );
+  });
+  assert.deepEqual(calls, [["createTaskSpace", "checkout-flow"]]);
 });
 
 test("newTaskSpace throws on binding error objects", async () => {
@@ -177,7 +205,7 @@ test("useOrCreateTaskSpace reuses existing agent-owned spaces", async () => {
       calls.push(["listTaskSpaces"]);
       return {
         taskSpaces: [
-          { taskId: "checkout-flow", id: "checkout-flow", name: "checkout-flow", ownership: "agent" }
+          { taskId: "checkout-flow", id: 7, name: "checkout-flow", ownership: "agent" }
         ]
       };
     },
@@ -187,23 +215,23 @@ test("useOrCreateTaskSpace reuses existing agent-owned spaces", async () => {
     },
     async createTaskSpace(name) {
       calls.push(["createTaskSpace", name]);
-      return { taskId: name, id: name, name, ownership: "agent" };
+      return { taskId: name, id: 8, name, ownership: "agent" };
     },
-    async claimTaskSpace(name) {
-      calls.push(["claimTaskSpace", name]);
-      return { taskId: name, id: name, name, ownership: "agent" };
+    async claimTaskSpace(id, name) {
+      calls.push(["claimTaskSpace", id, name]);
+      return { taskId: name, id, name, ownership: "agent" };
     }
   }, async () => {
     assert.deepEqual(await useOrCreateTaskSpace("checkout-flow"), {
       taskId: "checkout-flow",
-      id: "checkout-flow",
+      id: 7,
       name: "checkout-flow",
       ownership: "agent"
     });
   });
   assert.deepEqual(calls, [
     ["listTaskSpaces"],
-    ["useTaskSpace", "checkout-flow"]
+    ["useTaskSpace", 7]
   ]);
 });
 
@@ -214,13 +242,13 @@ test("useOrCreateTaskSpace claims existing user-owned spaces", async () => {
       calls.push(["listTaskSpaces"]);
       return {
         taskSpaces: [
-          { taskId: "checkout-flow", id: "checkout-flow", name: "checkout-flow", ownership: "user" }
+          { taskId: "checkout-flow", id: 7, name: "checkout-flow", ownership: "user" }
         ]
       };
     },
-    async claimTaskSpace(name) {
-      calls.push(["claimTaskSpace", name]);
-      return { taskId: name, id: name, name, ownership: "agent" };
+    async claimTaskSpace(id, name) {
+      calls.push(["claimTaskSpace", id, name]);
+      return { taskId: name, id, name, ownership: "agent" };
     },
     useTaskSpace(taskId) {
       calls.push(["useTaskSpace", taskId]);
@@ -229,15 +257,15 @@ test("useOrCreateTaskSpace claims existing user-owned spaces", async () => {
   }, async () => {
     assert.deepEqual(await useOrCreateTaskSpace("checkout-flow"), {
       taskId: "checkout-flow",
-      id: "checkout-flow",
+      id: 7,
       name: "checkout-flow",
       ownership: "agent"
     });
   });
   assert.deepEqual(calls, [
     ["listTaskSpaces"],
-    ["claimTaskSpace", "checkout-flow"],
-    ["useTaskSpace", "checkout-flow"]
+    ["claimTaskSpace", 7, "checkout-flow"],
+    ["useTaskSpace", 7]
   ]);
 });
 
@@ -250,7 +278,7 @@ test("useOrCreateTaskSpace creates missing spaces", async () => {
     },
     async createTaskSpace(name) {
       calls.push(["createTaskSpace", name]);
-      return { taskId: name, id: name, name, ownership: "agent" };
+      return { taskId: name, id: 7, name, ownership: "agent" };
     },
     useTaskSpace(taskId) {
       calls.push(["useTaskSpace", taskId]);
@@ -259,7 +287,7 @@ test("useOrCreateTaskSpace creates missing spaces", async () => {
   }, async () => {
     assert.deepEqual(await useOrCreateTaskSpace("checkout-flow"), {
       taskId: "checkout-flow",
-      id: "checkout-flow",
+      id: 7,
       name: "checkout-flow",
       ownership: "agent"
     });
@@ -267,7 +295,86 @@ test("useOrCreateTaskSpace creates missing spaces", async () => {
   assert.deepEqual(calls, [
     ["listTaskSpaces"],
     ["createTaskSpace", "checkout-flow"],
-    ["useTaskSpace", "checkout-flow"]
+    ["useTaskSpace", 7]
+  ]);
+});
+
+test("useOrCreateTaskSpace resolves string names before numeric id strings", async () => {
+  const calls = [];
+  await withEgo({
+    async listTaskSpaces() {
+      calls.push(["listTaskSpaces"]);
+      return {
+        taskSpaces: [
+          { taskId: "plain-seven", id: 7, name: "plain-seven", ownership: "agent" },
+          { taskId: "7", id: 8, name: "7", ownership: "agent" }
+        ]
+      };
+    },
+    useTaskSpace(id) {
+      calls.push(["useTaskSpace", id]);
+      return id;
+    }
+  }, async () => {
+    assert.deepEqual(await useOrCreateTaskSpace("7"), {
+      taskId: "7",
+      id: 8,
+      name: "7",
+      ownership: "agent"
+    });
+  });
+  assert.deepEqual(calls, [
+    ["listTaskSpaces"],
+    ["useTaskSpace", 8]
+  ]);
+});
+
+test("useOrCreateTaskSpace rejects missing numeric ids instead of creating", async () => {
+  const calls = [];
+  await withEgo({
+    async listTaskSpaces() {
+      calls.push(["listTaskSpaces"]);
+      return { taskSpaces: [] };
+    },
+    async createTaskSpace(name) {
+      calls.push(["createTaskSpace", name]);
+      return { taskId: String(name), id: 7, name: String(name), ownership: "agent" };
+    }
+  }, async () => {
+    await assert.rejects(
+      () => useOrCreateTaskSpace(7),
+      /task space not found: 7/
+    );
+  });
+  assert.deepEqual(calls, [["listTaskSpaces"]]);
+});
+
+test("completeTaskSpace selects by numeric id before completing", async () => {
+  const calls = [];
+  await withEgo({
+    async listTaskSpaces() {
+      calls.push(["listTaskSpaces"]);
+      return {
+        taskSpaces: [
+          { taskId: "checkout-flow", id: 7, name: "checkout-flow", ownership: "agent" }
+        ]
+      };
+    },
+    useTaskSpace(id) {
+      calls.push(["useTaskSpace", id]);
+      return id;
+    },
+    async completeTaskSpace() {
+      calls.push(["completeTaskSpace"]);
+      return "7 task space completed.";
+    }
+  }, async () => {
+    await completeTaskSpace("checkout-flow", { keep: true });
+  });
+  assert.deepEqual(calls, [
+    ["listTaskSpaces"],
+    ["useTaskSpace", 7],
+    ["completeTaskSpace"]
   ]);
 });
 
@@ -276,7 +383,7 @@ test("useOrCreateTaskSpace rejects unknown ownership", async () => {
     async listTaskSpaces() {
       return {
         taskSpaces: [
-          { taskId: "checkout-flow", id: "checkout-flow", name: "checkout-flow", ownership: "shared" }
+          { taskId: "checkout-flow", id: 7, name: "checkout-flow", ownership: "shared" }
         ]
       };
     }

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -43,7 +43,7 @@ export { browserFetch, serverFetch } from "./http.js";
 
 /**
  * List all task spaces.
- * @returns {Promise<Array<{taskId:string,id:string|number,name:string,createdBy?:string,ownership?:string,recentTabTitles?:string[]}>>}
+ * @returns {Promise<Array<{taskId:string,id:number,name:string,createdBy?:string,ownership?:string,recentTabTitles?:string[]}>>}
  */
 export async function listTaskSpaces() {
   const ego = globalThis.ego;
@@ -56,7 +56,7 @@ export async function listTaskSpaces() {
 /**
  * Select an existing task space by id/name for the current Node invocation.
  * @param {string|number} nameOrId Task space id or name.
- * @returns {Promise<{taskId:string,id:string|number,name:string,createdBy?:string,ownership?:string,recentTabTitles?:string[]}>}
+ * @returns {Promise<{taskId:string,id:number,name:string,createdBy?:string,ownership?:string,recentTabTitles?:string[]}>}
  */
 export async function switchTaskSpace(nameOrId) {
   const ego = globalThis.ego;
@@ -72,8 +72,8 @@ export async function switchTaskSpace(nameOrId) {
 
 /**
  * Create an agent-owned task space and select it for the current Node invocation.
- * @param {string} name Task space id or name.
- * @returns {Promise<{taskId:string,id:string|number,name:string,createdBy?:string,ownership?:string,recentTabTitles?:string[]}>}
+ * @param {string} name Task space name.
+ * @returns {Promise<{taskId:string,id:number,name:string,createdBy?:string,ownership?:string,recentTabTitles?:string[]}>}
  */
 export async function newTaskSpace(name) {
   const ego = globalThis.ego;
@@ -84,38 +84,44 @@ export async function newTaskSpace(name) {
   if (!created) {
     throw new Error("newTaskSpace returned an invalid task space");
   }
+  taskSpaceNumericId(created, "newTaskSpace");
   return selectTaskSpace(ego, created, "newTaskSpace");
 }
 
 /**
  * Use an existing agent-owned task space, claim an existing user-owned space, or create it when missing.
- * @param {string} name Task space name.
- * @returns {Promise<{taskId:string,id:string|number,name:string,createdBy?:string,ownership?:string,recentTabTitles?:string[]}>}
+ * @param {string|number} nameOrId Task space name or numeric id.
+ * @returns {Promise<{taskId:string,id:number,name:string,createdBy?:string,ownership?:string,recentTabTitles?:string[]}>}
  */
-export async function useOrCreateTaskSpace(name) {
+export async function useOrCreateTaskSpace(nameOrId) {
   const spaces = await listTaskSpaces();
-  const existing = spaces.find((space) => taskSpaceMatches(space, name));
+  const existing = findMatchingTaskSpace(spaces, nameOrId);
   if (!existing) {
-    return newTaskSpace(name);
+    if (typeof nameOrId === "number") {
+      throw new Error(`task space not found: ${nameOrId}`);
+    }
+    return newTaskSpace(nameOrId);
   }
   if (existing.ownership === "agent") {
     return selectTaskSpace(globalThis.ego, existing, "useOrCreateTaskSpace");
   }
   if (existing.ownership === "user") {
-    return claimTaskSpace(name);
+    return claimTaskSpace(existing);
   }
-  throw new Error(`useOrCreateTaskSpace cannot use task space ${JSON.stringify(name)} with ownership ${JSON.stringify(existing.ownership)}`);
+  throw new Error(`useOrCreateTaskSpace cannot use task space ${JSON.stringify(nameOrId)} with ownership ${JSON.stringify(existing.ownership)}`);
 }
 
-async function claimTaskSpace(name) {
+async function claimTaskSpace(space) {
   const ego = globalThis.ego;
   if (!ego || typeof ego.claimTaskSpace !== "function") {
     throw new Error("useOrCreateTaskSpace requires ego.claimTaskSpace");
   }
-  const claimed = normalizeTaskSpace(assertNoEgoError(await ego.claimTaskSpace(name), "claimTaskSpace"));
+  const id = taskSpaceNumericId(space, "claimTaskSpace");
+  const claimed = normalizeTaskSpace(assertNoEgoError(await ego.claimTaskSpace(id, space.name), "claimTaskSpace"));
   if (!claimed) {
     throw new Error("claimTaskSpace returned an invalid task space");
   }
+  taskSpaceNumericId(claimed, "claimTaskSpace");
   return selectTaskSpace(ego, claimed, "claimTaskSpace");
 }
 
@@ -123,27 +129,27 @@ function selectTaskSpace(ego, space, op: string) {
   if (!ego || typeof ego.useTaskSpace !== "function") {
     throw new Error(`${op} requires ego.useTaskSpace`);
   }
-  ego.useTaskSpace(space.taskId);
+  ego.useTaskSpace(taskSpaceNumericId(space, op));
   return space;
 }
 
-async function switchTaskSpaceIfNamed(ego, name?: string) {
-  if (name === undefined) return;
-  const match = await findTaskSpace(name);
-  ego.useTaskSpace(match.taskId);
+async function selectTaskSpaceIfProvided(ego, nameOrId?: string | number, op = "taskSpace") {
+  if (nameOrId === undefined) return;
+  const match = await findTaskSpace(nameOrId);
+  ego.useTaskSpace(taskSpaceNumericId(match, op));
 }
 
 /**
  * Finish working on a task space. With `{ keep: true }` the page stays open
  * with the agent overlay dismissed so the user can review the result; with
  * `{ keep: false }` the task space is closed entirely.
- * @param {string} name Task space id or name.
+ * @param {string|number} nameOrId Task space id or name.
  * @param {{ keep: boolean }} options Required. `keep:true` hands the page to the user; `keep:false` closes the space.
  * @returns {Promise<void>}
  */
-export async function completeTaskSpace(name: string, options: { keep: boolean }) {
-  if (typeof name !== "string" || !name) {
-    throw new Error("completeTaskSpace requires a task space name");
+export async function completeTaskSpace(nameOrId: string | number, options: { keep: boolean }) {
+  if ((typeof nameOrId !== "string" && typeof nameOrId !== "number") || nameOrId === "") {
+    throw new Error("completeTaskSpace requires a task space name or id");
   }
   if (!options || typeof options.keep !== "boolean") {
     throw new Error("completeTaskSpace requires { keep: boolean }");
@@ -153,11 +159,11 @@ export async function completeTaskSpace(name: string, options: { keep: boolean }
     throw new Error("completeTaskSpace requires ego runtime");
   }
   const spaces = await listTaskSpaces();
-  const match = spaces.find((space) => space.taskId === name || space.id === name || space.name === name);
+  const match = findMatchingTaskSpace(spaces, nameOrId);
   if (!match) {
-    throw new Error(`task space not found: ${name}`);
+    throw new Error(`task space not found: ${nameOrId}`);
   }
-  ego.useTaskSpace(match.taskId);
+  ego.useTaskSpace(taskSpaceNumericId(match, "completeTaskSpace"));
   if (options.keep) {
     if (typeof ego.completeTaskSpace !== "function") {
       throw new Error("completeTaskSpace requires ego.completeTaskSpace");
@@ -173,29 +179,29 @@ export async function completeTaskSpace(name: string, options: { keep: boolean }
 
 /**
  * Hand off a task space back to the user, hiding the agent overlay.
- * @param {string} [name] Task space id or name. If provided, switches to that space first.
+ * @param {string|number} [nameOrId] Task space id or name. If provided, switches to that space first.
  * @returns {Promise<void>}
  */
-export async function handOffTaskSpace(name?: string) {
+export async function handOffTaskSpace(nameOrId?: string | number) {
   const ego = globalThis.ego;
   if (!ego || typeof ego.handOffTaskSpace !== "function") {
     throw new Error("handOffTaskSpace requires ego.handOffTaskSpace");
   }
-  await switchTaskSpaceIfNamed(ego, name);
+  await selectTaskSpaceIfProvided(ego, nameOrId, "handOffTaskSpace");
   assertNoEgoError(await ego.handOffTaskSpace(), "handOffTaskSpace");
 }
 
 /**
  * Take over a task space, showing the agent overlay to indicate work has resumed.
- * @param {string} [name] Task space id or name. If provided, switches to that space first.
+ * @param {string|number} [nameOrId] Task space id or name. If provided, switches to that space first.
  * @returns {Promise<void>}
  */
-export async function takeOverTaskSpace(name?: string) {
+export async function takeOverTaskSpace(nameOrId?: string | number) {
   const ego = globalThis.ego;
   if (!ego || typeof ego.takeOverTaskSpace !== "function") {
     throw new Error("takeOverTaskSpace requires ego.takeOverTaskSpace");
   }
-  await switchTaskSpaceIfNamed(ego, name);
+  await selectTaskSpaceIfProvided(ego, nameOrId, "takeOverTaskSpace");
   assertNoEgoError(await ego.takeOverTaskSpace(), "takeOverTaskSpace");
 }
 
@@ -250,19 +256,19 @@ async function probeAgentControl() {
  * Block until the agent regains control of the named task space.
  * Polls a harmless probe until it succeeds, or throws when the timeout
  * elapses. Read-only — does not call takeOverTaskSpace.
- * @param {string} name Task space id or name.
+ * @param {string|number} nameOrId Task space id or name.
  * @param {{ interval?: number, timeout?: number }} [options] interval & timeout in seconds (default 20s / 600s).
  * @returns {Promise<void>}
  */
-export async function waitForAgentControl(name: string, options: { interval?: number; timeout?: number } = {}) {
-  if (typeof name !== "string" || !name) {
-    throw new Error("waitForAgentControl requires a task space name");
+export async function waitForAgentControl(nameOrId: string | number, options: { interval?: number; timeout?: number } = {}) {
+  if ((typeof nameOrId !== "string" && typeof nameOrId !== "number") || nameOrId === "") {
+    throw new Error("waitForAgentControl requires a task space name or id");
   }
   const ego = globalThis.ego;
   if (!ego) {
     throw new Error("waitForAgentControl requires ego runtime");
   }
-  await switchTaskSpaceIfNamed(ego, name);
+  await selectTaskSpaceIfProvided(ego, nameOrId, "waitForAgentControl");
   const interval = typeof options.interval === "number" ? options.interval : 20;
   const timeout = typeof options.timeout === "number" ? options.timeout : 600;
   const deadline = Date.now() + timeout * 1000;
@@ -306,28 +312,45 @@ function normalizeTaskSpaces(raw) {
 }
 
 function normalizeTaskSpace(space) {
-  const taskId = space?.taskId || space?.id || space?.name;
-  if (!taskId) {
+  const taskId = space?.taskId ?? space?.name ?? space?.id;
+  if (taskId === undefined || taskId === null || taskId === "") {
     return null;
   }
   return {
     ...space,
     taskId,
-    id: space.id || taskId,
-    name: space.name || taskId
+    id: space?.id ?? taskId,
+    name: space?.name ?? taskId
   };
+}
+
+function taskSpaceNumericId(space, op: string) {
+  if (typeof space?.id !== "number" || !Number.isFinite(space.id)) {
+    throw new Error(`${op} requires a numeric task space id, got ${JSON.stringify(space?.id)}`);
+  }
+  return space.id;
 }
 
 async function findTaskSpace(nameOrId) {
   const spaces = await listTaskSpaces();
-  const match = spaces.find((space) => taskSpaceMatches(space, nameOrId));
+  const match = findMatchingTaskSpace(spaces, nameOrId);
   if (!match) throw new Error(`task space not found: ${nameOrId}`);
   return match;
 }
 
-function taskSpaceMatches(space, nameOrId) {
-  const value = String(nameOrId);
-  return String(space.taskId) === value || String(space.id) === value || String(space.name) === value;
+function findMatchingTaskSpace(spaces, nameOrId) {
+  if (typeof nameOrId === "number") {
+    return spaces.find((space) => space.id === nameOrId);
+  }
+  const byName = spaces.find((space) => space.name === nameOrId || space.taskId === nameOrId);
+  if (byName) return byName;
+  if (/^\d+$/.test(nameOrId)) {
+    const id = Number(nameOrId);
+    if (Number.isFinite(id)) {
+      return spaces.find((space) => space.id === id);
+    }
+  }
+  return undefined;
 }
 
 export async function siteSkillsForUrl(url) {

--- a/package/ego-browser/src/taskspace-e2e.test.mjs
+++ b/package/ego-browser/src/taskspace-e2e.test.mjs
@@ -7,7 +7,8 @@ class FakeEgo {
   constructor(taskSpaces = []) {
     this.taskSpaces = taskSpaces.map((space) => ({ ...space }));
     this.calls = [];
-    this.selectedTaskId = null;
+    this.selectedId = null;
+    this.nextId = Math.max(0, ...this.taskSpaces.map((space) => typeof space.id === "number" ? space.id : 0)) + 1;
   }
 
   async listTaskSpaces() {
@@ -15,29 +16,37 @@ class FakeEgo {
     return { taskSpaces: this.taskSpaces.map((space) => ({ ...space })) };
   }
 
-  useTaskSpace(taskId) {
-    this.calls.push(["useTaskSpace", taskId]);
-    this.selectedTaskId = taskId;
-    return taskId;
+  useTaskSpace(id) {
+    if (typeof id !== "number") {
+      throw new TypeError("useTaskSpace requires numeric id");
+    }
+    this.calls.push(["useTaskSpace", id]);
+    this.selectedId = id;
+    return id;
   }
 
   async createTaskSpace(name) {
     this.calls.push(["createTaskSpace", name]);
-    if (this.taskSpaces.some((space) => space.taskId === name || space.id === name || space.name === name)) {
+    if (this.taskSpaces.some((space) => space.taskId === name || space.name === name)) {
       return { error: `Task space already exists: ${name}` };
     }
-    const created = { taskId: name, id: name, name, createdBy: "agent", ownership: "agent", recentTabTitles: [] };
+    const created = { taskId: name, id: this.nextId++, name, createdBy: "agent", ownership: "agent", recentTabTitles: [] };
     this.taskSpaces.push(created);
     return { ...created };
   }
 
-  async claimTaskSpace(name) {
-    this.calls.push(["claimTaskSpace", name]);
-    const space = this.taskSpaces.find((candidate) => (
-      candidate.taskId === name || candidate.id === name || candidate.name === name
-    ));
+  async claimTaskSpace(id, name) {
+    if (typeof id !== "number") {
+      throw new TypeError("claimTaskSpace requires numeric id");
+    }
+    this.calls.push(["claimTaskSpace", id, name]);
+    const space = this.taskSpaces.find((candidate) => candidate.id === id);
     if (!space || space.ownership !== "user") {
-      return { error: `Task space not found: ${name}` };
+      return { error: `Task space not found: ${id}` };
+    }
+    if (name !== undefined) {
+      space.name = name;
+      space.taskId = name;
     }
     space.createdBy = "agent";
     space.ownership = "agent";
@@ -88,25 +97,25 @@ test("taskspace e2e creates and selects a missing task space", async () => {
   const ego = new FakeEgo();
   const result = await runTaskspaceScript(ego, `
     const task = await useOrCreateTaskSpace("checkout-flow");
-    cliLog(JSON.stringify({ task, selected: ego.selectedTaskId }));
+    cliLog(JSON.stringify({ task, selected: ego.selectedId }));
   `);
 
   assert.equal(result.exitCode, 0);
   assert.deepEqual(firstJsonLine(result.stdout), {
     task: {
       taskId: "checkout-flow",
-      id: "checkout-flow",
+      id: 1,
       name: "checkout-flow",
       createdBy: "agent",
       ownership: "agent",
       recentTabTitles: []
     },
-    selected: "checkout-flow"
+    selected: 1
   });
   assert.deepEqual(ego.calls, [
     ["listTaskSpaces"],
     ["createTaskSpace", "checkout-flow"],
-    ["useTaskSpace", "checkout-flow"]
+    ["useTaskSpace", 1]
   ]);
 });
 
@@ -116,38 +125,38 @@ test("taskspace e2e reuses an existing agent-owned task space", async () => {
   ]);
   const result = await runTaskspaceScript(ego, `
     const task = await useOrCreateTaskSpace(7);
-    cliLog(JSON.stringify({ task, selected: ego.selectedTaskId }));
+    cliLog(JSON.stringify({ task, selected: ego.selectedId }));
   `);
 
   assert.equal(result.exitCode, 0);
   assert.deepEqual(firstJsonLine(result.stdout), {
     task: { taskId: "checkout-flow", id: 7, name: "Checkout flow", createdBy: "agent", ownership: "agent" },
-    selected: "checkout-flow"
+    selected: 7
   });
   assert.deepEqual(ego.calls, [
     ["listTaskSpaces"],
-    ["useTaskSpace", "checkout-flow"]
+    ["useTaskSpace", 7]
   ]);
 });
 
 test("taskspace e2e claims and selects an existing user-owned task space", async () => {
   const ego = new FakeEgo([
-    { taskId: "checkout-flow", id: "checkout-flow", name: "checkout-flow", createdBy: "user", ownership: "user" }
+    { taskId: "checkout-flow", id: 7, name: "checkout-flow", createdBy: "user", ownership: "user" }
   ]);
   const result = await runTaskspaceScript(ego, `
     const task = await useOrCreateTaskSpace("checkout-flow");
-    cliLog(JSON.stringify({ task, selected: ego.selectedTaskId }));
+    cliLog(JSON.stringify({ task, selected: ego.selectedId }));
   `);
 
   assert.equal(result.exitCode, 0);
   assert.deepEqual(firstJsonLine(result.stdout), {
-    task: { taskId: "checkout-flow", id: "checkout-flow", name: "checkout-flow", createdBy: "agent", ownership: "agent" },
-    selected: "checkout-flow"
+    task: { taskId: "checkout-flow", id: 7, name: "checkout-flow", createdBy: "agent", ownership: "agent" },
+    selected: 7
   });
   assert.deepEqual(ego.calls, [
     ["listTaskSpaces"],
-    ["claimTaskSpace", "checkout-flow"],
-    ["useTaskSpace", "checkout-flow"]
+    ["claimTaskSpace", 7, "checkout-flow"],
+    ["useTaskSpace", 7]
   ]);
 });
 
@@ -173,7 +182,7 @@ test("taskspace e2e exposes newTaskSpace but not claimTaskSpace as a helper", as
 
 test("taskspace e2e rejects explicit use of a user-owned task space", async () => {
   const ego = new FakeEgo([
-    { taskId: "checkout-flow", id: "checkout-flow", name: "checkout-flow", createdBy: "user", ownership: "user" }
+    { taskId: "checkout-flow", id: 7, name: "checkout-flow", createdBy: "user", ownership: "user" }
   ]);
 
   await assert.rejects(
@@ -185,7 +194,7 @@ test("taskspace e2e rejects explicit use of a user-owned task space", async () =
 
 test("taskspace e2e rejects unknown task space ownership", async () => {
   const ego = new FakeEgo([
-    { taskId: "checkout-flow", id: "checkout-flow", name: "checkout-flow", ownership: "shared" }
+    { taskId: "checkout-flow", id: 7, name: "checkout-flow", ownership: "shared" }
   ]);
 
   await assert.rejects(
@@ -197,7 +206,7 @@ test("taskspace e2e rejects unknown task space ownership", async () => {
 
 test("taskspace e2e surfaces newTaskSpace binding errors", async () => {
   const ego = new FakeEgo([
-    { taskId: "checkout-flow", id: "checkout-flow", name: "checkout-flow", ownership: "agent" }
+    { taskId: "checkout-flow", id: 7, name: "checkout-flow", ownership: "agent" }
   ]);
 
   await assert.rejects(


### PR DESCRIPTION
## Summary
- require numeric taskspace ids for internal ego taskspace calls
- clarify name/id matching and helper parameter naming
- update release workflow for dev nightly/beta/stable releases

## Verification
- npm test
- npm run e2e
- npm run validate:site-skills
- npm pack
- real ego-browser smoke tests with Wikipedia, MDN, and Python.org