### PR TITLE
Clarify control handoff and treat agentDelegatedToUser as agent-owned

### DIFF
--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -56,8 +56,12 @@ export async function listTaskSpaces() {
 }
 
 /*
- * Task space ownership policy (`ownership`: "agent" | "user").
- * What each helper does when the target space is user-owned:
+ * Task space ownership policy (`ownership`: "agent" | "agentDelegatedToUser" | "user").
+ * "agent" and "agentDelegatedToUser" are both agent-owned (see isAgentOwned) — the
+ * latter is the agent's own space with control temporarily handed to the user
+ * (handoff or GUI takeover). The user-control boundary is enforced at the native
+ * bridge when real commands run, not here. The rows below describe what each helper
+ * does when the target space is user-owned:
  *
  *   switchTaskSpace                     -> throws (agent-owned only)
  *   useOrCreateTaskSpace                -> claims it (ownership transfers to the agent)
@@ -70,6 +74,18 @@ export async function listTaskSpaces() {
  */
 
 /**
+ * Whether the agent owns the space. "agentDelegatedToUser" is still agent-owned —
+ * the agent created it but control is temporarily with the user (handoff / GUI
+ * takeover). Selecting such a space is fine; the user-control boundary is enforced
+ * separately at the native bridge when real commands run.
+ * @param {string|undefined} ownership
+ * @returns {boolean}
+ */
+function isAgentOwned(ownership) {
+  return ownership === "agent" || ownership === "agentDelegatedToUser";
+}
+
+/**
  * Select an existing task space by id/name for the current Node invocation.
  * @param {string|number} nameOrId Task space id or name.
  * @returns {Promise<{taskId:string,id:number,name:string,createdBy?:string,ownership?:string,recentTabTitles?:string[]}>}
@@ -80,7 +96,7 @@ export async function switchTaskSpace(nameOrId) {
     throw new Error("switchTaskSpace requires ego.useTaskSpace");
   }
   const space = await findTaskSpace(nameOrId);
-  if (space.ownership !== "agent") {
+  if (!isAgentOwned(space.ownership)) {
     throw new Error(`switchTaskSpace requires an agent-owned task space, got ownership ${JSON.stringify(space.ownership)}`);
   }
   return selectTaskSpace(ego, space, "switchTaskSpace");
@@ -118,7 +134,7 @@ export async function useOrCreateTaskSpace(nameOrId) {
     }
     return newTaskSpace(nameOrId);
   }
-  if (existing.ownership === "agent") {
+  if (isAgentOwned(existing.ownership)) {
     return selectTaskSpace(globalThis.ego, existing, "useOrCreateTaskSpace");
   }
   if (existing.ownership === "user") {

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -18,13 +18,26 @@ import {
   loadLearnedContext,
   runNodeSiteTool,
   siteSkillsForUrl as siteSkillsForUrlCore,
-  wrapBrowserTool
+  wrapBrowserTool,
 } from "./learning/index.js";
 
 export { NAME } from "./state.js";
 export { cdp, js } from "./cdp-eval.js";
-export { click, doubleClick, hover, dragMouse, scroll, scrollBy, scrollToBottomUntil } from "./driver/pointer.js";
-export { pressKey, typeText, fillInput, dispatchKey } from "./driver/keyboard.js";
+export {
+  click,
+  doubleClick,
+  hover,
+  dragMouse,
+  scroll,
+  scrollBy,
+  scrollToBottomUntil,
+} from "./driver/pointer.js";
+export {
+  pressKey,
+  typeText,
+  fillInput,
+  dispatchKey,
+} from "./driver/keyboard.js";
 export {
   INTERNAL_URL_PREFIXES,
   pageInfo,
@@ -36,10 +49,22 @@ export {
   gotoUrl,
   gotoAndWait,
   ensureRealTab,
-  iframeTarget
+  iframeTarget,
 } from "./driver/nav.js";
-export { snapshot, snapshotRaw, snapshotText, captureScreenshot, elementCenter, drainEvents } from "./driver/observe.js";
-export { wait, waitForLoad, waitForElement, waitForNetworkIdle } from "./driver/waits.js";
+export {
+  snapshot,
+  snapshotRaw,
+  snapshotText,
+  captureScreenshot,
+  elementCenter,
+  drainEvents,
+} from "./driver/observe.js";
+export {
+  wait,
+  waitForLoad,
+  waitForElement,
+  waitForNetworkIdle,
+} from "./driver/waits.js";
 export { uploadFile } from "./driver/files.js";
 export { browserFetch, serverFetch } from "./http.js";
 
@@ -52,7 +77,9 @@ export async function listTaskSpaces() {
   if (!ego || typeof ego.listTaskSpaces !== "function") {
     throw new Error("listTaskSpaces requires ego.listTaskSpaces");
   }
-  return normalizeTaskSpaces(assertNoEgoError(await ego.listTaskSpaces(), "listTaskSpaces"));
+  return normalizeTaskSpaces(
+    assertNoEgoError(await ego.listTaskSpaces(), "listTaskSpaces"),
+  );
 }
 
 /*
@@ -97,7 +124,9 @@ export async function switchTaskSpace(nameOrId) {
   }
   const space = await findTaskSpace(nameOrId);
   if (!isAgentOwned(space.ownership)) {
-    throw new Error(`switchTaskSpace requires an agent-owned task space, got ownership ${JSON.stringify(space.ownership)}`);
+    throw new Error(
+      `switchTaskSpace requires an agent-owned task space, got ownership ${JSON.stringify(space.ownership)}`,
+    );
   }
   return selectTaskSpace(ego, space, "switchTaskSpace");
 }
@@ -112,7 +141,9 @@ export async function newTaskSpace(name) {
   if (!ego || typeof ego.createTaskSpace !== "function") {
     throw new Error("newTaskSpace requires ego.createTaskSpace");
   }
-  const created = normalizeTaskSpace(assertNoEgoError(await ego.createTaskSpace(name), "newTaskSpace"));
+  const created = normalizeTaskSpace(
+    assertNoEgoError(await ego.createTaskSpace(name), "newTaskSpace"),
+  );
   if (!created) {
     throw new Error("newTaskSpace returned an invalid task space");
   }
@@ -140,7 +171,9 @@ export async function useOrCreateTaskSpace(nameOrId) {
   if (existing.ownership === "user") {
     return claimTaskSpace(existing, "useOrCreateTaskSpace");
   }
-  throw new Error(`useOrCreateTaskSpace cannot use task space ${JSON.stringify(nameOrId)} with ownership ${JSON.stringify(existing.ownership)}`);
+  throw new Error(
+    `useOrCreateTaskSpace cannot use task space ${JSON.stringify(nameOrId)} with ownership ${JSON.stringify(existing.ownership)}`,
+  );
 }
 
 async function claimTaskSpace(space, op = "claimTaskSpace") {
@@ -149,7 +182,9 @@ async function claimTaskSpace(space, op = "claimTaskSpace") {
     throw new Error(`${op} requires ego.claimTaskSpace`);
   }
   const id = taskSpaceNumericId(space, op);
-  const claimed = normalizeTaskSpace(assertNoEgoError(await ego.claimTaskSpace(id, space.name), op));
+  const claimed = normalizeTaskSpace(
+    assertNoEgoError(await ego.claimTaskSpace(id, space.name), op),
+  );
   if (!claimed) {
     throw new Error(`${op} returned an invalid task space`);
   }
@@ -165,7 +200,11 @@ async function selectTaskSpace(ego, space, op: string) {
   return space;
 }
 
-async function selectTaskSpaceIfProvided(ego, nameOrId?: string | number, op = "taskSpace") {
+async function selectTaskSpaceIfProvided(
+  ego,
+  nameOrId?: string | number,
+  op = "taskSpace",
+) {
   if (nameOrId === undefined) return;
   const match = await findTaskSpace(nameOrId);
   await selectTaskSpace(ego, match, op);
@@ -182,8 +221,14 @@ async function selectTaskSpaceIfProvided(ego, nameOrId?: string | number, op = "
  * @param {{ keep: boolean }} options Required. `keep:true` hands the page to the user; `keep:false` closes the space.
  * @returns {Promise<{done: boolean, skipped?: "user-owned"}>} `{ done: true }` when the space was completed or closed; `{ done: false, skipped: "user-owned" }` when nothing was done.
  */
