### PR TITLE
ci: use nightly tag as release title

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
             version_tag="$base_version-nightly.$(date -u +%Y%m%d).$short_sha"
             release_tag="$version_tag"
-            title="Nightly $version_tag"
+            title="$version_tag"
             prerelease="true"
             latest="false"
             previous_tag="$(git tag --merged HEAD --sort=-creatordate --list 'v*.*.*-nightly.*' | grep -v "^$release_tag$" | head -1 || true)"


### PR DESCRIPTION
## What
Use the nightly tag itself as the GitHub Release title.

## Why
Nightly releases should display as `v1.2.1-nightly.20260609.e5a3b87`, without the `Nightly ` prefix.

## How to verify
- YAML parses successfully
- Release script snippets pass `bash -n`
- `git diff --check -- .github/workflows/ci.yml`

## Impact
Release workflow display title only.