### PR TITLE
ci: create semver nightly tags before release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           release_args=()
           notes_args=()
 
-          if [[ "$release_tag" == nightly-* ]]; then
+          if [[ "$release_tag" == v*.*.*-nightly.* ]]; then
             git tag -f "$release_tag" "$commit_sha"
             git push -f origin "refs/tags/$release_tag"
           elif [ "$prerelease" = "false" ] && ! git merge-base --is-ancestor "$commit_sha" origin/main; then


### PR DESCRIPTION
## What
Fix nightly release creation for semver-style nightly tags such as `v1.2.1-nightly.20260609.50df6d6`.

## Why
The release workflow still checked `nightly-*`, so the new nightly tag was not created before `gh release create --verify-tag`, causing the release job to fail.

## How to verify
- YAML parses successfully
- Release script snippets pass `bash -n`
- `git diff --check -- .github/workflows/ci.yml`

## Impact
Release workflow only.