### PR TITLE
feat(ego-browser): align the two business error messages as parallel stop-and-resume guidance

### DIFF
--- a/package/ego-browser/src/browser-runtime.test.mjs
+++ b/package/ego-browser/src/browser-runtime.test.mjs
@@ -5,8 +5,8 @@ import { browserCdp } from "../dist/src/browser-runtime.js";
 
 // Gap A: ensureSession() calls the raw listTabs binding to attach a session.
 // When the task is blocked it returns { error, error_code }; the result must
-// surface the ego-browser-owned wording for the code (not the live text) and
-// carry error_code, instead of throwing bare live text.
+// surface the ego-browser-owned wording for the code (not the native error
+// message) and carry error_code, instead of throwing the bare native error message.
 test("browserCdp surfaces the owned message and error_code when ensureSession is blocked", async () => {
   globalThis.ego = {
     async listTabs() {

--- a/package/ego-browser/src/browser-runtime.test.mjs
+++ b/package/ego-browser/src/browser-runtime.test.mjs
@@ -21,10 +21,9 @@ test("browserCdp surfaces the owned message and error_code when ensureSession is
       () => browserCdp("Runtime.evaluate", {}, undefined, 1000),
       (err) => {
         assert.equal(err.error_code, "EGO_TASK_SPACE_INACTIVE");
-        assert.equal(
-          err.message,
-          "Task space is not assigned to an agent. Claim this task space before sending CDP messages.",
-        );
+        // Owned guidance block, not the native "Task space 10 ..." text.
+        assert.match(err.message, /claimTaskSpace\(id\)/);
+        assert.doesNotMatch(err.message, /\b10\b/);
         return true;
       },
     );
@@ -55,10 +54,9 @@ test("browserCdp rejects the in-flight request via onSendCDPMessageError", async
       () => browserCdp("Browser.getVersion", {}, undefined, 1000),
       (err) => {
         assert.equal(err.error_code, "EGO_TASK_SPACE_INACTIVE");
-        assert.equal(
-          err.message,
-          "Task space is not assigned to an agent. Claim this task space before sending CDP messages.",
-        );
+        // Owned guidance block, not the native reconstructed text.
+        assert.match(err.message, /claimTaskSpace\(id\)/);
+        assert.doesNotMatch(err.message, /native reconstructed text/);
         return true;
       },
     );

--- a/package/ego-browser/src/ego-errors.test.mjs
+++ b/package/ego-browser/src/ego-errors.test.mjs
@@ -42,15 +42,14 @@ test("isEgoErrorCode narrows to known codes only", () => {
 });
 
 test("resolveEgoError overrides the native error message with the owned wording for an owned code", () => {
-  const resolved = resolveEgoError({
+  const { code, message } = resolveEgoError({
     error: "Task space 7 is not assigned to an agent.",
     error_code: "EGO_TASK_SPACE_INACTIVE",
   });
-  assert.deepEqual(resolved, {
-    code: "EGO_TASK_SPACE_INACTIVE",
-    message:
-      "Task space is not assigned to an agent. Claim this task space before sending CDP messages.",
-  });
+  assert.equal(code, "EGO_TASK_SPACE_INACTIVE");
+  // Owned id-less guidance replaces the native "Task space 7 ..." text.
+  assert.match(message, /claimTaskSpace\(id\)/);
+  assert.doesNotMatch(message, /\b7\b/);
 });
 
 test("resolveEgoError keeps the native error message for an unknown future code", () => {
@@ -93,7 +92,8 @@ test("resolveEgoError falls back to the raw code for a bare non-owned code", () 
 test("resolveEgoError uses the id-less guidance block for a bare user-control code", () => {
   const { code, message } = resolveEgoError("EGO_TASK_SPACE_USER_IN_CONTROL");
   assert.equal(code, "EGO_TASK_SPACE_USER_IN_CONTROL");
-  assert.match(message, /controlling this task space/);
+  assert.match(message, /taken control of this task space/);
+  assert.match(message, /takeOverTaskSpace\(\)/);
   assert.doesNotMatch(message, /<id>/);
 });
 
@@ -152,10 +152,10 @@ test("assertNoEgoError omits the prefix when no op is given", () => {
     });
     assert.fail("expected assertNoEgoError to throw");
   } catch (err) {
-    assert.equal(
-      err.message,
-      "Task space is not assigned to an agent. Claim this task space before sending CDP messages.",
-    );
+    // No op given, so no "<op>: " prefix — the owned block starts the message.
+    assert.match(err.message, /^The user has taken control/);
+    assert.match(err.message, /claimTaskSpace\(id\)/);
+    assert.doesNotMatch(err.message, /\b10\b/);
     assert.equal(err.error_code, "EGO_TASK_SPACE_INACTIVE");
   }
 });

--- a/package/ego-browser/src/ego-errors.test.mjs
+++ b/package/ego-browser/src/ego-errors.test.mjs
@@ -41,7 +41,7 @@ test("isEgoErrorCode narrows to known codes only", () => {
   assert.equal(isEgoErrorCode(undefined), false);
 });
 
-test("resolveEgoError overrides live text with the owned wording for an owned code", () => {
+test("resolveEgoError overrides the native error message with the owned wording for an owned code", () => {
   const resolved = resolveEgoError({
     error: "Task space 7 is not assigned to an agent.",
     error_code: "EGO_TASK_SPACE_INACTIVE",
@@ -53,7 +53,7 @@ test("resolveEgoError overrides live text with the owned wording for an owned co
   });
 });
 
-test("resolveEgoError keeps live text for an unknown future code", () => {
+test("resolveEgoError keeps the native error message for an unknown future code", () => {
   assert.deepEqual(
     resolveEgoError({
       error: "Some build-specific detail",
@@ -66,7 +66,7 @@ test("resolveEgoError keeps live text for an unknown future code", () => {
   );
 });
 
-test("resolveEgoError defers to live text for a code ego-browser does not own", () => {
+test("resolveEgoError defers to the native error message for a code ego-browser does not own", () => {
   // EGO_OPERATION_FAILED is not owned: the client wording (e.g. which operation
   // failed) is more specific than any static line.
   assert.deepEqual(
@@ -82,7 +82,7 @@ test("resolveEgoError defers to live text for a code ego-browser does not own", 
 });
 
 test("resolveEgoError falls back to the raw code for a bare non-owned code", () => {
-  // ego-browser does not own NOT_SELECTED and a bare code carries no live text,
+  // ego-browser does not own NOT_SELECTED and a bare code carries no native error message,
   // so the stable code itself is the most specific thing to surface.
   assert.deepEqual(resolveEgoError("EGO_TASK_SPACE_NOT_SELECTED"), {
     code: "EGO_TASK_SPACE_NOT_SELECTED",

--- a/package/ego-browser/src/ego-errors.ts
+++ b/package/ego-browser/src/ego-errors.ts
@@ -44,15 +44,21 @@ export type EgoErrorCode = (typeof EGO_ERROR_CODES)[number];
  * specific than any static line.
  */
 const EGO_ERROR_MESSAGES: Partial<Record<EgoErrorCode, string>> = {
-  EGO_TASK_SPACE_INACTIVE:
-    "Task space is not assigned to an agent. Claim this task space before sending CDP messages.",
+  EGO_TASK_SPACE_INACTIVE: [
+    "The user has taken control of this task space and ended the task, so it is no longer assigned to the agent and browser commands are paused.",
+    "This is a hard stop, not an obstacle to route around — do not retry and do not take ownership back on your own.",
+    "Wait until the user explicitly asks you to continue, then claim the space and resume:",
+    "  await claimTaskSpace(id)",
+    "",
+    `Offer the user choices like "Continue" or "Finish task" if your harness supports it; otherwise tell them: "You now control this task space. Reply 'continue' when ready and I will resume."`,
+  ].join("\n"),
   EGO_TASK_SPACE_USER_IN_CONTROL: [
-    "The user is controlling this task space. Browser commands are paused.",
-    "Do not take over automatically. Wait for the user to return control or ask you to continue.",
-    "To resume after user confirmation, call:",
+    "The user has taken control of this task space, so browser commands are paused.",
+    "This is a hard stop, not an obstacle to route around — do not retry and do not take control back on your own.",
+    "Wait until the user explicitly asks you to continue, then take control back and resume:",
     "  await takeOverTaskSpace()",
     "",
-    `If supported, offer choices like "Continue" or "Finish task"; otherwise tell the user: "You are now controlling this task space. Reply 'continue' when ready, and I will resume."`,
+    `Offer the user choices like "Continue" or "Finish task" if your harness supports it; otherwise tell them: "You now control this task space. Reply 'continue' when ready and I will resume."`,
   ].join("\n"),
 };
 

--- a/package/ego-browser/src/ego-errors.ts
+++ b/package/ego-browser/src/ego-errors.ts
@@ -9,7 +9,7 @@
  * The code is the durable contract; the wording can drift between builds. Branch
  * on the code (isEgoUserControlError), not on the message. EGO_ERROR_MESSAGES is
  * where ego-browser owns its wording for the few codes an agent must act on; every
- * other code (and any unknown future code) defers to the browser's live text.
+ * other code (and any unknown future code) defers to the native error message.
  *
  * Single source of truth — error handling was previously duplicated across
  * helpers.ts and driver/nav.ts.
@@ -38,9 +38,9 @@ export type EgoErrorCode = (typeof EGO_ERROR_CODES)[number];
 
 /**
  * Codes whose wording ego-browser owns. A listed code returns this static, id-less
- * message instead of the browser's live text — reserved for the two business signals
- * an agent must react to, not just report. Every other code is absent here and
- * defers to the live message (and any unknown future code does too), which is more
+ * message instead of the native error message — reserved for the two business signals
+ * an agent must react to, not just report. Every other code is absent here and defers
+ * to the native error message (and any unknown future code does too), which is more
  * specific than any static line.
  */
 const EGO_ERROR_MESSAGES: Partial<Record<EgoErrorCode, string>> = {
@@ -86,7 +86,7 @@ export function egoErrorCode(err: unknown): string | undefined {
  *
  * For a code ego-browser owns wording for, `message` is that owned wording.
  * Otherwise (a code not owned here, or an unknown future code) it falls back to
- * the live human-readable text the browser supplied, then the bare code, then a
+ * the native error message the binding returned, then the bare code, then a
  * generic string. `code` is the stable classifier and may be undefined.
  */
 export function resolveEgoError(err: unknown): {
@@ -96,7 +96,7 @@ export function resolveEgoError(err: unknown): {
   const code = egoErrorCode(err);
   const message =
     (isEgoErrorCode(code) ? EGO_ERROR_MESSAGES[code] : undefined) ??
-    liveErrorText(err) ??
+    nativeErrorText(err) ??
     code ??
     "Unknown ego error";
   return { code, message };
@@ -138,8 +138,11 @@ export function assertNoEgoError(result, op?: string) {
   return result;
 }
 
-/** Human-readable text from any ego error shape, ignoring bare codes. */
-function liveErrorText(err: unknown): string | undefined {
+/**
+ * The native error message from any ego error shape — the binding's runtime
+ * `error`/`message` text (dynamic, may vary across builds). Ignores bare codes.
+ */
+function nativeErrorText(err: unknown): string | undefined {
   if (typeof err === "string") {
     return isEgoErrorCode(err) ? undefined : err;
   }

--- a/package/ego-browser/src/helpers.test.mjs
+++ b/package/ego-browser/src/helpers.test.mjs
@@ -353,7 +353,7 @@ test("useOrCreateTaskSpace selects user-owned spaces without claiming and surfac
     async () => {
       await assert.rejects(
         () => useOrCreateTaskSpace("checkout-flow"),
-        /useOrCreateTaskSpace: The user is controlling this task space/,
+        /useOrCreateTaskSpace: The user has taken control of this task space/,
       );
     },
   );

--- a/package/ego-browser/src/taskspace-e2e.test.mjs
+++ b/package/ego-browser/src/taskspace-e2e.test.mjs
@@ -230,7 +230,7 @@ test("taskspace e2e useOrCreateTaskSpace selects user-owned spaces without claim
   await assert.rejects(
     () =>
       runTaskspaceScript(ego, `await useOrCreateTaskSpace("checkout-flow")`),
-    /controlling this task space/,
+    /has taken control of this task space/,
   );
   assert.deepEqual(ego.calls, [["listTaskSpaces"], ["useTaskSpace", 7]]);
 });


### PR DESCRIPTION
## Summary

Reworks the owned wording for the two business error codes an agent must *act* on, so both read as parallel "stop and resume" guidance instead of two differently-shaped strings.

- **`EGO_TASK_SPACE_INACTIVE`** (user ended the task via *Finish task*): was a single terse line; now a structured block — cause + commands paused, a hard-stop line, the resume call `await claimTaskSpace(id)`, and a user-choice prompt.
- **`EGO_TASK_SPACE_USER_IN_CONTROL`** (user took control via *Take over*): rephrased to the same structure, resuming with `await takeOverTaskSpace()`.

The two codes stay semantically distinct (terminated vs. took control; `claimTaskSpace(id)` vs. `takeOverTaskSpace()`) — only the shape is unified. The `error_code` remains the durable contract; only the displayed message changed.

Also includes `e568aab`, a no-behavior rename `liveErrorText` → `nativeErrorText` in the same module.

## Tests

Wording assertions across `ego-errors.test.mjs`, `browser-runtime.test.mjs`, `helpers.test.mjs`, and `taskspace-e2e.test.mjs` switched from exact full-message equality to intent matches on the resume call (mirroring the existing user-control test style). Full suite (build + typecheck + 93 tests + e2e + style + audit) passes via the pre-commit gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)