### PR TITLE
fix: address code review findings in ego-browser helper runtime

### DIFF
--- a/package/ego-browser/README.md
+++ b/package/ego-browser/README.md
@@ -10,11 +10,11 @@ ego-browser (Chromium) → globalThis.ego → helper functions → agent heredoc
 
 ```bash
 npm ci
-npm run build     # bundle to artifacts/ego-browser/index.js
+npm run build     # bundle to dist/out/index.js
 npm test          # build + tsc --noEmit + node --test
 ```
 
-The build emits a single ESM file `artifacts/ego-browser/index.js`. The ego-browser browser dispatches `ego-browser nodejs <<'EOF' ... EOF` heredocs to that bundle. Inside the heredoc, all helpers (`snapshotText`, `click`, `useOrCreateTaskSpace`, ...) are pre-imported in camelCase.
+The build emits a single ESM file `dist/out/index.js`. The ego-browser browser dispatches `ego-browser nodejs <<'EOF' ... EOF` heredocs to that bundle. Inside the heredoc, all helpers (`snapshotText`, `click`, `useOrCreateTaskSpace`, ...) are pre-imported in camelCase.
 
 ```bash
 ego-browser nodejs <<'EOF'
@@ -27,7 +27,7 @@ EOF
 Local invocation without the browser (for debugging the helper bundle itself) reads stdin:
 
 ```bash
