### PR TITLE
Handle task-space hard stops

### DIFF
--- a/package/ego-browser/src/browser-runtime.ts
+++ b/package/ego-browser/src/browser-runtime.ts
@@ -1,4 +1,5 @@
 import { state } from "./state.js";
+import { assertNoEgoError } from "./ego-errors.js";
 
 const RESPONSE_TIMEOUT_MS = 15000;
 const SESSION_TTL_MS = 2000;
@@ -104,10 +105,10 @@ export async function ensureSession() {
   }
   state.sessionInflight = (async () => {
     try {
-      const result = await browserEgo().listTabs();
-      if (result?.error) {
-        throw new Error(result.error);
-      }
+      const result = assertNoEgoError(
+        await browserEgo().listTabs(),
+        "listTabs",
+      );
       const tabs = result?.tabs || result?.targetInfos || [];
       const preferred = state.preferredTargetId
         ? tabs.find((t) => t.targetId === state.preferredTargetId)

--- a/package/ego-browser/src/ego-errors.test.mjs
+++ b/package/ego-browser/src/ego-errors.test.mjs
@@ -5,6 +5,7 @@ import {
   assertNoEgoError,
   egoErrorCode,
   isEgoErrorCode,
+  isEgoHardStopError,
   isEgoUserControlError,
   resolveEgoError,
 } from "../dist/src/ego-errors.js";
@@ -86,6 +87,30 @@ test("isEgoUserControlError keys on the stable code, not wording", () => {
   );
   assert.equal(
     isEgoUserControlError({ error_code: "EGO_SNAPSHOT_FAILED" }),
+    false,
+  );
+});
+
+test("hard-stop classification includes user-control and inactive task spaces", () => {
+  assert.equal(
+    isEgoHardStopError({
+      error_code: "EGO_TASK_SPACE_USER_IN_CONTROL",
+      error: "user has control",
+    }),
+    true,
+  );
+  assert.equal(
+    isEgoHardStopError({
+      error_code: "EGO_TASK_SPACE_INACTIVE",
+      error: "not assigned",
+    }),
+    true,
+  );
+  assert.equal(
+    isEgoHardStopError({
+      error_code: "EGO_TASK_SPACE_NOT_FOUND",
+      error: "not found",
+    }),
     false,
   );
 });

--- a/package/ego-browser/src/ego-errors.ts
+++ b/package/ego-browser/src/ego-errors.ts
@@ -51,7 +51,8 @@ const EGO_ERROR_MESSAGES: Record<EgoErrorCode, string> = {
   EGO_RESULT_CONVERSION_FAILED: "Failed to convert the browser result.",
   EGO_SNAPSHOT_FAILED: "Failed to capture the page snapshot.",
   EGO_TASK_HOST_DISCONNECTED: "The task host is no longer available.",
-  EGO_TASK_SPACE_INACTIVE: "The task space is inactive.",
+  EGO_TASK_SPACE_INACTIVE:
+    "The task space is inactive or not assigned to this agent.",
   EGO_TASK_SPACE_NOT_FOUND: "Task space not found.",
   EGO_TASK_SPACE_NOT_SELECTED: "Task space not selected.",
   EGO_TASK_SPACE_UNAVAILABLE: "The task space is unavailable.",
@@ -107,6 +108,16 @@ export function resolveEgoError(err: unknown): {
 /** Whether an ego error means the task is currently under user control. */
 export function isEgoUserControlError(err: unknown): boolean {
   return egoErrorCode(err) === "EGO_TASK_SPACE_USER_IN_CONTROL";
+}
+
+/** Whether claiming the task space would cross a user-owned permission boundary. */
+export function isEgoTaskSpaceInactiveError(err: unknown): boolean {
+  return egoErrorCode(err) === "EGO_TASK_SPACE_INACTIVE";
+}
+
+/** Whether an ego error must stop the current agent script immediately. */
+export function isEgoHardStopError(err: unknown): boolean {
+  return isEgoUserControlError(err) || isEgoTaskSpaceInactiveError(err);
 }
 
 export function assertNoEgoError(result, op: string) {

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -88,10 +88,12 @@ export async function listTaskSpaces() {
  * latter is the agent's own space with control temporarily handed to the user
  * (handoff or GUI takeover). The user-control boundary is enforced at the native
  * bridge when real commands run, not here. The rows below describe what each helper
- * does when the target space is user-owned:
+ * does when the target space is user-owned. Calling a helper that claims a
+ * user-owned or inactive space crosses a hard permission boundary; agent-facing
+ * instructions must require explicit user confirmation before doing so.
  *
  *   switchTaskSpace                     -> throws (agent-owned only)
- *   useOrCreateTaskSpace                -> claims it (ownership transfers to the agent)
+ *   useOrCreateTaskSpace                -> claims it (ownership transfers to the agent; only after confirmation)
  *   handOffTaskSpace                    -> skipped, resolves { done: false, skipped: "user-owned" }
  *   completeTaskSpace { keep: true }    -> skipped, resolves { done: false, skipped: "user-owned" }
  *   completeTaskSpace { keep: false }   -> claims it, then closes it

--- a/package/ego-browser/src/run-hard-stop.test.mjs
+++ b/package/ego-browser/src/run-hard-stop.test.mjs
@@ -1,0 +1,340 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { HARD_STOP_EXIT_CODE, runMain } from "../dist/src/run.js";
+
+const USER_CONTROL_MESSAGE =
+  "The user has taken control of this task space, so browser commands are paused.";
+const INACTIVE_MESSAGE =
+  "Task space 8 is not assigned to an agent. Claim this task space before sending commands.";
+
+async function runScript(code, { ego } = {}) {
+  const previous = globalThis.ego;
+  if (ego === undefined) {
+    delete globalThis.ego;
+  } else {
+    globalThis.ego = ego;
+  }
+  const stdout = captureStream();
+  const stderr = captureStream();
+  try {
+    const exitCode = await runMain({
+      argv: [],
+      stdinText: code,
+      stdout,
+      stderr,
+      services: { printUpdateBanner() {} },
+    });
+    return { exitCode, stdout: stdout.text(), stderr: stderr.text() };
+  } finally {
+    if (previous === undefined) {
+      delete globalThis.ego;
+    } else {
+      globalThis.ego = previous;
+    }
+  }
+}
+
+function captureStream() {
+  const chunks = [];
+  return {
+    write(chunk) {
+      chunks.push(String(chunk));
+    },
+    text() {
+      return chunks.join("");
+    },
+  };
+}
+
+function userControlErrorExpression(message = USER_CONTROL_MESSAGE) {
+  return `Object.assign(new Error(${JSON.stringify(message)}), { error_code: "EGO_TASK_SPACE_USER_IN_CONTROL" })`;
+}
+
+function inactiveErrorExpression(message = INACTIVE_MESSAGE) {
+  return `Object.assign(new Error(${JSON.stringify(message)}), { error_code: "EGO_TASK_SPACE_INACTIVE" })`;
+}
+
+test("ordinary errors can still be handled by user catch blocks", async () => {
+  const result = await runScript(`
+    try {
+      throw new Error("plain page failure");
+    } catch (error) {
+      cliLog("caught: " + error.message);
+    }
+  `);
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stdout, "caught: plain page failure\n");
+  assert.equal(result.stderr, "");
+});
+
+test("hard-stop errors pass through user catch blocks", async () => {
+  const result = await runScript(`
+    try {
+      throw ${userControlErrorExpression()};
+    } catch (error) {
+      cliLog("swallowed: " + error.message);
+    }
+  `);
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, new RegExp(USER_CONTROL_MESSAGE));
+});
+
+test("hard-stop errors without user catch blocks are reported by the runner", async () => {
+  const result = await runScript(`
+    throw ${userControlErrorExpression()};
+  `);
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, new RegExp(USER_CONTROL_MESSAGE));
+});
+
+test("inactive task-space errors are hard stops with a permission-boundary message", async () => {
+  const result = await runScript(`
+    try {
+      throw ${inactiveErrorExpression()};
+    } catch (error) {
+      cliLog("swallowed: " + error.message);
+    }
+  `);
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /Task space 8 is not assigned to this agent/);
+  assert.match(result.stderr, /hard permission boundary/);
+  assert.match(
+    result.stderr,
+    /must not claim, inspect, modify, close, organize, or otherwise operate/,
+  );
+  assert.match(result.stderr, /Do not infer consent from prior instructions/);
+  assert.match(result.stderr, /await useOrCreateTaskSpace\(8\)/);
+});
+
+test("hard-stop errors pass through catch blocks without bindings", async () => {
+  const result = await runScript(`
+    try {
+      throw ${userControlErrorExpression()};
+    } catch {
+      cliLog("swallowed");
+    }
+  `);
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, new RegExp(USER_CONTROL_MESSAGE));
+});
+
+test("hard-stop passthrough avoids user names that resemble internal helpers", async () => {
+  const result = await runScript(`
+    try {
+      throw ${userControlErrorExpression()};
+    } catch (__egoBrowserRethrowHardStop) {
+      const __egoBrowserCaughtError0 = "user local";
+      cliLog("swallowed: " + __egoBrowserRethrowHardStop.message + __egoBrowserCaughtError0);
+    }
+  `);
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, new RegExp(USER_CONTROL_MESSAGE));
+});
+
+test("hard-stop errors pass through destructuring catch bindings", async () => {
+  const result = await runScript(`
+    try {
+      throw ${userControlErrorExpression()};
+    } catch ({ message }) {
+      cliLog("swallowed: " + message);
+    }
+  `);
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, new RegExp(USER_CONTROL_MESSAGE));
+});
+
+test("ordinary errors still support destructuring catch bindings", async () => {
+  const result = await runScript(`
+    try {
+      throw new Error("plain page failure");
+    } catch ({ message }) {
+      cliLog("caught: " + message);
+    }
+  `);
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stdout, "caught: plain page failure\n");
+  assert.equal(result.stderr, "");
+});
+
+test("ordinary destructuring catch bindings remain assignable", async () => {
+  const result = await runScript(`
+    try {
+      throw new Error("plain page failure");
+    } catch ({ message }) {
+      message = message.toUpperCase();
+      cliLog("caught: " + message);
+    }
+  `);
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stdout, "caught: PLAIN PAGE FAILURE\n");
+  assert.equal(result.stderr, "");
+});
+
+test("hard-stop errors pass through promise catch callbacks", async () => {
+  const result = await runScript(`
+    await Promise.reject(${userControlErrorExpression()}).catch(() => {
+      cliLog("swallowed");
+    });
+    cliLog("after");
+  `);
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, new RegExp(USER_CONTROL_MESSAGE));
+});
+
+test("ordinary errors can still be handled by promise catch callbacks", async () => {
+  const result = await runScript(`
+    const value = await Promise.reject(new Error("plain page failure")).catch((error) => {
+      cliLog("caught: " + error.message);
+      return "handled";
+    });
+    cliLog("value: " + value);
+  `);
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stdout, "caught: plain page failure\nvalue: handled\n");
+  assert.equal(result.stderr, "");
+});
+
+test("ordinary promise catch destructuring bindings remain assignable", async () => {
+  const result = await runScript(`
+    await Promise.reject(new Error("plain page failure")).catch(({ message }) => {
+      message = message.toUpperCase();
+      cliLog("caught: " + message);
+    });
+  `);
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stdout, "caught: PLAIN PAGE FAILURE\n");
+  assert.equal(result.stderr, "");
+});
+
+test("promise catch expression bodies preserve return values", async () => {
+  const result = await runScript(`
+    const value = await Promise.reject(new Error("plain page failure")).catch(error => error.message);
+    cliLog(value);
+  `);
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stdout, "plain page failure\n");
+  assert.equal(result.stderr, "");
+});
+
+test("hard-stop errors pass through named promise catch handlers", async () => {
+  const result = await runScript(`
+    const handleError = (error) => {
+      cliLog("swallowed: " + error.message);
+    };
+    await Promise.reject(${userControlErrorExpression()}).catch(handleError);
+  `);
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, new RegExp(USER_CONTROL_MESSAGE));
+});
+
+test("ordinary errors can still be handled by named promise catch handlers", async () => {
+  const result = await runScript(`
+    const handleError = (error) => error.message;
+    const value = await Promise.reject(new Error("plain page failure")).catch(handleError);
+    cliLog(value);
+  `);
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stdout, "plain page failure\n");
+  assert.equal(result.stderr, "");
+});
+
+test("ego user-control errors from helpers cannot be swallowed as per-item failures", async () => {
+  const ego = {
+    async listTabs() {
+      return {
+        error: USER_CONTROL_MESSAGE,
+        error_code: "EGO_TASK_SPACE_USER_IN_CONTROL",
+      };
+    },
+  };
+  const result = await runScript(
+    `
+      try {
+        await openOrReuseTab("https://example.com");
+      } catch (error) {
+        cliLog(JSON.stringify({ error: error.message }));
+      }
+    `,
+    { ego },
+  );
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /listTabs: The user has taken control/);
+});
+
+test("ego inactive errors from helpers cannot be swallowed as per-item failures", async () => {
+  const ego = {
+    async listTabs() {
+      return {
+        error: INACTIVE_MESSAGE,
+        error_code: "EGO_TASK_SPACE_INACTIVE",
+      };
+    },
+  };
+  const result = await runScript(
+    `
+      try {
+        await openOrReuseTab("https://example.com");
+      } catch (error) {
+        cliLog(JSON.stringify({ error: error.message }));
+      }
+    `,
+    { ego },
+  );
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /Task space 8 is not assigned to this agent/);
+  assert.match(result.stderr, /await useOrCreateTaskSpace\(8\)/);
+});
+
+test("ego inactive errors from implicit session setup preserve error_code", async () => {
+  const ego = {
+    async listTabs() {
+      return {
+        error: INACTIVE_MESSAGE,
+        error_code: "EGO_TASK_SPACE_INACTIVE",
+      };
+    },
+  };
+  const result = await runScript(
+    `
+      try {
+        await pageInfo();
+      } catch (error) {
+        cliLog(JSON.stringify({ error: error.message }));
+      }
+    `,
+    { ego },
+  );
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /Task space 8 is not assigned to this agent/);
+  assert.match(result.stderr, /await useOrCreateTaskSpace\(8\)/);
+});

