### PR TITLE
docs(ego-browser): scope completeTaskSpace to its own final heredoc

### DIFF
--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -55,7 +55,7 @@ A task space is an **isolated browsing context** that ego-browser provides for A
 
 A task often takes multiple heredoc rounds to complete. Because the Node.js runtime exits after each heredoc and retains no state, every heredoc you emit should start with an explicit call to `useOrCreateTaskSpace(name)` to reuse the same space — this lets you operate continuously and reuse tabs across rounds.
 
-**Only call `completeTaskSpace(name, { keep })` in the final heredoc round of the task** — do not call it in intermediate rounds. `keep` is required: pass `false` to close the space, or `true` to leave the page visible to the user:
+**`completeTaskSpace(name, { keep })` must occupy its own dedicated final heredoc, and run only after a prior heredoc's output has confirmed the task is genuinely done.** `keep` is required: pass `false` to close the space, or `true` to leave the page visible to the user:
 
 ```js
 await completeTaskSpace(name, { keep: false })  // close the space


### PR DESCRIPTION
## What

Reword the task-space section of the ego-browser skill so that `completeTaskSpace(name, { keep })` must occupy its own dedicated final heredoc and run only after a prior heredoc's output has confirmed the task is genuinely done.

**Before**
> **Only call `completeTaskSpace(name, { keep })` in the final heredoc round of the task** — do not call it in intermediate rounds.

**After**
> **`completeTaskSpace(name, { keep })` must occupy its own dedicated final heredoc, and run only after a prior heredoc's output has confirmed the task is genuinely done.**

## Why

"In the final round" still lets an agent fold the close into the same heredoc as its navigation/extraction/output. When the agent assumes a one-shot solution, it closes the space before observing the result; the next same-named round then gets a freshly recreated empty space, losing tabs and login state. Requiring a separate, post-verification closing heredoc keeps the irreversible close out of the work heredoc.

## Scope

Single-line wording change to `skills/ego-browser/SKILL.md`. No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