-node artifacts/ego-browser/index.js <<'JS'
+node dist/out/index.js <<'JS'
 cliLog(await pageInfo())
 JS
 ```

--- a/package/ego-browser/package.json
+++ b/package/ego-browser/package.json
@@ -4,14 +4,14 @@
   "description": "A TypeScript single-file build of the ego-browser CDP harness.",
   "type": "module",
   "bin": {
-    "index": "./dist/out/index.js"
+    "ego-browser": "./dist/out/index.js"
   },
   "scripts": {
     "clean": "rm -rf dist artifacts",
     "build": "node scripts/build.mjs",
     "e2e": "bash scripts/run-e2e.sh",
     "typecheck": "tsc --noEmit",
-    "test": "npm run build && npm run typecheck && node --test",
+    "test": "npm run build && npm run typecheck && node --test \"src/**/*.test.mjs\" \"test/*.test.js\"",
     "validate:learnings": "npm run build && EGO_BROWSER_AGENT_WORKSPACE=../../skills/ego-browser node dist/scripts/validate-site-skills.js",
     "validate:site-skills": "npm run build && EGO_BROWSER_AGENT_WORKSPACE=../../skills/ego-browser node dist/scripts/validate-site-skills.js"
   },

--- a/package/ego-browser/src/browser-runtime.ts
+++ b/package/ego-browser/src/browser-runtime.ts
@@ -2,6 +2,9 @@ import { state } from "./state.js";
 
 const RESPONSE_TIMEOUT_MS = 15000;
 const SESSION_TTL_MS = 2000;
+// Upper bound for buffered CDP events. The runtime can be long-lived (installEgoSdk
+// inside the browser); without a cap, undrained events grow without bound.
+const MAX_BUFFERED_EVENTS = 10000;
 const SESSION_LOST = /Session (?:with given id )?not found|Target closed|No session/i;
 const BROWSER_LEVEL = (method) => method.startsWith("Target.") || method.startsWith("Browser.");
 let nextMessageId = 1;
@@ -153,6 +156,9 @@ function handleMessage(message) {
     }
   }
   events.push(data);
+  if (events.length > MAX_BUFFERED_EVENTS) {
+    events.splice(0, events.length - MAX_BUFFERED_EVENTS);
+  }
 }
 
 export function browserSnapshotRefsToRefMap(refMap, refs = []) {

--- a/package/ego-browser/src/cdp-eval.ts
+++ b/package/ego-browser/src/cdp-eval.ts
@@ -12,11 +12,16 @@ let hasWarnedAboutFunctionJs = false;
  * @returns {Promise<object>} CDP result object.
  */
 export async function cdp(method, params: any = {}, sessionId = undefined) {
-  if (state.cdpOverride) {
-    return state.cdpOverride(method, params, sessionId);
+  const result = state.cdpOverride
+    ? await state.cdpOverride(method, params, sessionId)
+    : (await send({ method, params, session_id: sessionId })).result || {};
+  if (!sessionId && (method === "Network.enable" || method === "Network.disable")) {
+    // Mirror the default session's Network domain state so helpers like
+    // waitForNetworkIdle can restore it instead of tearing down a domain
+    // the caller still relies on for drainEvents().
+    state.networkDomainEnabled = method === "Network.enable";
   }
-  const response = await send({ method, params, session_id: sessionId });
-  return response.result || {};
+  return result;
 }
 
 /**

--- a/package/ego-browser/src/driver/nav.ts
+++ b/package/ego-browser/src/driver/nav.ts
@@ -1,5 +1,6 @@
 import { browserEgo, invalidateSession, setPreferredTarget } from "../browser-runtime.js";
 import { cdp, js } from "../cdp-eval.js";
+import { assertNoEgoError } from "../ego-errors.js";
 import { state } from "../state.js";
 import { waitForDocumentLoad } from "./load.js";
 
@@ -204,26 +205,4 @@ function tabMatchesUrl(tabUrl: string, wantedUrl: string, match: UrlMatchMode) {
 
 function trimSlash(pathname: string) {
   return pathname.replace(/\/+$/, "") || "/";
-}
-
-function assertNoEgoError(result, op: string) {
-  if (result && typeof result === "object" && "error" in result && result.error != null) {
-    throw new Error(`${op}: ${formatEgoError(result.error)}`);
-  }
-  return result;
-}
-
-function formatEgoError(err: unknown): string {
-  if (err == null) return String(err);
-  if (typeof err === "string") return err;
-  if (typeof err === "object") {
-    const obj = err as Record<string, unknown>;
-    if (typeof obj.message === "string") return obj.message;
-    try {
-      return JSON.stringify(err);
-    } catch {
-      return String(err);
-    }
-  }
-  return String(err);
 }

--- a/package/ego-browser/src/driver/pointer.test.mjs
+++ b/package/ego-browser/src/driver/pointer.test.mjs
@@ -4,6 +4,29 @@ import assert from "node:assert/strict";
 import { setOverrides } from "../../dist/src/state.js";
 import { scroll } from "../../dist/src/driver/pointer.js";
 
+test("scroll defaults to scrolling down (positive deltaY, DOM wheel convention)", async () => {
+  // Regression: the default used to be deltaY -300, which scrolls UP — CDP
+  // negates wheel deltas internally, so the DOM convention (positive = down)
+  // applies end to end. SKILL.md documents scroll({ dy: 900 }) as a downward
+  // scroll, matching scrollBy / scrollToBottomUntil.
+  const calls = [];
+  const restore = setOverrides({
+    cdpOverride(method, params) {
+      calls.push({ method, params });
+      return {};
+    }
+  });
+  try {
+    await scroll();
+  } finally {
+    restore();
+  }
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, "Input.dispatchMouseEvent");
+  assert.equal(calls[0].params.deltaY, 300);
+  assert.equal(calls[0].params.deltaX, 0);
+});
+
 test("scroll falls back to DOM scrolling when mouseWheel dispatch fails", async () => {
   const calls = [];
   const restore = setOverrides({

--- a/package/ego-browser/src/driver/pointer.ts
+++ b/package/ego-browser/src/driver/pointer.ts
@@ -164,10 +164,14 @@ export async function dragMouse(points: MouseTarget[], options: DragMouseOptions
 }
 
 /**
- * Scroll by wheel coordinates.
+ * Scroll by dispatching a CDP mouse wheel event.
+ * Sign convention follows DOM WheelEvent: positive dy scrolls down, negative dy scrolls up
+ * (CDP negates deltas internally when building the Blink wheel event, so the DOM convention
+ * applies end to end). Defaults to scrolling down by 300 CSS pixels, matching the downward
+ * defaults of scrollBy and scrollToBottomUntil.
  * @param {number|{x?:number,y?:number,dx?:number,dy?:number}} [x=0] Viewport x, or scroll options.
  * @param {number|{dx?: number, dy?: number}} [y=0] Viewport y, or scroll delta options.
- * @param {{dx?: number, dy?: number}} [options]
+ * @param {{dx?: number, dy?: number}} [options] Deltas in CSS pixels; positive dy scrolls down.
  * @returns {Promise<void>}
  */
 export async function scroll(x: number | ScrollOptions = 0, y: number | ScrollOptions = 0, options: ScrollOptions = {}) {
@@ -184,7 +188,7 @@ export async function scroll(x: number | ScrollOptions = 0, y: number | ScrollOp
     x: Number(x) || 0,
     y: Number(y) || 0,
     deltaX: options.dx ?? 0,
-    deltaY: options.dy ?? -300
+    deltaY: options.dy ?? 300
   };
   try {
     await browserCdp("Input.dispatchMouseEvent", params, undefined, 1000);
@@ -194,8 +198,9 @@ export async function scroll(x: number | ScrollOptions = 0, y: number | ScrollOp
 }
 
 /**
- * Scroll the window with DOM APIs.
- * @param {number|{dx?:number,dy?:number,left?:number,top?:number,behavior?: ScrollBehavior}} [amount=900] Vertical pixels, or scroll options.
+ * Scroll the window with DOM APIs. Positive dy scrolls down, negative dy scrolls up
+ * (same sign convention as scroll()).
+ * @param {number|{dx?:number,dy?:number,left?:number,top?:number,behavior?: ScrollBehavior}} [amount=900] Vertical pixels (positive scrolls down), or scroll options.
  * @param {{dx?:number,dy?:number,left?:number,top?:number,behavior?: ScrollBehavior}} [options]
  * @returns {Promise<{x:number,y:number}>} New window scroll position.
  */

--- a/package/ego-browser/src/driver/waits.test.mjs
+++ b/package/ego-browser/src/driver/waits.test.mjs
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { setOverrides } from "../../dist/src/state.js";
+import { waitForNetworkIdle } from "../../dist/src/driver/waits.js";
+
+test("waitForNetworkIdle enables the Network domain and disables it afterwards", async () => {
+  // Regression: nothing used to enable the Network domain, so the helper could
+  // report "idle" without ever being able to observe traffic.
+  const methods = [];
+  let t = 0;
+  const restore = setOverrides({
+    cdpOverride: async (method) => {
+      methods.push(method);
+      return {};
+    },
+    now: () => t,
+    sleep: async (ms) => {
+      t += ms;
+    }
+  });
+  try {
+    const result = await waitForNetworkIdle({ timeout: 5 });
+    assert.equal(result, true, "no traffic for idleMs resolves true");
+  } finally {
+    restore();
+  }
+  assert.equal(methods[0], "Network.enable", "must enable Network before observing");
+  assert.equal(methods.at(-1), "Network.disable", "must disable Network when done");
+});
+
+test("waitForNetworkIdle survives a bridge that rejects Network.enable", async () => {
+  let t = 0;
+  const restore = setOverrides({
+    cdpOverride: async (method) => {
+      if (method === "Network.enable" || method === "Network.disable") {
+        throw new Error("'Network.enable' wasn't found");
+      }
+      return {};
+    },
+    now: () => t,
+    sleep: async (ms) => {
+      t += ms;
+    }
+  });
+  try {
+    const result = await waitForNetworkIdle({ timeout: 5 });
+    assert.equal(result, true, "falls back to passive observation");
+  } finally {
+    restore();
+  }
+});

--- a/package/ego-browser/src/driver/waits.test.mjs
+++ b/package/ego-browser/src/driver/waits.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { setOverrides } from "../../dist/src/state.js";
+import { cdp } from "../../dist/src/cdp-eval.js";
 import { waitForNetworkIdle } from "../../dist/src/driver/waits.js";
 
 test("waitForNetworkIdle enables the Network domain and disables it afterwards", async () => {
@@ -27,6 +28,33 @@ test("waitForNetworkIdle enables the Network domain and disables it afterwards",
   }
   assert.equal(methods[0], "Network.enable", "must enable Network before observing");
   assert.equal(methods.at(-1), "Network.disable", "must disable Network when done");
+});
+
+test("waitForNetworkIdle leaves a caller-enabled Network domain enabled", async () => {
+  const methods = [];
+  let t = 0;
+  const restore = setOverrides({
+    cdpOverride: async (method) => {
+      methods.push(method);
+      return {};
+    },
+    now: () => t,
+    sleep: async (ms) => {
+      t += ms;
+    }
+  });
+  try {
+    await cdp("Network.enable"); // the caller owns the domain
+    methods.length = 0;
+    const result = await waitForNetworkIdle({ timeout: 5 });
+    assert.equal(result, true);
+  } finally {
+    restore();
+  }
+  assert.ok(
+    !methods.includes("Network.disable"),
+    "must not tear down a Network domain the caller enabled"
+  );
 });
 
 test("waitForNetworkIdle survives a bridge that rejects Network.enable", async () => {

--- a/package/ego-browser/src/driver/waits.ts
+++ b/package/ego-browser/src/driver/waits.ts
@@ -76,6 +76,11 @@ export async function waitForElement(selector: string, options: WaitForElementOp
 
 /**
  * Wait until network events are idle.
+ * Enables the CDP Network domain for the duration of the wait so that network
+ * events are actually delivered (previously nothing enabled the domain, so this
+ * could report "idle" without ever observing traffic). Best-effort: if the
+ * runtime does not deliver Network events, an idle window of idleMs still
+ * resolves true.
  * @param {{timeout?: number, idleMs?: number}} [options]
  * @returns {Promise<boolean>} True when idle before timeout.
  */
@@ -85,24 +90,33 @@ export async function waitForNetworkIdle(options: WaitForNetworkIdleOptions = {}
   const deadline = state.now() + timeout * 1000;
   let lastActivity = state.now();
   const inflight = new Set();
-  while (state.now() < deadline) {
-    for (const event of await drainEvents()) {
-      const method = event.method || "";
-      const params = event.params || {};
-      if (method === "Network.requestWillBeSent") {
-        inflight.add(params.requestId);
-        lastActivity = state.now();
-      } else if (method === "Network.loadingFinished" || method === "Network.loadingFailed") {
-        inflight.delete(params.requestId);
-        lastActivity = state.now();
-      } else if (method.startsWith("Network.")) {
-        lastActivity = state.now();
+  await cdp("Network.enable").catch(() => {
+    // Domain may be unsupported by the bridge; fall back to passive observation.
+  });
+  try {
+    while (state.now() < deadline) {
+      for (const event of await drainEvents()) {
+        const method = event.method || "";
+        const params = event.params || {};
+        if (method === "Network.requestWillBeSent") {
+          inflight.add(params.requestId);
+          lastActivity = state.now();
+        } else if (method === "Network.loadingFinished" || method === "Network.loadingFailed") {
+          inflight.delete(params.requestId);
+          lastActivity = state.now();
+        } else if (method.startsWith("Network.")) {
+          lastActivity = state.now();
+        }
       }
+      if (inflight.size === 0 && state.now() - lastActivity >= idleMs) {
+        return true;
+      }
+      await state.sleep(100);
     }
-    if (inflight.size === 0 && state.now() - lastActivity >= idleMs) {
-      return true;
-    }
-    await state.sleep(100);
+    return false;
+  } finally {
+    await cdp("Network.disable").catch(() => {
+      // Best-effort cleanup; keeps the event buffer from accumulating after the wait.
+    });
   }
-  return false;
 }

--- a/package/ego-browser/src/driver/waits.ts
+++ b/package/ego-browser/src/driver/waits.ts
@@ -78,8 +78,9 @@ export async function waitForElement(selector: string, options: WaitForElementOp
  * Wait until network events are idle.
  * Enables the CDP Network domain for the duration of the wait so that network
  * events are actually delivered (previously nothing enabled the domain, so this
- * could report "idle" without ever observing traffic). Best-effort: if the
- * runtime does not deliver Network events, an idle window of idleMs still
+ * could report "idle" without ever observing traffic). If the caller had
+ * already enabled the domain, it is left enabled on return. Best-effort: if
+ * the runtime does not deliver Network events, an idle window of idleMs still
  * resolves true.
  * @param {{timeout?: number, idleMs?: number}} [options]
  * @returns {Promise<boolean>} True when idle before timeout.
@@ -90,6 +91,7 @@ export async function waitForNetworkIdle(options: WaitForNetworkIdleOptions = {}
   const deadline = state.now() + timeout * 1000;
   let lastActivity = state.now();
   const inflight = new Set();
+  const ownsNetworkDomain = !state.networkDomainEnabled;
   await cdp("Network.enable").catch(() => {
     // Domain may be unsupported by the bridge; fall back to passive observation.
   });
@@ -115,8 +117,10 @@ export async function waitForNetworkIdle(options: WaitForNetworkIdleOptions = {}
     }
     return false;
   } finally {
-    await cdp("Network.disable").catch(() => {
-      // Best-effort cleanup; keeps the event buffer from accumulating after the wait.
-    });
+    if (ownsNetworkDomain) {
+      await cdp("Network.disable").catch(() => {
+        // Best-effort cleanup; keeps the event buffer from accumulating after the wait.
+      });
+    }
   }
 }

--- a/package/ego-browser/src/ego-errors.ts
+++ b/package/ego-browser/src/ego-errors.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared handling for `{ error: ... }` result objects returned by ego bindings.
+ * Single source of truth — previously duplicated in helpers.ts and driver/nav.ts.
+ */
+
+export function assertNoEgoError(result, op: string) {
+  if (result && typeof result === "object" && "error" in result && result.error != null) {
+    throw new Error(`${op}: ${formatEgoError(result.error)}`);
+  }
+  return result;
+}
+
+export function formatEgoError(err: unknown): string {
+  if (err == null) return String(err);
+  if (typeof err === "string") return err;
+  if (typeof err === "object") {
+    const obj = err as Record<string, unknown>;
+    if (typeof obj.message === "string") return obj.message;
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}

--- a/package/ego-browser/src/element-resolver.test.mjs
+++ b/package/ego-browser/src/element-resolver.test.mjs
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveElementCenter, ElementResolutionError } from "../dist/src/element-resolver.js";
+import { RefMap } from "../dist/src/ref-map.js";
+
+class FakeCDP {
+  constructor(handler) {
+    this.calls = [];
+    this.handler = handler;
+  }
+
+  async sendRaw(method, params = {}, sessionId = undefined) {
+    this.calls.push([method, params, sessionId]);
+    return this.handler(method, params, sessionId);
+  }
+}
+
+const AX_TREE = {
+  nodes: [
+    { role: { value: "button" }, name: { value: "ok" }, backendDOMNodeId: 100 }
+  ]
+};
+
+test("resolveElementCenter computes the center from a valid box model", async () => {
+  const refMap = new RefMap();
+  refMap.add("5", 100, "button", "ok");
+  const cdp = new FakeCDP(async (method) => {
+    if (method === "DOM.getBoxModel") {
+      return { model: { content: [0, 0, 10, 0, 10, 10, 0, 10] } };
+    }
+    return {};
+  });
+  const point = await resolveElementCenter(cdp, undefined, refMap, "@5");
+  assert.equal(point.x, 5);
+  assert.equal(point.y, 5);
+});
+
+test("degenerate box model throws transient instead of returning (0,0)", async () => {
+  // Regression: boxModelCenter used to return {x:0,y:0} for a missing content
+  // quad, which made callers click the top-left viewport corner.
+  const refMap = new RefMap();
+  refMap.add("5", 100, "button", "ok");
+  const cdp = new FakeCDP(async (method) => {
+    if (method === "DOM.getBoxModel") {
+      return { model: { content: [] } };
+    }
+    if (method === "Accessibility.getFullAXTree") {
+      return AX_TREE;
+    }
+    return {};
+  });
+  await assert.rejects(
+    () => resolveElementCenter(cdp, undefined, refMap, "@5"),
+    (error) => {
+      assert.ok(error instanceof ElementResolutionError);
+      assert.equal(error.kind, "transient");
+      assert.match(error.message, /no box model/);
+      return true;
+    }
+  );
+});
+
+test("role locator with degenerate box model throws transient", async () => {
+  const cdp = new FakeCDP(async (method) => {
+    if (method === "Accessibility.getFullAXTree") {
+      return AX_TREE;
+    }
+    if (method === "DOM.getBoxModel") {
+      return { model: {} };
+    }
+    return {};
+  });
+  await assert.rejects(
+    () => resolveElementCenter(cdp, undefined, new RefMap(), 'loc=role:button[name="ok"]'),
+    (error) => {
+      assert.ok(error instanceof ElementResolutionError);
+      assert.equal(error.kind, "transient");
+      return true;
+    }
+  );
+});

--- a/package/ego-browser/src/element-resolver.test.mjs
+++ b/package/ego-browser/src/element-resolver.test.mjs
@@ -59,6 +59,36 @@ test("degenerate box model throws transient instead of returning (0,0)", async (
       return true;
     }
   );
+  assert.ok(
+    !cdp.calls.some(([method]) => method === "Accessibility.getFullAXTree"),
+    "must not fall back to role/name lookup — it could match a different node with the same label"
+  );
+});
+
+test("stale backend node still falls back to role/name lookup", async () => {
+  const refMap = new RefMap();
+  refMap.add("5", 100, "button", "ok");
+  let boxModelCalls = 0;
+  const cdp = new FakeCDP(async (method) => {
+    if (method === "DOM.getBoxModel") {
+      boxModelCalls += 1;
+      if (boxModelCalls === 1) {
+        throw new Error("No node with given id found");
+      }
+      return { model: { content: [0, 0, 10, 0, 10, 10, 0, 10] } };
+    }
+    if (method === "Accessibility.getFullAXTree") {
+      return AX_TREE;
+    }
+    return {};
+  });
+  const point = await resolveElementCenter(cdp, undefined, refMap, "@5");
+  assert.equal(point.x, 5);
+  assert.equal(point.y, 5);
+  assert.ok(
+    cdp.calls.some(([method]) => method === "Accessibility.getFullAXTree"),
+    "a stale node must trigger the role/name fallback"
+  );
 });
 
 test("role locator with degenerate box model throws transient", async () => {

--- a/package/ego-browser/src/element-resolver.ts
+++ b/package/ego-browser/src/element-resolver.ts
@@ -344,7 +344,10 @@ function parseLocatorName(raw) {
 function boxModelCenter(model: any = {}) {
   const content = model.content || [];
   if (content.length < 8) {
-    return { x: 0, y: 0 };
+    // Returning a fake (0,0) here would silently click the viewport corner.
+    // Treat a missing/degenerate box model as "element not ready" so callers
+    // with retry semantics (waitForElement, ref fallback) can poll.
+    throw new ElementResolutionError("Element has no box model (not rendered or zero-sized)", "transient");
   }
   return {
     x: (content[0] + content[2] + content[4] + content[6]) / 4,

--- a/package/ego-browser/src/element-resolver.ts
+++ b/package/ego-browser/src/element-resolver.ts
@@ -32,7 +32,13 @@ export async function resolveElementCenter(cdp, sessionId, refMap, selectorOrRef
       try {
         const result = await send(cdp, "DOM.getBoxModel", { backendNodeId: entry.backendNodeId }, effectiveSessionId);
         return { ...boxModelCenter(result.model), sessionId: effectiveSessionId };
-      } catch {
+      } catch (error) {
+        if (error instanceof ElementResolutionError) {
+          // The node resolved but has no usable box model (not rendered yet).
+          // Propagate the retryable state instead of falling back to role/name,
+          // which could silently target a different node with the same label.
+          throw error;
+        }
         // The backend node can become stale after DOM updates; fall back to role/name lookup below.
       }
     }

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { setOverrides, state } from "./state.js";
+import { assertNoEgoError } from "./ego-errors.js";
 import { help as helpRuntime, formatHelp } from "./help-runtime.js";
 import { cdp, decodeUnserializableJsValue, js } from "./cdp-eval.js";
 import * as pointer from "./driver/pointer.js";
@@ -36,7 +37,7 @@ export {
   ensureRealTab,
   iframeTarget
 } from "./driver/nav.js";
-export { snapshot, snapshotRaw, snapshotText, captureScreenshot, elementEval, elementCenter, drainEvents } from "./driver/observe.js";
+export { snapshot, snapshotRaw, snapshotText, captureScreenshot, elementEval, elementCenter, fillElement, drainEvents } from "./driver/observe.js";
 export { wait, waitForLoad, waitForElement, waitForNetworkIdle } from "./driver/waits.js";
 export { uploadFile } from "./driver/files.js";
 export { browserFetch, serverFetch } from "./http.js";
@@ -213,28 +214,6 @@ export async function takeOverTaskSpace(nameOrId?: string | number) {
   }
   await selectTaskSpaceIfProvided(ego, nameOrId, "takeOverTaskSpace");
   assertNoEgoError(await ego.takeOverTaskSpace(), "takeOverTaskSpace");
-}
-
-function assertNoEgoError(result, op: string) {
-  if (result && typeof result === "object" && "error" in result && result.error != null) {
-    throw new Error(`${op}: ${formatEgoError(result.error)}`);
-  }
-  return result;
-}
-
-function formatEgoError(err: unknown): string {
-  if (err == null) return String(err);
-  if (typeof err === "string") return err;
-  if (typeof err === "object") {
-    const obj = err as Record<string, unknown>;
-    if (typeof obj.message === "string") return obj.message;
-    try {
-      return JSON.stringify(err);
-    } catch {
-      return String(err);
-    }
-  }
-  return String(err);
 }
 
 function isUserControlError(err: unknown) {

--- a/package/ego-browser/src/index.ts
+++ b/package/ego-browser/src/index.ts
@@ -24,6 +24,9 @@ export * from "./helpers.js";
 export { runMain } from "./run.js";
 
 const SYNC_HELPERS = new Set(["help"]);
+// Marks an ego runtime whose mutating methods have already been wrapped, so a
+// second installEgoSdk call cannot double-wrap createTab / task-space methods.
+const EGO_WRAPPED = Symbol.for("egoBrowser.sdkWrapped");
 
 export function installEgoSdk(target: InstallTarget = globalThis, options: InstallEgoSdkOptions = {}) {
   if (!target || typeof target !== "object") {
@@ -56,8 +59,11 @@ export function installEgoSdk(target: InstallTarget = globalThis, options: Insta
   if (target.ego && typeof target.ego === "object") {
     target.ego.helpers = installed;
     target.ego.learnings = {};
-    wrapCreateTab(target.ego);
-    wrapInvalidating(target.ego, ["useTaskSpace", "closeTaskSpace", "createTaskSpace", "claimTaskSpace"]);
+    if (!(target.ego as Record<symbol, unknown>)[EGO_WRAPPED]) {
+      wrapCreateTab(target.ego);
+      wrapInvalidating(target.ego, ["useTaskSpace", "closeTaskSpace", "createTaskSpace", "claimTaskSpace"]);
+      Object.defineProperty(target.ego, EGO_WRAPPED, { value: true, enumerable: false });
+    }
     exposeEgoMethods(target, target.ego);
   }
   return target;

--- a/package/ego-browser/src/learning/check-domain-learning.ts
+++ b/package/ego-browser/src/learning/check-domain-learning.ts
@@ -164,7 +164,7 @@ export async function pathExists(path: string) {
   }
 }
 
-function urlHostname(url) {
+export function urlHostname(url) {
   try {
     const parsed = String(url).includes("://")
       ? new URL(String(url))

--- a/package/ego-browser/src/learning/index.ts
+++ b/package/ego-browser/src/learning/index.ts
@@ -9,6 +9,7 @@ import {
   loadLearningManifest,
   siteSkillsForUrl,
   siteSkillsRoot,
+  urlHostname,
   LearningEntry,
   LearningManifest,
   LearnedContext,
@@ -109,17 +110,6 @@ export async function loadLearnedContext(url: string, options: any = {}): Promis
     knowledge: knowledgeNotes,
     tools: toolSignatures,
   };
-}
-
-function urlHostname(url) {
-  try {
-    const parsed = String(url).includes("://")
-      ? new URL(String(url))
-      : new URL(`https://${url}`);
-    return (parsed.hostname || "").toLowerCase().replace(/\.$/, "");
-  } catch {
-    return "";
-  }
 }
 
 function isLearningNotePath(siteDir: string, notePath: string) {

--- a/package/ego-browser/src/ref-map.ts
+++ b/package/ego-browser/src/ref-map.ts
@@ -1,10 +1,8 @@
 export class RefMap {
   map: Map<string, any>;
-  nextRef: number;
 
   constructor() {
     this.map = new Map();
-    this.nextRef = 1;
   }
 
   add(refId, backendNodeId, role, name, nth = undefined) {
@@ -22,23 +20,8 @@ export class RefMap {
     });
   }
 
-  addSelector(refId, selector, role, name, nth = undefined) {
-    this.map.set(refId, {
-      backendNodeId: undefined,
-      role,
-      name,
-      nth,
-      selector,
-      frameId: undefined
-    });
-  }
-
   get(refId) {
     return this.map.get(refId);
-  }
-
-  entriesSorted() {
-    return [...this.map.entries()].sort(([left], [right]) => refSortKey(left) - refSortKey(right));
   }
 
   remove(refId) {
@@ -47,15 +30,6 @@ export class RefMap {
 
   clear() {
     this.map.clear();
-    this.nextRef = 1;
-  }
-
-  nextRefNum() {
-    return this.nextRef;
-  }
-
-  setNextRefNum(value) {
-    this.nextRef = value;
   }
 }
 
@@ -71,9 +45,4 @@ export function parseRef(input) {
     }
   }
   return null;
-}
-
-function refSortKey(refId) {
-  const match = /^(\d+)$/.exec(refId);
-  return match ? Number(match[1]) : Number.MAX_SAFE_INTEGER;
 }

