### PR TITLE
chore: project-level skill symlinks for claude and codex

### DIFF
--- a/.claude/skills/ego-browser
+++ b/.claude/skills/ego-browser
@@ -1,0 +1,1 @@
+../../skills/ego-browser

--- a/.codex/skills/ego-browser
+++ b/.codex/skills/ego-browser
@@ -1,0 +1,1 @@
+../../skills/ego-browser

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ browser/
 task/
 test-e2e/
 test/
+# Translated skill (local only)
+skills/ego-browser/SKILL.zh.md


### PR DESCRIPTION
Link .claude/skills/ego-browser and .codex/skills/ego-browser to the shared skills/ego-browser source so both Claude Code and Codex pick up the project skill without copying files into global config. Also gitignore the local Chinese translation (SKILL.zh.md).