--- a/package/ego-browser/src/run.ts
+++ b/package/ego-browser/src/run.ts
@@ -4,6 +4,12 @@ import {
   stderr as processStderr,
 } from "node:process";
 
+import { parse } from "acorn";
+
+import {
+  isEgoHardStopError,
+  resolveEgoError,
+} from "./ego-errors.js";
 import { formatCliLogValue } from "./format.js";
 import * as helpers from "./helpers.js";
 
@@ -57,6 +63,12 @@ export const USAGE = `Usage:
   JS
 `;
 
+// EX_TEMPFAIL communicates a resumable pause rather than a script bug.
+export const HARD_STOP_EXIT_CODE = 75;
+const HARD_STOP_RETHROW_HELPER_PREFIX = "__egoBrowserRethrowHardStop";
+const HARD_STOP_CATCH_PREFIX = "__egoBrowserCaughtError";
+const HARD_STOP_PROMISE_CATCH_PREFIX = "__egoBrowserPromiseCatchError";
+
 export async function runMain(options: RunMainOptions = {}) {
   const argv = options.argv || process.argv.slice(2);
   const stdout = options.stdout || processStdout;
@@ -100,17 +112,36 @@ export async function runMain(options: RunMainOptions = {}) {
   }
 
   services.printUpdateBanner(stderr);
-  await execute(code, stdout);
-  return 0;
+  try {
+    await execute(code, stdout);
+    return 0;
+  } catch (error) {
+    if (isEgoHardStopError(error)) {
+      write(stderr, formatHardStopError(error));
+      return HARD_STOP_EXIT_CODE;
+    }
+    throw error;
+  }
 }
 
 async function execute(code: string, stdout: WritableLike) {
   const context = await executionContext(stdout);
   Object.assign(globalThis, context);
   const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-  const names = Object.keys(context);
-  const values = Object.values(context);
-  const fn = new AsyncFunction(...names, `"use strict";\n${code}`);
+  const internalNames = new Set<string>();
+  const rethrowHelperName = uniqueInternalName(
+    HARD_STOP_RETHROW_HELPER_PREFIX,
+    code,
+    internalNames,
+  );
+  const names = [...Object.keys(context), rethrowHelperName];
+  const values = [...Object.values(context), rethrowHardStop];
+  const transformedCode = rewriteCatchClausesForHardStop(
+    code,
+    rethrowHelperName,
+    internalNames,
+  );
+  const fn = new AsyncFunction(...names, `"use strict";\n${transformedCode}`);
   await fn(...values);
 }
 