--- a/package/ego-browser/src/state.ts
+++ b/package/ego-browser/src/state.ts
@@ -27,7 +27,9 @@ export const state = {
   sessionTargetId: null,
   sessionAt: 0,
   sessionInflight: null,
-  preferredTargetId: null
+  preferredTargetId: null,
+  // Last observed Network domain state on the default session (tracked in cdp()).
+  networkDomainEnabled: false
 };
 
 export async function send(req) {


### PR DESCRIPTION
## Summary

Addresses the code review findings in the ego-browser helper runtime — a mix of behavioral bug fixes, regression coverage, and tech-debt cleanup.

## Bug fixes

- **`scroll()`**: default `deltaY` was `-300` (scrolls *up*). CDP negates wheel deltas internally (`input_handler.cc`), so the DOM convention (positive = down) applies end to end. Default is now `300` (down), consistent with `scrollBy`/`scrollToBottomUntil`; sign convention documented in JSDoc.
- **`boxModelCenter()`**: throws a transient `ElementResolutionError` on a degenerate box model instead of silently returning `(0,0)`, which made callers click the viewport corner.
- **`waitForNetworkIdle()`**: enables the Network domain for the duration of the wait (and disables it afterwards); previously nothing enabled it, so the helper could report idle without ever observing traffic.
- **`npm test`**: uses explicit globs so manual tests under `test/manual/` (which require a live browser) are no longer auto-discovered and failing.

## Maintenance

- Deduplicate `assertNoEgoError`/`formatEgoError` into `ego-errors.ts` and `urlHostname` into `check-domain-learning.ts`.
- Remove vestigial `RefMap` API (`addSelector`, `entriesSorted`, `nextRef` counters) per the tech-debt inventory.
- Guard `installEgoSdk` against double-wrapping ego methods on repeated installs; cap the buffered CDP event queue for long-lived runtimes.
- Re-export `fillElement` from `helpers.ts` so the module surface matches the injected helper context.
- Fix bin name (`index` → `ego-browser`) and stale artifact paths in README.

## Tests

New regression coverage for the scroll default direction, box model errors, and Network domain lifecycle.

- `npm test`: 64/64 pass
- `npm run e2e`: 7/7 pass
