### PR TITLE
Unify helper surface, report skipped task-space ops, narrow scroll fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,148 +1,60 @@
 # Repository Guidelines
 
 ## Project Overview
-`ego-browser` is a Node.js CDP browser-automation CLI for AI agents. It drives a real Chrome session through `ego` helpers, exposes a compact snapshot/ref workflow, and layers reusable site-specific knowledge on top of the browser runtime.
+`ego-browser` is a Node.js CDP browser-automation harness for AI agents. It drives the ego lite browser through `globalThis.ego` bindings (provided by the closed-source ego lite app), exposes a compact snapshot/ref workflow, and layers reusable site-specific knowledge ("learnings") on top of the browser runtime.
+
+This repo contains the open-source harness and the agent skill package — **not** the browser itself. The ego lite app bundles its own `ego-browser` binary that embeds this runtime; `skills/ego-browser/SKILL.md` documents that binary's usage (`ego-browser nodejs <<'EOF' ... EOF`). The repo CLI built here takes the heredoc directly on stdin with no subcommand.
 
 ## Architecture & Data Flow
-- `package/ego-browser/bin/ego-browser.js` is the entrypoint.
-  - Direct CLI execution calls `runMain()`.
-  - Importing the package installs the SDK onto `globalThis`.
-- `package/ego-browser/src/run.js` reads JavaScript from stdin and executes it inside an async function with helper APIs injected as parameters.
-- `package/ego-browser/src/helpers.js` composes the user-facing helper surface: navigation, observation, waits, pointer/keyboard/file helpers, `js()`, `cdp()`, and site-skill execution helpers.
-- `package/ego-browser/src/browser-runtime.js` owns CDP transport, session attachment/caching, event buffering, and session invalidation.
-- `package/ego-browser/src/element-resolver.js` resolves refs, locators, CSS/XPath, and AX-based targets.
-- `package/ego-browser/src/site-skills.js` discovers and loads site skills from `skills/ego-browser/learnings/`.
-- Shared mutable runtime state lives in `package/ego-browser/src/state.js`.
+- `package/ego-browser/src/index.ts` is the entrypoint with two startup paths:
+  - Executed directly as a CLI → `runMain()` (reads JavaScript from stdin, executes it).
+  - Imported as a module (how the app embeds it) → `installEgoSdk(globalThis)`.
+- Both paths expose the same helper surface, built by `helperContext()` in `src/helpers.ts` — the single source of truth for what agents can call (including `help()` and `agent_helpers.js` extensions).
+- `src/run.ts` executes stdin JavaScript inside an async function with the helpers injected as parameters.
+- `src/browser-runtime.ts` owns CDP transport over `ego.sendCDPMessage`, session attach/caching (2s TTL, auto re-attach on session loss), the buffered event queue (10k cap), and JS dialog tracking.
+- `src/cdp-eval.ts` provides `cdp()` and `js()` (string-expression evaluation; top-level `return` is auto-wrapped in an IIFE).
+- `src/element-resolver.ts` resolves all target forms — `@N` refs, `loc=css:` / `loc=role:` / `loc=href:` locators, `xpath=`, raw CSS — and classifies failures as `transient` (retryable) or `permanent`.
+- `src/ref-map.ts` + `src/ref-state.ts`: refs are numeric `backendNodeId`s (`@21`, not `@e21`). The map is rebuilt on every snapshot; using a ref while the map is empty triggers an automatic re-snapshot, which is what makes refs work across heredoc rounds.
+- `src/driver/` — `nav` (tabs, navigation), `pointer` (click/scroll/drag), `keyboard`, `observe` (snapshot/screenshot), `waits`, `files` (upload), `element-ops` (objectId handles), `load`.
+- `src/learning/` — discovery, validation, and execution of site skills from `skills/ego-browser/learnings/<site>/manifest.json` (`runSiteTool`, `runSiteBrowserTool`, `learnContext`).
+- `src/state.ts` is the shared mutable runtime state singleton; `src/env.ts` resolves the agent workspace (`EGO_BROWSER_AGENT_WORKSPACE`, falling back to the skill dir bundled next to the build output, then the repo's `skills/ego-browser`).
+- `src/help-runtime.ts` parses the built bundle's JSDoc with acorn at runtime to power `help()` — JSDoc on exported helpers is therefore user-facing documentation.
 
-Data flow is generally:
-`stdin JS` → `runMain()` → injected helpers → browser runtime/CDP → snapshot or DOM/AX resolution → optional site skills/tools.
+Data flow: `stdin JS` → `runMain()` → `helperContext()` helpers → browser runtime/CDP → snapshot or DOM/AX resolution → optional site tools → `cliLog(...)`.
+
+## Task Spaces
+Task spaces are isolated browsing contexts with an ownership model (`agent` / `user`):
+- `useOrCreateTaskSpace(nameOrId)` reuses an agent-owned space, claims a user-owned one, or creates a new one. Ids are numeric; prefer `task.id` over names across rounds.
+- `switchTaskSpace` requires agent ownership; `newTaskSpace` creates; `completeTaskSpace(nameOrId, { keep })` finishes (`keep` is mandatory).
+- Control handoff: `handOffTaskSpace` / `takeOverTaskSpace` / `waitForAgentControl`.
 
 ## Key Directories
-- `package/ego-browser/src/` — runtime, helpers, resolver, and site-skill loading.
-- `package/ego-browser/bin/` — CLI entrypoint.
-- `package/ego-browser/test/` — Node test suite for runtime, helpers, navigation, state, and site skills.
-- `package/ego-browser/scripts/` — validation scripts for learned site skills.
-- `skills/ego-browser/` — agent skill package, docs, references, and learned site skills.
-- `skills/ego-browser/learnings/` — reusable per-site experience packs.
-- `skills/ego-browser/references/` — maintenance guidance for learned skills.
+- `package/ego-browser/src/` — runtime, helpers, resolver, drivers, learning subsystem.
+- `package/ego-browser/src/**/*.test.mjs` — tests are colocated with the code (there is no separate `test/` directory).
+- `package/ego-browser/scripts/` — `build.mjs` (esbuild per-file → `dist/src`, rollup bundle → `dist/out/index.js`, copies `skills/ego-browser` → `dist/out/ego-browser`), `validate-site-skills.ts`, `run-e2e.sh`.
+- `skills/ego-browser/` — agent skill package: `SKILL.md` (canonical agent-facing usage guide), `references/install.md`, `scripts/install.sh`.
+- `skills/ego-browser/learnings/` — reusable per-site experience packs (`manifest.json` + `notes/` + `tools/` + `browser-tools/`).
 
 ## Development Commands
 Run from `package/ego-browser/`:
-- `npm test` — run the Node test suite (`node --test`).
-- `npm run validate:learnings` — validate learned site skills.
-- `npm run validate:site-skills` — same validator entrypoint.
-- `node bin/ego-browser.js <<'JS' ... JS` — run the CLI from this checkout.
-- `npm link` — make the CLI available on PATH locally.
+- `npm test` — build, typecheck, then `node --test` over `src/**/*.test.mjs`.
+- `npm run e2e` — task-space e2e suite (`src/taskspace-e2e.test.mjs`).
+- `npm run validate:site-skills` (alias `validate:learnings`) — validate learned site skills.
+- `node dist/out/index.js <<'JS' ... JS` — run the built CLI from this checkout (requires an `ego` runtime for real browser work; `--doctor`, `--reload`, `-h` also supported).
 
 ## Code Conventions & Common Patterns
-- ESM only: `"type": "module"`.
-- Node 22+ is required by `package/ego-browser/package.json`.
-- Public helpers are camelCase only; avoid snake_case aliases.
-- Async helpers use verb-first names such as `runMain`, `ensureSession`, `siteSkillsForUrl`, and `runSiteTool`.
-- The code prefers a small shared state singleton over threading connection state through many call sites.
-- Helpers are designed to be injected into the script scope, not imported manually by agent scripts.
-- Snapshot refs like `@e1` are short-lived; re-snapshot after navigation or DOM changes and prefer stable `loc=...` values for reuse.
+- ESM only (`"type": "module"`); Node 22+.
+- Public helpers are camelCase, verb-first for async actions (`ensureSession`, `runSiteTool`).
+- Time parameters are in seconds unless the name ends in `Ms`.
+- Helpers are injected into the script scope, not imported by agent scripts.
+- New public helpers go through `helperContext()` in `src/helpers.ts` and need JSDoc (it feeds `help()`); keep `SKILL.md` in sync.
+- Snapshot refs (`@N`) are short-lived; re-snapshot after navigation or DOM changes and prefer stable `loc=...` values for reuse.
+- Element-resolution failures should use `ElementResolutionError` with an honest `transient`/`permanent` kind — wait loops rely on it.
+- The code prefers the small shared state singleton (`src/state.ts`) over threading connection state through call sites.
 - Site skills must stay site-shaped and verifiable: stable URLs, durable selectors, no pixel coordinates, no secrets.
 
-## Important Files
-- `package/ego-browser/bin/ego-browser.js` — CLI/SDK bootstrap.
-- `package/ego-browser/src/run.js` — stdin executor.
-- `package/ego-browser/src/browser-runtime.js` — CDP transport and session handling.
-- `package/ego-browser/src/helpers.js` — helper composition.
-- `package/ego-browser/src/site-skills.js` — site-skill discovery and execution.
-- `package/ego-browser/scripts/validate-site-skills.js` — skill manifest validator.
-- `skills/ego-browser/SKILL.md` — canonical agent-facing usage guide.
-- `skills/ego-browser/scripts/check-domain-learned.js` — checks whether a domain is already covered by a learning.
-- `skills/ego-browser/learnings/_template/TEMPLATE.md` — starting point for new learnings.
-
-## Runtime/Tooling Preferences
-- Use Node.js 22 or newer.
-- Package manager is npm.
-- The runnable CLI lives in `package/ego-browser`; the skill package under `skills/ego-browser` is documentation and reusable learning assets, not the executable CLI.
-- By default the CLI loads agent workspace content from `../../skills/ego-browser`; override with `EGO_BROWSER_AGENT_WORKSPACE`.
-- Learned site skills are always active and are read on each helper call.
-
 ## Testing & QA
-- Test framework: Node’s built-in test runner via `node --test`.
-- Assertions use `node:assert/strict`.
-- Tests are behavior-focused and rely on temporary workspaces plus injected overrides.
-- Validate changes that affect learned skills with `npm run validate:site-skills`.
-- Prefer covering session handling, locator resolution, helper behavior, and site-skill validation when changing runtime code.
-
-## The Solution
-
-Four principles in one file that directly address these issues:
-
-| Principle | Addresses |
-|-----------|-----------|
-| **Think Before Coding** | Wrong assumptions, hidden confusion, missing tradeoffs |
-| **Simplicity First** | Overcomplication, bloated abstractions |
-| **Surgical Changes** | Orthogonal edits, touching code you shouldn't |
-| **Goal-Driven Execution** | Leverage through tests-first, verifiable success criteria |
-
-## The Four Principles in Detail
-
-### 1. Think Before Coding
-
-**Don't assume. Don't hide confusion. Surface tradeoffs.**
-
-LLMs often pick an interpretation silently and run with it. This principle forces explicit reasoning:
-
-- **State assumptions explicitly** — If uncertain, ask rather than guess
-- **Present multiple interpretations** — Don't pick silently when ambiguity exists
-- **Push back when warranted** — If a simpler approach exists, say so
-- **Stop when confused** — Name what's unclear and ask for clarification
-
-### 2. Simplicity First
-
-**Minimum code that solves the problem. Nothing speculative.**
-
-Combat the tendency toward overengineering:
-
-- No features beyond what was asked
-- No abstractions for single-use code
-- No "flexibility" or "configurability" that wasn't requested
-- No error handling for impossible scenarios
-- If 200 lines could be 50, rewrite it
-
-**The test:** Would a senior engineer say this is overcomplicated? If yes, simplify.
-
-### 3. Surgical Changes
-
-**Touch only what you must. Clean up only your own mess.**
-
-When editing existing code:
-
-- Don't "improve" adjacent code, comments, or formatting
-- Don't refactor things that aren't broken
-- Match existing style, even if you'd do it differently
-- If you notice unrelated dead code, mention it — don't delete it
-
-When your changes create orphans:
-
-- Remove imports/variables/functions that YOUR changes made unused
-- Don't remove pre-existing dead code unless asked
-
-**The test:** Every changed line should trace directly to the user's request.
-
-### 4. Goal-Driven Execution
-
-**Define success criteria. Loop until verified.**
-
-Transform imperative tasks into verifiable goals:
-
-| Instead of... | Transform to... |
-|--------------|-----------------|
-| "Add validation" | "Write tests for invalid inputs, then make them pass" |
-| "Fix the bug" | "Write a test that reproduces it, then make it pass" |
-| "Refactor X" | "Ensure tests pass before and after" |
-
-For multi-step tasks, state a brief plan:
-
-```
-1. [Step] → verify: [check]
-2. [Step] → verify: [check]
-3. [Step] → verify: [check]
-```
-
-Strong success criteria let the LLM loop independently. Weak criteria ("make it work") require constant clarification.
+- Framework: Node's built-in runner (`node --test`), assertions via `node:assert/strict`.
+- Tests run against the build output (`dist/src/...`) — `npm test` builds first.
+- Behavior-focused tests inject overrides (`__testing.setOverrides`) or a `FakeEgo` double (see `src/helpers.test.mjs`, `src/taskspace-e2e.test.mjs`).
+- Cover session handling, locator resolution, helper behavior, and site-skill validation when changing runtime code; run `npm run validate:site-skills` for learning changes.

--- a/package/ego-browser/src/driver/observe.ts
+++ b/package/ego-browser/src/driver/observe.ts
@@ -6,7 +6,6 @@ import { cdp, js } from "../cdp-eval.js";
 import { pageInfo } from "./nav.js";
 import { browserEgo, browserSnapshotRefsToRefMap, drainBrowserEvents, ensureSession, isBrowserRuntime, pendingDialog } from "../browser-runtime.js";
 import { resolveElementCenter } from "../element-resolver.js";
-import { withHandle } from "./element-ops.js";
 import { browserRefMap, ensureRefMapForRef, registerSnapshotForRefRefresh } from "../ref-state.js";
 
 type SnapshotOptions = {
@@ -62,25 +61,12 @@ export async function elementCenter(selectorOrRef) {
   return resolveElementCenter({ sendRaw: cdp }, undefined, browserRefMap, selectorOrRef);
 }
 
-export async function fillElement(selectorOrRef, value) {
-  await withHandle(selectorOrRef, async ({ objectId, sessionId }) => {
-    await cdp("Runtime.callFunctionOn", {
-      functionDeclaration: "function() { this.focus(); }",
-      objectId,
-      returnByValue: true,
-      awaitPromise: false
-    }, sessionId);
-    await cdp("Runtime.callFunctionOn", {
-      functionDeclaration: "function() { this.select && this.select(); this.value = ''; this.dispatchEvent(new Event('input', { bubbles: true })); }",
-      objectId,
-      returnByValue: true,
-      awaitPromise: false
-    }, sessionId);
-    await cdp("Input.insertText", { text: String(value) }, sessionId);
-  });
-}
+// Sequence number for default screenshot file names. Combined with the pid it
+// keeps concurrent agent processes (parallel task spaces) from overwriting each
+// other's shots in the shared tmpdir, and successive shots in one run distinct.
+let screenshotSeq = 0;
 
-export async function captureScreenshot(path = join(tmpdir(), "ego-browser-shot.png"), options: CaptureScreenshotOptions = {}) {
+export async function captureScreenshot(path = join(tmpdir(), `ego-browser-shot-${process.pid}-${++screenshotSeq}.png`), options: CaptureScreenshotOptions = {}) {
   const full = options.full ?? false;
   const raw = options.raw ?? false;
   const params: any = {

--- a/package/ego-browser/src/driver/pointer.test.mjs
+++ b/package/ego-browser/src/driver/pointer.test.mjs
@@ -67,13 +67,13 @@ test("scroll defaults to scrolling down (positive deltaY, DOM wheel convention)"
   assert.equal(calls[0].params.deltaX, 0);
 });
 
-test("scroll falls back to DOM scrolling when mouseWheel dispatch fails", async () => {
+test("scroll falls back to DOM scrolling only when wheel dispatch is unsupported", async () => {
   const calls = [];
   const restore = setOverrides({
     cdpOverride(method, params, sessionId) {
       calls.push({ method, params, sessionId });
       if (method === "Input.dispatchMouseEvent") {
-        throw new Error("CDP request timed out: Input.dispatchMouseEvent");
+        throw new Error("'Input.dispatchMouseEvent' wasn't found");
       }
       if (method === "Runtime.evaluate") {
         return { result: { value: { x: 0, y: 450 } } };
@@ -98,4 +98,42 @@ test("scroll falls back to DOM scrolling when mouseWheel dispatch fails", async 
   });
   assert.equal(calls[1].method, "Runtime.evaluate");
   assert.match(calls[1].params.expression, /window\.scrollBy/);
+});
+
+test("scroll propagates wheel dispatch timeouts instead of silently degrading", async () => {
+  // Regression: any error (including timeouts and "user is controlling") used
+  // to silently fall back to window.scrollBy, which is not equivalent to a
+  // real wheel event and masked the original failure.
+  const calls = [];
+  const restore = setOverrides({
+    cdpOverride(method) {
+      calls.push(method);
+      if (method === "Input.dispatchMouseEvent") {
+        throw new Error("CDP request timed out: Input.dispatchMouseEvent");
+      }
+      return {};
+    }
+  });
+  try {
+    await assert.rejects(() => scroll({ dy: 450 }), /timed out/);
+  } finally {
+    restore();
+  }
+  assert.deepEqual(calls, ["Input.dispatchMouseEvent"]);
+});
+
+test("scroll propagates user-control errors from wheel dispatch", async () => {
+  const restore = setOverrides({
+    cdpOverride(method) {
+      if (method === "Input.dispatchMouseEvent") {
+        throw new Error("user is controlling this task space");
+      }
+      return {};
+    }
+  });
+  try {
+    await assert.rejects(() => scroll(), /user is controlling/);
+  } finally {
+    restore();
+  }
 });

--- a/package/ego-browser/src/driver/pointer.ts
+++ b/package/ego-browser/src/driver/pointer.ts
@@ -193,9 +193,32 @@ export async function scroll(x: number | ScrollOptions = 0, y: number | ScrollOp
   };
   try {
     await browserCdp("Input.dispatchMouseEvent", params, undefined, 1000);
-  } catch {
+  } catch (error) {
+    // Degrade to DOM scrolling only when the target genuinely cannot dispatch
+    // wheel events. Everything else (timeouts, "user is controlling", session
+    // loss) propagates — window.scrollBy is NOT equivalent to a real wheel
+    // event (virtualized lists and inner scroll panes ignore window scrolling),
+    // so a silent fallback would hide the failure behind a different behavior.
+    if (!isWheelDispatchUnsupported(error)) {
+      throw error;
+    }
+    if (!hasWarnedAboutWheelFallback) {
+      hasWarnedAboutWheelFallback = true;
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(
+        `[ego-browser] scroll(): wheel dispatch unsupported on this target (${message}); ` +
+        `falling back to DOM scrollBy(). Wheel-only behaviors (virtualized lists, inner scroll panes) may not trigger.\n`
+      );
+    }
     return scrollBy({ dx: params.deltaX, dy: params.deltaY });
   }
+}
+
+let hasWarnedAboutWheelFallback = false;
+
+function isWheelDispatchUnsupported(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return /not (?:supported|implemented)|wasn't found|isn't found|unknown (?:method|command)|method not found/i.test(message);
 }
 
 /**

--- a/package/ego-browser/src/helpers.test.mjs
+++ b/package/ego-browser/src/helpers.test.mjs
@@ -463,7 +463,8 @@ test("completeTaskSpace claims user-owned spaces before closing", async () => {
       return "7 task space closed.";
     }
   }, async () => {
-    await completeTaskSpace("checkout-flow", { keep: false });
+    const result = await completeTaskSpace("checkout-flow", { keep: false });
+    assert.deepEqual(result, { done: true });
   });
   assert.deepEqual(calls, [
     ["listTaskSpaces"],
@@ -473,7 +474,7 @@ test("completeTaskSpace claims user-owned spaces before closing", async () => {
   ]);
 });
 
-test("completeTaskSpace keep true is a no-op for user-owned spaces", async () => {
+test("completeTaskSpace keep true skips user-owned spaces and reports it", async () => {
   const calls = [];
   await withEgo({
     async listTaskSpaces() {
@@ -488,14 +489,15 @@ test("completeTaskSpace keep true is a no-op for user-owned spaces", async () =>
       calls.push(["completeTaskSpace"]);
     }
   }, async () => {
-    await completeTaskSpace("checkout-flow", { keep: true });
+    const result = await completeTaskSpace("checkout-flow", { keep: true });
+    assert.deepEqual(result, { done: false, skipped: "user-owned" });
   });
   assert.deepEqual(calls, [
     ["listTaskSpaces"]
   ]);
 });
 
-test("handOffTaskSpace is a no-op for user-owned spaces", async () => {
+test("handOffTaskSpace skips user-owned spaces and reports it", async () => {
   const calls = [];
   await withEgo({
     async listTaskSpaces() {
@@ -510,10 +512,40 @@ test("handOffTaskSpace is a no-op for user-owned spaces", async () => {
       calls.push(["handOffTaskSpace"]);
     }
   }, async () => {
-    await handOffTaskSpace("checkout-flow");
+    const result = await handOffTaskSpace("checkout-flow");
+    assert.deepEqual(result, { done: false, skipped: "user-owned" });
   });
   assert.deepEqual(calls, [
     ["listTaskSpaces"]
+  ]);
+});
+
+test("handOffTaskSpace reports done for agent-owned spaces", async () => {
+  const calls = [];
+  await withEgo({
+    async listTaskSpaces() {
+      calls.push(["listTaskSpaces"]);
+      return {
+        taskSpaces: [
+          { taskId: "checkout-flow", id: 7, name: "checkout-flow", ownership: "agent" }
+        ]
+      };
+    },
+    async useTaskSpace(id) {
+      calls.push(["useTaskSpace", id]);
+      return id;
+    },
+    async handOffTaskSpace() {
+      calls.push(["handOffTaskSpace"]);
+    }
+  }, async () => {
+    const result = await handOffTaskSpace("checkout-flow");
+    assert.deepEqual(result, { done: true });
+  });
+  assert.deepEqual(calls, [
+    ["listTaskSpaces"],
+    ["useTaskSpace", 7],
+    ["handOffTaskSpace"]
   ]);
 });
 

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -33,11 +33,12 @@ export {
   switchTab,
   openOrReuseTab,
   closeTab,
+  gotoUrl,
   gotoAndWait,
   ensureRealTab,
   iframeTarget
 } from "./driver/nav.js";
-export { snapshot, snapshotRaw, snapshotText, captureScreenshot, elementCenter, fillElement, drainEvents } from "./driver/observe.js";
+export { snapshot, snapshotRaw, snapshotText, captureScreenshot, elementCenter, drainEvents } from "./driver/observe.js";
 export { wait, waitForLoad, waitForElement, waitForNetworkIdle } from "./driver/waits.js";
 export { uploadFile } from "./driver/files.js";
 export { browserFetch, serverFetch } from "./http.js";
@@ -53,6 +54,20 @@ export async function listTaskSpaces() {
   }
   return normalizeTaskSpaces(assertNoEgoError(await ego.listTaskSpaces(), "listTaskSpaces"));
 }
+
+/*
+ * Task space ownership policy (`ownership`: "agent" | "user").
+ * What each helper does when the target space is user-owned:
+ *
+ *   switchTaskSpace                     -> throws (agent-owned only)
+ *   useOrCreateTaskSpace                -> claims it (ownership transfers to the agent)
+ *   handOffTaskSpace                    -> skipped, resolves { done: false, skipped: "user-owned" }
+ *   completeTaskSpace { keep: true }    -> skipped, resolves { done: false, skipped: "user-owned" }
+ *   completeTaskSpace { keep: false }   -> claims it, then closes it
+ *   takeOverTaskSpace / waitForAgentControl -> no ownership check (operates as-is)
+ *
+ * Keep this table in sync with the one in skills/ego-browser/SKILL.md.
+ */
 
 /**
  * Select an existing task space by id/name for the current Node invocation.
@@ -144,9 +159,12 @@ async function selectTaskSpaceIfProvided(ego, nameOrId?: string | number, op = "
  * Finish working on a task space. With `{ keep: true }` the page stays open
  * with the agent overlay dismissed so the user can review the result; with
  * `{ keep: false }` the task space is closed entirely.
+ * User-owned spaces: `keep:true` is skipped (the user already has the page) and
+ * resolves `{ done: false, skipped: "user-owned" }`; `keep:false` claims the
+ * space first, then closes it.
  * @param {string|number} nameOrId Task space id or name.
  * @param {{ keep: boolean }} options Required. `keep:true` hands the page to the user; `keep:false` closes the space.
- * @returns {Promise<void>}
+ * @returns {Promise<{done: boolean, skipped?: "user-owned"}>} `{ done: true }` when the space was completed or closed; `{ done: false, skipped: "user-owned" }` when nothing was done.
  */
 export async function completeTaskSpace(nameOrId: string | number, options: { keep: boolean }) {
   if ((typeof nameOrId !== "string" && typeof nameOrId !== "number") || nameOrId === "") {
@@ -165,7 +183,9 @@ export async function completeTaskSpace(nameOrId: string | number, options: { ke
     throw new Error(`task space not found: ${nameOrId}`);
   }
   if (options.keep) {
-    if (match.ownership === "user") return;
+    if (match.ownership === "user") {
+      return { done: false, skipped: "user-owned" as const };
+    }
     await selectTaskSpace(ego, match, "completeTaskSpace");
     if (typeof ego.completeTaskSpace !== "function") {
       throw new Error("completeTaskSpace requires ego.completeTaskSpace");
@@ -182,12 +202,15 @@ export async function completeTaskSpace(nameOrId: string | number, options: { ke
     }
     assertNoEgoError(await ego.closeTaskSpace(), "completeTaskSpace");
   }
+  return { done: true };
 }
 
 /**
  * Hand off a task space back to the user, hiding the agent overlay.
+ * User-owned spaces are skipped (the user already controls them) and resolve
+ * `{ done: false, skipped: "user-owned" }`.
  * @param {string|number} [nameOrId] Task space id or name. If provided, switches to that space first.
- * @returns {Promise<void>}
+ * @returns {Promise<{done: boolean, skipped?: "user-owned"}>} `{ done: true }` when control was handed off; `{ done: false, skipped: "user-owned" }` when nothing was done.
  */
 export async function handOffTaskSpace(nameOrId?: string | number) {
   const ego = globalThis.ego;
@@ -196,10 +219,13 @@ export async function handOffTaskSpace(nameOrId?: string | number) {
   }
   if (nameOrId !== undefined) {
     const match = await findTaskSpace(nameOrId);
-    if (match.ownership === "user") return;
+    if (match.ownership === "user") {
+      return { done: false, skipped: "user-owned" as const };
+    }
     await selectTaskSpace(ego, match, "handOffTaskSpace");
   }
   assertNoEgoError(await ego.handOffTaskSpace(), "handOffTaskSpace");
+  return { done: true };
 }
 
 /**
@@ -268,29 +294,6 @@ export async function waitForAgentControl(nameOrId: string | number, options: { 
     }
     await waits.wait(interval);
   }
-}
-
-/**
- * Navigate the current tab to a URL and include matching site skill hints when enabled.
- * @param {string} url URL to navigate to.
- * @returns {Promise<object>} CDP navigation result, optionally with domain_skills.
- */
-export async function gotoUrl(url) {
-  const result = await nav.gotoUrl(url);
-  if (process.env.EGO_BROWSER_DOMAIN_SKILLS !== "1") {
-    return result;
-  }
-  const host = new URL(url).hostname.replace(/^www\./, "").split(".")[0];
-  const dir = join(state.agentWorkspace(), "domain-skills", host);
-  if (!existsSync(dir)) {
-    return result;
-  }
-  const skills = readdirSync(dir, { recursive: true })
-    .filter((file) => String(file).endsWith(".md"))
-    .map((file) => String(file).split("/").at(-1))
-    .sort()
-    .slice(0, 10);
-  return { ...result, domain_skills: skills };
 }
 
 function normalizeTaskSpaces(raw) {
@@ -411,7 +414,6 @@ export function helperContext(extra: any = {}) {
     js,
     serverFetch,
     browserFetch,
-    gotoUrl,
     siteSkills,
     siteSkillsForUrl,
     runSiteTool,

--- a/package/ego-browser/src/run.ts
+++ b/package/ego-browser/src/run.ts
@@ -109,22 +109,14 @@ async function execute(code: string, stdout: WritableLike) {
 
 export async function executionContext(stdout: WritableLike = processStdout) {
   const agentHelpers = await helpers.loadAgentHelpers();
-  const context = publicContext({ ...helpers, ...agentHelpers });
-  context.cliLog = (...args) => {
+  // Single source of truth for the agent-facing surface: the same helperContext()
+  // that installEgoSdk() exposes in the browser runtime, so the CLI and SDK paths
+  // cannot drift apart (and `help` exists in both).
+  const context: Record<string, any> = helpers.helperContext(agentHelpers);
+  context.cliLog = (...args: unknown[]) => {
     write(stdout, `${args.map(formatCliLogValue).join(" ")}\n`);
   };
   return context;
-}
-
-function publicContext(moduleLike: Record<string, any>) {
-  const out: Record<string, any> = {};
-  for (const [name, value] of Object.entries(moduleLike)) {
-    if (name === "__testing" || name.startsWith("_")) {
-      continue;
-    }
-    out[name] = value;
-  }
-  return out;
 }
 
 function readAll(stream: ReadableLike) {

--- a/package/ego-browser/src/taskspace-e2e.test.mjs
+++ b/package/ego-browser/src/taskspace-e2e.test.mjs
@@ -180,6 +180,28 @@ test("taskspace e2e exposes newTaskSpace but not claimTaskSpace as a helper", as
   });
 });
 
+test("cli e2e exposes the unified helperContext surface (help present, internals hidden)", async () => {
+  const ego = new FakeEgo();
+  const result = await runTaskspaceScript(ego, `
+    cliLog(JSON.stringify({
+      helpType: typeof help,
+      helpResultType: typeof help("click"),
+      newTabType: typeof newTab,
+      helperContextType: typeof helperContext,
+      loadAgentHelpersType: typeof loadAgentHelpers
+    }));
+  `);
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(firstJsonLine(result.stdout), {
+    helpType: "function",
+    helpResultType: "string",
+    newTabType: "undefined",
+    helperContextType: "undefined",
+    loadAgentHelpersType: "undefined"
+  });
+});
+
 test("taskspace e2e rejects explicit use of a user-owned task space", async () => {
   const ego = new FakeEgo([
     { taskId: "checkout-flow", id: 7, name: "checkout-flow", createdBy: "user", ownership: "user" }

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -63,6 +63,19 @@ Use a descriptive string name for a new task space. Prefer using the numeric `id
 
 To continue work from an existing user-owned task space, use `listTaskSpaces()` to find the space, call `useOrCreateTaskSpace(id)` to claim it, then use `listTabs()` and `switchTab(targetId)` to select the exact tab before acting. This is different from resuming a handoff from your own prior task space, which starts with `takeOverTaskSpace(nameOrId)`.
 
+**Ownership policy** — every task space has `ownership: 'agent' | 'user'`; the helpers treat user-owned spaces differently:
+
+| Helper | When the target space is user-owned |
+|---|---|
+| `switchTaskSpace` | throws — agent-owned spaces only |
+| `useOrCreateTaskSpace` | claims it (ownership transfers to the agent) |
+| `handOffTaskSpace` | skipped — resolves `{ done: false, skipped: 'user-owned' }` |
+| `completeTaskSpace(…, { keep: true })` | skipped — resolves `{ done: false, skipped: 'user-owned' }` |
+| `completeTaskSpace(…, { keep: false })` | claims it, then closes it |
+| `takeOverTaskSpace` / `waitForAgentControl` | no ownership check |
+
+`handOffTaskSpace` and `completeTaskSpace` resolve `{ done: true }` when the operation actually happened. Check `done` before telling the user the handoff/cleanup is finished — a `skipped` result usually means you targeted a space that was never yours.
+
 **`completeTaskSpace(nameOrId, { keep })` must occupy its own dedicated final heredoc, and run only after a prior heredoc's output has confirmed the task is genuinely done.** `keep` is required: pass `false` to close the space, or `true` to complete the space and leave the page visible to the user.
 
 When passing a string that may create a new task space, the string should reflect the task's intent (e.g. `'search github issues'`); don't use literal placeholders.


### PR DESCRIPTION
## Summary

Follow-up review pass on the helper layer and skill docs. Five changes, each small and independently revertable:

### 1. CLI and SDK paths now share one helper surface
`executionContext()` builds from the same `helperContext()` that `installEgoSdk()` uses, instead of re-deriving the surface from module exports. Fixes concrete drift that already existed:
- `help()` was documented in SKILL.md but missing from the CLI path
- `agent_helpers.js` extensions only loaded in the CLI path, not the SDK path
- internals (`helperContext`, `loadAgentHelpers`, `newTab`) leaked into the CLI script scope

Also removes `fillElement` — an undocumented, weaker duplicate of `fillInput` (no `change` event, no `clearFirst`/`timeout`) with zero callers. A new e2e test locks the unified surface in.

### 2. Task-space helpers report skipped operations
`handOffTaskSpace` / `completeTaskSpace` previously returned `void` and **silently did nothing** for user-owned spaces. Agents reading their own `cliLog` output had no way to distinguish "handed off" from "skipped", and would report success to the user for an operation that never happened. They now resolve `{ done: true }` or `{ done: false, skipped: "user-owned" }` — zero impact on existing `await` callers.

The full ownership policy table (all six entry points: `switchTaskSpace` throws, `useOrCreateTaskSpace` claims, hand-off/complete-keep skip, complete-close claims-then-closes, take-over/wait don't check) is now documented in `helpers.ts` and SKILL.md, kept in sync by comment cross-reference.

### 3. `scroll()` fallback narrowed to genuine "unsupported" errors
The catch-all fallback to `window.scrollBy` masked timeouts and "user is controlling" errors behind silently different behavior — DOM window scrolling is not equivalent to a real wheel event (virtualized lists and inner scroll panes ignore it), so the agent saw "success", re-snapshotted, found nothing changed, and burned rounds debugging. Now: only `not supported` / `wasn't found`-class errors degrade, with a one-time stderr notice (same pattern as the `js()` function warning); everything else propagates. Test coverage for all three cases.

### 4. Unique screenshot default paths
`captureScreenshot()` defaulted to a fixed `tmpdir()/ego-browser-shot.png`. With parallel agents in separate task spaces (the headline use case), concurrent sessions overwrote each other's screenshots and could act on coordinates derived from the wrong page. Defaults are now `ego-browser-shot-<pid>-<seq>.png`.

### 5. Drop the `domain-skills` residue from `gotoUrl()` + rewrite AGENTS.md
- The env-gated `EGO_BROWSER_DOMAIN_SKILLS` lookup used a first-DNS-label site match (`mail.google.com` → `mail`) that contradicts the learnings matcher, and never fired on the documented navigation paths (`openOrReuseTab`/`gotoAndWait` call `nav.gotoUrl` directly). No tests, no docs, no `domain-skills/` directory reference it.
- AGENTS.md referenced files that don't exist in this tree (`bin/ego-browser.js`, `src/site-skills.js`, `test/`, `_template/`), used a ref format the resolver rejects (`@e1`), and carried an unrelated prompt-engineering essay. Rewritten against the actual dev architecture.

## Test plan

- `npm test` — 54/54 pass (build + typecheck + unit/e2e), including 4 new tests:
  - CLI surface contract (help present, internals hidden)
  - `handOffTaskSpace`/`completeTaskSpace` status objects for user-owned and agent-owned paths
  - `scroll()` falls back on unsupported, propagates timeout and user-control errors
- `npm run validate:site-skills` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)