@@ -140,4 +171,382 @@ function readAll(stream: ReadableLike) {
 
 function write(stream: WritableLike, text: string) {
   stream.write(text);
+}
+
+function rethrowHardStop(error: unknown) {
+  if (isEgoHardStopError(error)) {
+    throw error;
+  }
+}
+
+function formatHardStopError(error: unknown) {
+  const resolved = resolveEgoError(error);
+  const message =
+    resolved.code === "EGO_TASK_SPACE_INACTIVE"
+      ? formatInactiveTaskSpaceHardStop(resolved.message)
+      : error instanceof Error && error.message
+        ? error.message
+        : resolved.message;
+  return message.endsWith("\n") ? message : `${message}\n`;
+}
+
+function formatInactiveTaskSpaceHardStop(message: string) {
+  const taskSpaceId = taskSpaceIdFromErrorMessage(message);
+  const subject = taskSpaceId
+    ? `Task space ${taskSpaceId}`
+    : "This task space";
+  const resumeTarget = taskSpaceId ?? "<task-space-id>";
+  return [
+    `${subject} is not assigned to this agent. Browser commands are stopped.`,
+    "",
+    "This is a hard permission boundary. The agent must not claim, inspect, modify, close, organize, or otherwise operate on this task space automatically.",
+    "",
+    "Claiming it would give the agent control over tabs and pages that may belong to the user. The agent must stop now and ask for explicit user confirmation.",
+    "",
+    "Do not infer consent from prior instructions or from the original task request.",
+    "",
+    `After the user explicitly confirms they want the agent to take control of ${subject.toLowerCase()}, resume with:`,
+    `  await useOrCreateTaskSpace(${resumeTarget})`,
+  ].join("\n");
+}
+
+function taskSpaceIdFromErrorMessage(message: string) {
+  return /\bTask space\s+(\d+)\b/i.exec(message)?.[1];
+}
+
+type TextEdit = {
+  start: number;
+  end: number;
+  text: string;
+};
+
+function rewriteCatchClausesForHardStop(
+  code: string,
+  rethrowHelperName: string,
+  internalNames: Set<string>,
+) {
+  const ast = parse(code, {
+    ecmaVersion: "latest",
+    sourceType: "script",
+    allowAwaitOutsideFunction: true,
+    allowReturnOutsideFunction: true,
+  } as any) as any;
+  const catches: any[] = [];
+  const promiseCatchHandlers: any[] = [];
+  walkAst(ast, (node) => {
+    if (node.type === "CatchClause") {
+      catches.push(node);
+    }
+    const promiseCatchHandler = promiseCatchHandlerForNode(node);
+    if (promiseCatchHandler) {
+      promiseCatchHandlers.push(promiseCatchHandler);
+    }
+  });
+  if (catches.length === 0 && promiseCatchHandlers.length === 0) {
+    return code;
+  }
+
+  const edits: TextEdit[] = [];
+  catches.forEach((node, index) =>
+    appendCatchClauseEdits(
+      edits,
+      node,
+      index,
+      code,
+      rethrowHelperName,
+      internalNames,
+    ),
+  );
+  promiseCatchHandlers.forEach((node, index) =>
+    appendPromiseCatchCallbackEdits(
+      edits,
+      node,
+      index,
+      code,
+      rethrowHelperName,
+      internalNames,
+    ),
+  );
+
+  return applyTextEdits(code, edits);
+}
+
+function appendCatchClauseEdits(
+  edits: TextEdit[],
+  node: any,
+  index: number,
+  code: string,
+  rethrowHelperName: string,
+  internalNames: Set<string>,
+) {
+  const caughtErrorName = uniqueInternalName(
+    `${HARD_STOP_CATCH_PREFIX}${index}`,
+    code,
+    internalNames,
+  );
+  const bodyStart = node.body.start + 1;
+  if (!node.param) {
+    edits.push({
+      start: node.start + "catch".length,
+      end: node.start + "catch".length,
+      text: ` (${caughtErrorName})`,
+    });
+    edits.push({
+      start: bodyStart,
+      end: bodyStart,
+      text: `\n${rethrowHelperName}(${caughtErrorName});`,
+    });
+    return;
+  }
+
+  if (node.param.type === "Identifier") {
+    edits.push({
+      start: bodyStart,
+      end: bodyStart,
+      text: `\n${rethrowHelperName}(${node.param.name});`,
+    });
+    return;
+  }
+
+  const originalBinding = code.slice(node.param.start, node.param.end);
+  edits.push({
+    start: node.param.start,
+    end: node.param.end,
+    text: caughtErrorName,
+  });
+  // Preserve destructuring catch bindings while still inspecting the original
+  // thrown value before user code can turn a hard-stop into an ordinary error.
+  edits.push({
+    start: bodyStart,
+    end: bodyStart,
+    text: `\n${rethrowHelperName}(${caughtErrorName});\nlet ${originalBinding} = ${caughtErrorName};`,
+  });
+}
+
+function appendPromiseCatchCallbackEdits(
+  edits: TextEdit[],
+  node: any,
+  index: number,
+  code: string,
+  rethrowHelperName: string,
+  internalNames: Set<string>,
+) {
+  if (
+    node.type !== "ArrowFunctionExpression" &&
+    node.type !== "FunctionExpression"
+  ) {
+    appendPromiseCatchHandlerWrapperEdits(
+      edits,
+      node,
+      index,
+      code,
+      rethrowHelperName,
+      internalNames,
+    );
+    return;
+  }
+  const caughtErrorName = uniqueInternalName(
+    `${HARD_STOP_PROMISE_CATCH_PREFIX}${index}`,
+    code,
+    internalNames,
+  );
+  const binding = promiseCatchErrorBinding(node, caughtErrorName, code);
+  if (!binding) {
+    return;
+  }
+  edits.push(...binding.edits);
+
+  const prelude = `\n${rethrowHelperName}(${binding.errorExpression});${binding.restoreBinding}`;
+  if (node.body.type === "BlockStatement") {
+    edits.push({
+      start: node.body.start + 1,
+      end: node.body.start + 1,
+      text: prelude,
+    });
+    return;
+  }
+
+  const expression = code.slice(node.body.start, node.body.end);
+  edits.push({
+    start: node.body.start,
+    end: node.body.end,
+    text: `{\n${rethrowHelperName}(${binding.errorExpression});${binding.restoreBinding}\nreturn ${expression};\n}`,
+  });
+}
+
+function appendPromiseCatchHandlerWrapperEdits(
+  edits: TextEdit[],
+  node: any,
+  index: number,
+  code: string,
+  rethrowHelperName: string,
+  internalNames: Set<string>,
+) {
+  const caughtErrorName = uniqueInternalName(
+    `${HARD_STOP_PROMISE_CATCH_PREFIX}${index}`,
+    code,
+    internalNames,
+  );
+  const handlerName = uniqueInternalName(
+    `__egoBrowserPromiseCatchHandler${index}`,
+    code,
+    internalNames,
+  );
+  const originalHandler = code.slice(node.start, node.end);
+  edits.push({
+    start: node.start,
+    end: node.end,
+    text:
+      `((${handlerName}) => (${caughtErrorName}) => {\n` +
+      `${rethrowHelperName}(${caughtErrorName});\n` +
+      `return typeof ${handlerName} === "function" ? ${handlerName}(${caughtErrorName}) : Promise.reject(${caughtErrorName});\n` +
+      `})(${originalHandler})`,
+  });
+}
+
+function promiseCatchErrorBinding(node: any, errorName: string, code: string) {
+  if (node.params.length === 0) {
+    const insertPosition = emptyParameterInsertPosition(node, code);
+    return {
+      errorExpression: errorName,
+      restoreBinding: "",
+      edits: [
+        {
+          start: insertPosition,
+          end: insertPosition,
+          text: errorName,
+        },
+      ],
+    };
+  }
+
+  const firstParam = node.params[0];
+  if (firstParam.type === "Identifier") {
+    return { errorExpression: firstParam.name, restoreBinding: "", edits: [] };
+  }
+  if (
+    firstParam.type === "ObjectPattern" ||
+    firstParam.type === "ArrayPattern"
+  ) {
+    const originalBinding = code.slice(firstParam.start, firstParam.end);
+    return {
+      errorExpression: errorName,
+      restoreBinding: `\nlet ${originalBinding} = ${errorName};`,
+      edits: [
+        {
+          start: firstParam.start,
+          end: firstParam.end,
+          text: errorName,
+        },
+      ],
+    };
+  }
+  if (
+    firstParam.type === "RestElement" &&
+    firstParam.argument?.type === "Identifier"
+  ) {
+    return {
+      errorExpression: errorName,
+      restoreBinding: `\nlet ${firstParam.argument.name} = [${errorName}];`,
+      edits: [
+        {
+          start: firstParam.start,
+          end: firstParam.end,
+          text: errorName,
+        },
+      ],
+    };
+  }
+  return null;
+}
+
+function emptyParameterInsertPosition(node: any, code: string) {
+  const beforeBody = code.slice(node.start, node.body.start);
+  const closeParenOffset = beforeBody.lastIndexOf(")");
+  if (closeParenOffset < 0) {
+    throw new Error("expected empty callback parameters to use parentheses");
+  }
+  return node.start + closeParenOffset;
+}
+
+function promiseCatchHandlerForNode(node: any) {
+  if (node.type !== "CallExpression") {
+    return null;
+  }
+  if (!isCatchMemberExpression(node.callee)) {
+    return null;
+  }
+  const firstArg = node.arguments?.[0];
+  if (
+    firstArg?.type === "ArrowFunctionExpression" ||
+    firstArg?.type === "FunctionExpression" ||
+    firstArg?.type === "Identifier" ||
+    isSimpleMemberExpression(firstArg)
+  ) {
+    return firstArg;
+  }
+  return null;
+}
+
+function isSimpleMemberExpression(node: any) {
+  if (node?.type !== "MemberExpression") {
+    return false;
+  }
+  if (!node.computed) {
+    return true;
+  }
+  return node.property?.type === "Literal";
+}
+
+function isCatchMemberExpression(node: any) {
+  if (node.type !== "MemberExpression") {
+    return false;
+  }
+  if (node.computed) {
+    return (
+      node.property?.type === "Literal" && node.property.value === "catch"
+    );
+  }
+  return node.property?.type === "Identifier" && node.property.name === "catch";
+}
+
+function uniqueInternalName(
+  baseName: string,
+  code: string,
+  reserved: Set<string>,
+) {
+  let candidate = baseName;
+  let suffix = 0;
+  while (reserved.has(candidate) || code.includes(candidate)) {
+    suffix += 1;
+    candidate = `${baseName}${suffix}`;
+  }
+  reserved.add(candidate);
+  return candidate;
+}
+
+function walkAst(node: any, visit: (node: any) => void) {
+  if (!node || typeof node !== "object") {
+    return;
+  }
+  if (typeof node.type === "string") {
+    visit(node);
+  }
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        walkAst(item, visit);
+      }
+    } else if (value && typeof value === "object") {
+      walkAst(value, visit);
+    }
+  }
+}
+
+function applyTextEdits(code: string, edits: TextEdit[]) {
+  let out = code;
+  for (const edit of [...edits].sort((a, b) => b.start - a.start)) {
+    out = `${out.slice(0, edit.start)}${edit.text}${out.slice(edit.end)}`;
+  }
+  return out;
 }

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -65,7 +65,7 @@ Use a short name for the active user goal when creating a new task space. Keep r
 
 For any follow-up on the same user goal — including continue, corrections, retries, validation, user-reported problems, or work after `completeTaskSpace(..., { keep: true })` — resume the original task space first if it still exists. Do not create a new task space for the same goal unless the user asks for a fresh space, starts an unrelated goal, or the original space is unavailable after checking. If a new space is necessary, state why.
 
