### PR TITLE
Clarify and fix task space helper flow

### DIFF
--- a/package/ego-browser/src/helpers.test.mjs
+++ b/package/ego-browser/src/helpers.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   completeTaskSpace,
+  handOffTaskSpace,
   newTaskSpace,
   helperContext,
   listTaskSpaces,
@@ -128,6 +129,26 @@ test("switchTaskSpace rejects non-agent-owned task spaces", async () => {
     await assert.rejects(
       () => switchTaskSpace("checkout-flow"),
       /switchTaskSpace requires an agent-owned task space/
+    );
+  });
+});
+
+test("switchTaskSpace awaits useTaskSpace binding errors", async () => {
+  await withEgo({
+    async listTaskSpaces() {
+      return {
+        taskSpaces: [
+          { taskId: "checkout-flow", id: 7, name: "checkout-flow", ownership: "agent" }
+        ]
+      };
+    },
+    async useTaskSpace() {
+      return { error: "Task space not selected" };
+    }
+  }, async () => {
+    await assert.rejects(
+      () => switchTaskSpace("checkout-flow"),
+      /switchTaskSpace: Task space not selected/
     );
   });
 });
@@ -375,6 +396,115 @@ test("completeTaskSpace selects by numeric id before completing", async () => {
     ["listTaskSpaces"],
     ["useTaskSpace", 7],
     ["completeTaskSpace"]
+  ]);
+});
+
+test("completeTaskSpace waits for async useTaskSpace before completing", async () => {
+  const calls = [];
+  await withEgo({
+    async listTaskSpaces() {
+      calls.push(["listTaskSpaces"]);
+      return {
+        taskSpaces: [
+          { taskId: "checkout-flow", id: 7, name: "checkout-flow", ownership: "agent" }
+        ]
+      };
+    },
+    async useTaskSpace(id) {
+      calls.push(["useTaskSpace:start", id]);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      calls.push(["useTaskSpace:end", id]);
+    },
+    async completeTaskSpace() {
+      calls.push(["completeTaskSpace"]);
+      return "7 task space completed.";
+    }
+  }, async () => {
+    await completeTaskSpace("checkout-flow", { keep: true });
+  });
+  assert.deepEqual(calls, [
+    ["listTaskSpaces"],
+    ["useTaskSpace:start", 7],
+    ["useTaskSpace:end", 7],
+    ["completeTaskSpace"]
+  ]);
+});
+
+test("completeTaskSpace claims user-owned spaces before closing", async () => {
+  const calls = [];
+  await withEgo({
+    async listTaskSpaces() {
+      calls.push(["listTaskSpaces"]);
+      return {
+        taskSpaces: [
+          { taskId: "checkout-flow", id: 7, name: "checkout-flow", ownership: "user" }
+        ]
+      };
+    },
+    async claimTaskSpace(id, name) {
+      calls.push(["claimTaskSpace", id, name]);
+      return { taskId: name, id, name, ownership: "agent" };
+    },
+    async useTaskSpace(id) {
+      calls.push(["useTaskSpace", id]);
+      return id;
+    },
+    async closeTaskSpace() {
+      calls.push(["closeTaskSpace"]);
+      return "7 task space closed.";
+    }
+  }, async () => {
+    await completeTaskSpace("checkout-flow", { keep: false });
+  });
+  assert.deepEqual(calls, [
+    ["listTaskSpaces"],
+    ["claimTaskSpace", 7, "checkout-flow"],
+    ["useTaskSpace", 7],
+    ["closeTaskSpace"]
+  ]);
+});
+
+test("completeTaskSpace keep true is a no-op for user-owned spaces", async () => {
+  const calls = [];
+  await withEgo({
+    async listTaskSpaces() {
+      calls.push(["listTaskSpaces"]);
+      return {
+        taskSpaces: [
+          { taskId: "checkout-flow", id: 7, name: "checkout-flow", ownership: "user" }
+        ]
+      };
+    },
+    async completeTaskSpace() {
+      calls.push(["completeTaskSpace"]);
+    }
+  }, async () => {
+    await completeTaskSpace("checkout-flow", { keep: true });
+  });
+  assert.deepEqual(calls, [
+    ["listTaskSpaces"]
+  ]);
+});
+
+test("handOffTaskSpace is a no-op for user-owned spaces", async () => {
+  const calls = [];
+  await withEgo({
+    async listTaskSpaces() {
+      calls.push(["listTaskSpaces"]);
+      return {
+        taskSpaces: [
+          { taskId: "checkout-flow", id: 7, name: "checkout-flow", ownership: "user" }
+        ]
+      };
+    },
+    async handOffTaskSpace() {
+      calls.push(["handOffTaskSpace"]);
+    }
+  }, async () => {
+    await handOffTaskSpace("checkout-flow");
+  });
+  assert.deepEqual(calls, [
+    ["listTaskSpaces"]
   ]);
 });
 

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -106,37 +106,37 @@ export async function useOrCreateTaskSpace(nameOrId) {
     return selectTaskSpace(globalThis.ego, existing, "useOrCreateTaskSpace");
   }
   if (existing.ownership === "user") {
-    return claimTaskSpace(existing);
+    return claimTaskSpace(existing, "useOrCreateTaskSpace");
   }
   throw new Error(`useOrCreateTaskSpace cannot use task space ${JSON.stringify(nameOrId)} with ownership ${JSON.stringify(existing.ownership)}`);
 }
 
