### PR TITLE
ci: use semver nightly release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,25 @@ jobs:
           previous_tag=""
 
           if [ "$ref_name" = "dev" ]; then
-            version_tag="nightly-$(date -u +%Y%m%d)-$short_sha"
+            latest_beta="$(git tag --sort=-v:refname --list 'v*.*.*-beta.*' | head -1 || true)"
+            latest_stable="$(git tag --sort=-v:refname --list 'v*.*.*' --list '[0-9]*.[0-9]*' | grep -E '^(v?[0-9]+\.[0-9]+\.[0-9]+|[0-9]+\.[0-9]+)$' | head -1 || true)"
+
+            if [ -n "$latest_beta" ]; then
+              base_version="${latest_beta%%-beta.*}"
+            elif [[ "$latest_stable" =~ ^v?([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+              base_version="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))"
+            elif [[ "$latest_stable" =~ ^([0-9]+)\.([0-9]+)$ ]]; then
+              base_version="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.1"
+            else
+              base_version="v0.1.0"
+            fi
+
+            version_tag="$base_version-nightly.$(date -u +%Y%m%d).$short_sha"
             release_tag="$version_tag"
             title="Nightly $version_tag"
             prerelease="true"
             latest="false"
-            previous_tag="$(git tag --merged HEAD --sort=-creatordate --list 'nightly-*' | grep -v "^$release_tag$" | head -1 || true)"
+            previous_tag="$(git tag --merged HEAD --sort=-creatordate --list 'v*.*.*-nightly.*' | grep -v "^$release_tag$" | head -1 || true)"
           elif [[ "$ref_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$ ]]; then
             release_tag="$ref_name"
             version_tag="$ref_name"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,7 +316,7 @@ Add at least one release-note label so generated releases are grouped correctly:
 
 - CI config: `.github/workflows/ci.yml`
   - Every push / PR: on Node 22 + ubuntu-latest, runs `npm ci` → `npm test` → `npm run validate:site-skills`
-  - After push to `dev`: the `release` job builds a `nightly-YYYYMMDD-SHA` prerelease
+  - After push to `dev`: the `release` job builds a `vX.Y.Z-nightly.YYYYMMDD.SHA` prerelease
   - Tags matching `vX.Y.Z-beta.N`: build a beta prerelease
   - Tags matching `vX.Y.Z`: build a stable release and mark it as latest
 - Release notes are generated automatically from merged PRs and grouped by `.github/release.yml` labels: Features, Fixes, Documentation, Maintenance, and Other Changes.


### PR DESCRIPTION
## What
Update nightly release tags to use the semver prerelease-style format `vX.Y.Z-nightly.YYYYMMDD.SHA`.

## Why
This keeps nightly tags visually tied to the upcoming version while preserving a unique tag per nightly build.

## How to verify
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/release.yml"); puts "yaml ok"'`\n- `bash -n` on the workflow release script snippets\n- `git diff --check -- .github/workflows/ci.yml CONTRIBUTING.md`\n\n## Impact\nRelease workflow only. Future `dev` pushes produce nightly tags such as `v1.2.1-nightly.20260609.f3e88bb`.