-To continue work from an existing user-owned task space, use `await listTaskSpaces()` to find the space, call `await useOrCreateTaskSpace(id)` to claim it, then use `await listTabs()` and `await switchTab(targetId)` to select the exact tab before acting. This is different from resuming a handoff from your own prior task space, which starts with `await takeOverTaskSpace(nameOrId)`.
+After explicit user confirmation, to continue work from an existing user-owned, inactive, or unassigned task space, use `await listTaskSpaces()` to find the space, call `await useOrCreateTaskSpace(id)` to claim it, then use `await listTabs()` and `await switchTab(targetId)` to select the exact tab before acting.
 
 **Ownership policy** — every task space has `ownership: 'agent' | 'agentDelegatedToUser' | 'user'`; the helpers treat user-owned spaces differently:
 
@@ -94,6 +94,8 @@ When passing a string that may create a new task space, the string should reflec
 Only one side — agent or user — holds control of a task space at any time. While the user holds control, any browser operation by the agent fails with a "user is controlling" message — do not retry it; follow the steps below to resume.
 
 A "user is controlling" error is a hard stop on the whole task — not an obstacle to route around. It means the user has deliberately taken the browser back, often because your current approach is going wrong. Honoring it *is* the correct outcome here; pushing the goal forward anyway is the failure. The only thing you may do is **ask the user and wait**.