-export async function completeTaskSpace(nameOrId: string | number, options: { keep: boolean }) {
-  if ((typeof nameOrId !== "string" && typeof nameOrId !== "number") || nameOrId === "") {
+export async function completeTaskSpace(
+  nameOrId: string | number,
+  options: { keep: boolean },
+) {
+  if (
+    (typeof nameOrId !== "string" && typeof nameOrId !== "number") ||
+    nameOrId === ""
+  ) {
     throw new Error("completeTaskSpace requires a task space name or id");
   }
   if (!options || typeof options.keep !== "boolean") {
@@ -291,8 +336,14 @@ async function probeAgentControl() {
  * @param {{ interval?: number, timeout?: number }} [options] interval & timeout in seconds (default 20s / 600s).
  * @returns {Promise<void>}
  */
-export async function waitForAgentControl(nameOrId: string | number, options: { interval?: number; timeout?: number } = {}) {
-  if ((typeof nameOrId !== "string" && typeof nameOrId !== "number") || nameOrId === "") {
+export async function waitForAgentControl(
+  nameOrId: string | number,
+  options: { interval?: number; timeout?: number } = {},
+) {
+  if (
+    (typeof nameOrId !== "string" && typeof nameOrId !== "number") ||
+    nameOrId === ""
+  ) {
     throw new Error("waitForAgentControl requires a task space name or id");
   }
   const ego = globalThis.ego;
@@ -328,13 +379,15 @@ function normalizeTaskSpace(space) {
     ...space,
     taskId,
     id: space?.id ?? taskId,
-    name: space?.name ?? taskId
+    name: space?.name ?? taskId,
   };
 }
 
 function taskSpaceNumericId(space, op: string) {
   if (typeof space?.id !== "number" || !Number.isFinite(space.id)) {
-    throw new Error(`${op} requires a numeric task space id, got ${JSON.stringify(space?.id)}`);
+    throw new Error(
+      `${op} requires a numeric task space id, got ${JSON.stringify(space?.id)}`,
+    );
   }
   return space.id;
 }
@@ -350,7 +403,9 @@ function findMatchingTaskSpace(spaces, nameOrId) {
   if (typeof nameOrId === "number") {
     return spaces.find((space) => space.id === nameOrId);
   }
-  const byName = spaces.find((space) => space.name === nameOrId || space.taskId === nameOrId);
+  const byName = spaces.find(
+    (space) => space.name === nameOrId || space.taskId === nameOrId,
+  );
   if (byName) return byName;
   if (/^\d+$/.test(nameOrId)) {
     const id = Number(nameOrId);
@@ -363,7 +418,7 @@ function findMatchingTaskSpace(spaces, nameOrId) {
 
 export async function siteSkillsForUrl(url) {
   return siteSkillsForUrlCore(url, {
-    agentWorkspace: state.agentWorkspace()
+    agentWorkspace: state.agentWorkspace(),
   });
 }
 
@@ -386,7 +441,7 @@ export async function siteSkills(url = undefined) {
  */
 export async function runSiteTool(siteId, toolName, args: any = {}) {
   return runNodeSiteTool(siteId, toolName, args, helperContext(), {
-    agentWorkspace: state.agentWorkspace()
+    agentWorkspace: state.agentWorkspace(),
   });
 }
 
@@ -399,7 +454,7 @@ export async function runSiteTool(siteId, toolName, args: any = {}) {
  */
 export async function runSiteBrowserTool(siteId, toolName, args: any = {}) {
   const source = await loadBrowserToolSource(siteId, toolName, {
-    agentWorkspace: state.agentWorkspace()
+    agentWorkspace: state.agentWorkspace(),
   });
   return js(wrapBrowserTool(source, args));
 }
@@ -413,7 +468,7 @@ export async function runSiteBrowserTool(siteId, toolName, args: any = {}) {
 export async function learnContext(url = undefined) {
   const targetUrl = url ?? (await nav.pageInfo()).url ?? "";
   return loadLearnedContext(targetUrl, {
-    agentWorkspace: state.agentWorkspace()
+    agentWorkspace: state.agentWorkspace(),
   });
 }
 
@@ -443,7 +498,7 @@ export function helperContext(extra: any = {}) {
     handOffTaskSpace,
     takeOverTaskSpace,
     waitForAgentControl,
-    ...extra
+    ...extra,
   };
   return {
     ...all,
@@ -452,7 +507,7 @@ export function helperContext(extra: any = {}) {
       if (typeof result === "string") return result;
       if (Array.isArray(result)) return result.map(formatHelp).join("\n\n");
       return formatHelp(result);
-    }
+    },
   };
 }
 

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -57,7 +57,7 @@ Notes:
 
 A task space is an **isolated browsing context** that ego-browser provides for AI Agents. Each task space has its own set of tabs but **inherits the current user's login state** by default, so Agents can operate on authenticated sites without competing with or disturbing the user's normal browser windows.
 
-A task often takes multiple heredoc rounds to complete. Because the Node.js runtime exits after each heredoc and retains no state, normal working heredocs should start with an explicit call to `useOrCreateTaskSpace(nameOrId)` to reuse the same space — this lets you operate continuously and reuse tabs across rounds. The exception is resuming after a user handoff: when the user says "continue" in chat, start the next heredoc with `takeOverTaskSpace(nameOrId)` instead.
+A task often takes multiple heredoc rounds to complete. Because the Node.js runtime exits after each heredoc and retains no state, normal working heredocs should start with an explicit call to `useOrCreateTaskSpace(nameOrId)` to reuse the same space — this lets you operate continuously and reuse tabs across rounds. The exception is resuming after a handoff: once the user confirms "continue" (through an Ask or in chat), start the next heredoc with `takeOverTaskSpace(nameOrId)` instead.
 
 `nameOrId` can be a task space name, numeric id, or digit-only numeric id string. String values match `name`/`taskId` first, then digit-only strings fall back to numeric id. Number values match existing numeric ids only; if no matching id exists, `useOrCreateTaskSpace` fails instead of creating a new space.
 
@@ -87,29 +87,17 @@ Keep loose awareness of how many tabs are open — a quick `(await listTabs()).l
 
 ### Control handoff
 
-Only one side — agent or user — holds control of a task space at any time.
+Only one side — agent or user — holds control of a task space at any time. While the user holds control, any browser operation by the agent fails with a "user is controlling" message — do not retry it; follow the steps below to resume.
 
-**Handing off**: When the task requires user intervention (e.g. login, captcha, manual confirmation), call `await handOffTaskSpace([nameOrId])` to give control to the user. Omitting `nameOrId` uses the currently selected task space; pass `task.id` across heredoc rounds to avoid ambiguity. After handoff, any browser operation by the agent will fail with a "user is controlling" message.
+A "user is controlling" error is a hard stop on the whole task — not an obstacle to route around. It means the user has deliberately taken the browser back, often because your current approach is going wrong. Honoring it *is* the correct outcome here; pushing the goal forward anyway is the failure. The only thing you may do is **ask the user and wait**.
 
-**Regaining control** — two paths:
+**Handing off**: When the task requires user intervention (e.g. login, captcha, manual confirmation), call `await handOffTaskSpace([nameOrId])` to give control to the user, and tell them exactly what to do. Omitting `nameOrId` uses the currently selected task space; pass `task.id` across heredoc rounds to avoid ambiguity.
 
-1. **User says "continue" in chat** → call `await takeOverTaskSpace([nameOrId])` to take back control, then continue. Omitting `nameOrId` uses the currently selected task space. `await takeOverTaskSpace(...)` is idempotent — safe to call even if the user already returned control via GUI.
-2. **User returns via browser GUI** (without chatting) → the agent receives no notification. Use `await waitForAgentControl(nameOrId)` to block until control comes back; once it returns, you can operate directly without calling `await takeOverTaskSpace(...)`.
+**Regaining control**: Take control back *only* after the user explicitly confirms — through an Ask (your harness's button/option prompt, e.g. "Continue" vs "Finish task") or a "continue" message in chat. Then start a new heredoc with `await takeOverTaskSpace([nameOrId])` and resume; if the user chooses to finish, close out with `await completeTaskSpace(nameOrId, { keep })`. Never call `takeOverTaskSpace` on your own to grab control back — it has no ownership check and will seize the browser away from the user.
 
-**Waiting for control handback example**:
+**Unexpected takeover**: The user can take over at any time via the browser GUI — the same effect as the agent calling `handOffTaskSpace`. Do not retry the failed operation and do not auto-takeover; surface the Ask above (Continue / Finish) and resume only when the user picks Continue.
 
-```js
-await handOffTaskSpace(nameOrId)
-cliLog('Please complete the login')
-
-await waitForAgentControl(nameOrId)              // polls every 20s by default, 10-minute timeout
-// await waitForAgentControl(nameOrId, { interval: 10, timeout: 300 })
-// continue working...
-```
-
-If the user action may take a while, exit the heredoc to keep the chat channel open. When the user says "continue" in chat, start a new heredoc with `await takeOverTaskSpace(...)` to resume.
-
-**Unexpected takeover**: The user can take over the task space at any time via the browser GUI — the effect is the same as the agent calling `handOffTaskSpace`. The agent's operations will fail with a "user is controlling" message. Do not retry — inform the user and wait for control to be returned.
+`await waitForAgentControl(nameOrId)` is a read-only blocking poll (it never takes control); use it only to wait inside the current heredoc for a handoff you initiated.
 
 
 ### Scroll / mouse

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -65,7 +65,7 @@ Use a short name for the current user goal when creating a new task space. Reuse
 
 To continue work from an existing user-owned task space, use `await listTaskSpaces()` to find the space, call `await useOrCreateTaskSpace(id)` to claim it, then use `await listTabs()` and `await switchTab(targetId)` to select the exact tab before acting. This is different from resuming a handoff from your own prior task space, which starts with `await takeOverTaskSpace(nameOrId)`.
 
-**Ownership policy** — every task space has `ownership: 'agent' | 'user'`; the helpers treat user-owned spaces differently:
+**Ownership policy** — every task space has `ownership: 'agent' | 'agentDelegatedToUser' | 'user'`; the helpers treat user-owned spaces differently:
 
 | Helper | When the target space is user-owned |
 |---|---|


### PR DESCRIPTION
## Summary

Refines the ego-browser control-handoff guidance and aligns the task-space helpers with the `agentDelegatedToUser` ownership state.

- **helpers.ts**: introduce `isAgentOwned()` so `switchTaskSpace` and `useOrCreateTaskSpace` accept `agentDelegatedToUser` alongside `agent`. Such a space is still the agent's own — control is only temporarily handed to the user, and the user-control boundary is enforced at the native bridge rather than in these selectors.
- **SKILL.md**: revise the control-handoff guidance and document the three-value ownership policy (`agent | agentDelegatedToUser | user`), keeping the table in sync with the helper comment.

## Test plan

- [ ] Selecting an `agentDelegatedToUser` space via `switchTaskSpace` / `useOrCreateTaskSpace` succeeds instead of throwing.
- [ ] User-owned spaces still follow the documented policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)