-async function claimTaskSpace(space) {
+async function claimTaskSpace(space, op = "claimTaskSpace") {
   const ego = globalThis.ego;
   if (!ego || typeof ego.claimTaskSpace !== "function") {
-    throw new Error("useOrCreateTaskSpace requires ego.claimTaskSpace");
+    throw new Error(`${op} requires ego.claimTaskSpace`);
   }
-  const id = taskSpaceNumericId(space, "claimTaskSpace");
-  const claimed = normalizeTaskSpace(assertNoEgoError(await ego.claimTaskSpace(id, space.name), "claimTaskSpace"));
+  const id = taskSpaceNumericId(space, op);
+  const claimed = normalizeTaskSpace(assertNoEgoError(await ego.claimTaskSpace(id, space.name), op));
   if (!claimed) {
-    throw new Error("claimTaskSpace returned an invalid task space");
+    throw new Error(`${op} returned an invalid task space`);
   }
-  taskSpaceNumericId(claimed, "claimTaskSpace");
-  return selectTaskSpace(ego, claimed, "claimTaskSpace");
+  taskSpaceNumericId(claimed, op);
+  return selectTaskSpace(ego, claimed, op);
 }
 
-function selectTaskSpace(ego, space, op: string) {
+async function selectTaskSpace(ego, space, op: string) {
   if (!ego || typeof ego.useTaskSpace !== "function") {
     throw new Error(`${op} requires ego.useTaskSpace`);
   }
-  ego.useTaskSpace(taskSpaceNumericId(space, op));
+  assertNoEgoError(await ego.useTaskSpace(taskSpaceNumericId(space, op)), op);
   return space;
 }
 
 async function selectTaskSpaceIfProvided(ego, nameOrId?: string | number, op = "taskSpace") {
   if (nameOrId === undefined) return;
   const match = await findTaskSpace(nameOrId);
-  ego.useTaskSpace(taskSpaceNumericId(match, op));
+  await selectTaskSpace(ego, match, op);
 }
 
 /**
@@ -163,13 +163,19 @@ export async function completeTaskSpace(nameOrId: string | number, options: { ke
   if (!match) {
     throw new Error(`task space not found: ${nameOrId}`);
   }
-  ego.useTaskSpace(taskSpaceNumericId(match, "completeTaskSpace"));
   if (options.keep) {
+    if (match.ownership === "user") return;
+    await selectTaskSpace(ego, match, "completeTaskSpace");
     if (typeof ego.completeTaskSpace !== "function") {
       throw new Error("completeTaskSpace requires ego.completeTaskSpace");
     }
     assertNoEgoError(await ego.completeTaskSpace(), "completeTaskSpace");
   } else {
+    if (match.ownership === "user") {
+      await claimTaskSpace(match, "completeTaskSpace");
+    } else {
+      await selectTaskSpace(ego, match, "completeTaskSpace");
+    }
     if (typeof ego.closeTaskSpace !== "function") {
       throw new Error("completeTaskSpace requires ego.closeTaskSpace");
     }
@@ -187,7 +193,11 @@ export async function handOffTaskSpace(nameOrId?: string | number) {
   if (!ego || typeof ego.handOffTaskSpace !== "function") {
     throw new Error("handOffTaskSpace requires ego.handOffTaskSpace");
   }
-  await selectTaskSpaceIfProvided(ego, nameOrId, "handOffTaskSpace");
+  if (nameOrId !== undefined) {
+    const match = await findTaskSpace(nameOrId);
+    if (match.ownership === "user") return;
+    await selectTaskSpace(ego, match, "handOffTaskSpace");
+  }
   assertNoEgoError(await ego.handOffTaskSpace(), "handOffTaskSpace");
 }
 

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -53,16 +53,22 @@ Notes:
 
 A task space is an **isolated browsing context** that ego-browser provides for AI Agents. Each task space has its own set of tabs but **inherits the current user's login state** by default, so Agents can operate on authenticated sites without competing with or disturbing the user's normal browser windows.
 
-A task often takes multiple heredoc rounds to complete. Because the Node.js runtime exits after each heredoc and retains no state, every heredoc you emit should start with an explicit call to `useOrCreateTaskSpace(name)` to reuse the same space — this lets you operate continuously and reuse tabs across rounds.
+A task often takes multiple heredoc rounds to complete. Because the Node.js runtime exits after each heredoc and retains no state, normal working heredocs should start with an explicit call to `useOrCreateTaskSpace(nameOrId)` to reuse the same space — this lets you operate continuously and reuse tabs across rounds. The exception is resuming after a user handoff: when the user says "continue" in chat, start the next heredoc with `takeOverTaskSpace(nameOrId)` instead.
 
-**`completeTaskSpace(name, { keep })` must occupy its own dedicated final heredoc, and run only after a prior heredoc's output has confirmed the task is genuinely done.** `keep` is required: pass `false` to close the space, or `true` to leave the page visible to the user:
+`nameOrId` can be a task space name, numeric id, or digit-only numeric id string. String values match `name`/`taskId` first, then digit-only strings fall back to numeric id. Number values match existing numeric ids only; if no matching id exists, `useOrCreateTaskSpace` fails instead of creating a new space.
+
+Use a descriptive string name for a new task space. Prefer using the numeric `id` returned by `useOrCreateTaskSpace` (for example, `task.id`) to resume a known task in later rounds and avoid name collisions.
+
+To continue work from an existing user-owned task space, use `listTaskSpaces()` to find the space, call `useOrCreateTaskSpace(id)` to claim it, then use `listTabs()` and `switchTab(targetId)` to select the exact tab before acting. This is different from resuming a handoff from your own prior task space, which starts with `takeOverTaskSpace(nameOrId)`.
+
+**`completeTaskSpace(nameOrId, { keep })` must occupy its own dedicated final heredoc, and run only after a prior heredoc's output has confirmed the task is genuinely done.** `keep` is required: pass `false` to close the space, or `true` to complete the space and leave the page visible to the user:
 
 ```js
-await completeTaskSpace(name, { keep: false })  // close the space
-await completeTaskSpace(name, { keep: true })   // keep the page for the user
+await completeTaskSpace(nameOrId, { keep: false })  // close the space
+await completeTaskSpace(nameOrId, { keep: true })   // keep the page for the user
 ```
 
-`name` should reflect the task's intent (e.g. `'search github issues'`); don't use literal placeholders.
+When passing a string that may create a new task space, the string should reflect the task's intent (e.g. `'search github issues'`); don't use literal placeholders.
 
 Keep loose awareness of how many tabs are open — a quick `(await listTabs()).length` is enough; there's no need to spend a dedicated round just to check. When scratch tabs (search-result pages, cross-check pages, and other one-off pages) pile up, close them as you go rather than letting them all accumulate for the end. When finishing with `{ keep: true }` to leave pages for the user, clear out the remaining scratch tabs so only the pages worth showing stay open. Close a single tab with `await cdp('Target.closeTarget', { targetId })` (`targetId` comes from `listTabs()` or an `openOrReuseTab` return value).
 
@@ -71,21 +77,21 @@ Keep loose awareness of how many tabs are open — a quick `(await listTabs()).l
 
 Only one side — agent or user — holds control of a task space at any time.
 
-**Handing off**: When the task requires user intervention (e.g. login, captcha, manual confirmation), call `handOffTaskSpace(name)` to give control to the user. After handoff, any browser operation by the agent will fail with a "user is controlling" message.
+**Handing off**: When the task requires user intervention (e.g. login, captcha, manual confirmation), call `handOffTaskSpace([nameOrId])` to give control to the user. Omitting `nameOrId` uses the currently selected task space; pass `task.id` across heredoc rounds to avoid ambiguity. After handoff, any browser operation by the agent will fail with a "user is controlling" message.
 
 **Regaining control** — two paths:
 
-1. **User says "continue" in chat** → call `takeOverTaskSpace(name)` to take back control, then continue. `takeOverTaskSpace` is idempotent — safe to call even if the user already returned control via GUI.
-2. **User returns via browser GUI** (without chatting) → the agent receives no notification. Use `waitForAgentControl(name)` to block until control comes back; once it returns, you can operate directly without calling `takeOverTaskSpace`.
+1. **User says "continue" in chat** → call `takeOverTaskSpace([nameOrId])` to take back control, then continue. Omitting `nameOrId` uses the currently selected task space. `takeOverTaskSpace` is idempotent — safe to call even if the user already returned control via GUI.
+2. **User returns via browser GUI** (without chatting) → the agent receives no notification. Use `waitForAgentControl(nameOrId)` to block until control comes back; once it returns, you can operate directly without calling `takeOverTaskSpace`.
 
 **Waiting for control handback example**:
 
 ```js
-await handOffTaskSpace(name)
+await handOffTaskSpace(nameOrId)
 cliLog('Please complete the login')
 
-await waitForAgentControl(name)              // polls every 20s by default, 10-minute timeout
-// await waitForAgentControl(name, { interval: 10, timeout: 300 })
+await waitForAgentControl(nameOrId)              // polls every 20s by default, 10-minute timeout
+// await waitForAgentControl(nameOrId, { interval: 10, timeout: 300 })
 // continue working...
 ```
 


### PR DESCRIPTION
## Summary
- Clarify ego-browser task space SKILL guidance for `nameOrId`, handoff recovery, and continuing from user-owned task spaces.
- Await and validate `ego.useTaskSpace(...)` before continuing with helper operations.
- Keep user-owned task-space semantics explicit: `useOrCreateTaskSpace` claims for agent continuation, handoff and `completeTaskSpace({ keep: true })` no-op when already user-owned, and `completeTaskSpace({ keep: false })` claims only to close.

## Testing
- `npm test` from `package/ego-browser`
- Real `ego-browser nodejs` heredoc sanity checks for cross-process task space reuse and handoff/takeover/complete flow using the debug index build.