+
+An "inactive", "not assigned to an agent", or similar task-space error is also a hard stop; wait for explicit user confirmation before resuming with `await useOrCreateTaskSpace(id)`.
 
 **Handing off**: When the task requires user intervention (e.g. login, captcha, manual confirmation), call `await handOffTaskSpace([nameOrId])` to give control to the user, and tell them exactly what to do. Omitting `nameOrId` uses the currently selected task space; pass `task.id` across heredoc rounds to avoid ambiguity.
 


### PR DESCRIPTION
## Summary

- Treat `EGO_TASK_SPACE_INACTIVE` as a hard-stop task-space error, alongside `EGO_TASK_SPACE_USER_IN_CONTROL`.
- Preserve native `error_code` values from `ensureSession()` so hard-stop classification can see structured browser errors.
- Transform user `try/catch` blocks and Promise `.catch(...)` handlers so task-space hard stops cannot be swallowed by broad agent code.
- Add an inactive-task-space permission-boundary message that requires explicit user confirmation before resuming with `useOrCreateTaskSpace(id)`.
- Keep the ego-browser skill wording minimal and aligned with the new hard-stop behavior.

## Root Cause

The native ego binding can return structured errors such as `{ error, error_code }`, but `ensureSession()` previously rethrew `listTabs()` failures as `new Error(result.error)`, dropping the stable `error_code`. Separately, broad user-authored `catch` blocks could swallow task-space control errors and let scripts continue after the user had taken control or the space was inactive.

## Validation

- `npm test` from `package/ego-browser` passed: build, typecheck, and 83 tests.
- Synthetic `EGO_TASK_SPACE_INACTIVE` CLI run exits with hard-stop code 75 and prints the explicit permission-boundary message.
- Real ego-browser task-space test exercised the blog collection workflow, observed the inactive-space hard stop, resumed only after explicit user confirmation, organized the task-space tabs, and completed the space with `completeTaskSpace(9, { keep: true })`.
