### PR TITLE
Handle hard-stop task-space errors

### DIFF
--- a/package/ego-browser/src/browser-runtime.ts
+++ b/package/ego-browser/src/browser-runtime.ts
@@ -1,5 +1,9 @@
 import { state } from "./state.js";
-import { assertNoEgoError, buildEgoError } from "./ego-errors.js";
+import {
+  assertNoEgoError,
+  buildEgoError,
+  rethrowIfEgoHardStop,
+} from "./ego-errors.js";
 
 const RESPONSE_TIMEOUT_MS = 15000;
 const SESSION_TTL_MS = 2000;
@@ -173,7 +177,8 @@ async function enablePageEvents(sessionId) {
   try {
     await rawCdp("Page.enable", {}, sessionId);
     pageEnabledSessions.add(sessionId);
-  } catch {
+  } catch (err) {
+    rethrowIfEgoHardStop(err);
     // Dialog tracking is best-effort. Do not make all helpers fail on targets
     // that reject Page.enable, such as unusual internal pages.
   }

--- a/package/ego-browser/src/driver/element-ops.ts
+++ b/package/ego-browser/src/driver/element-ops.ts
@@ -1,4 +1,5 @@
 import { cdp } from "../cdp-eval.js";
+import { rethrowIfEgoHardStop } from "../ego-errors.js";
 import { browserRefMap, ensureRefMapForRef } from "../ref-state.js";
 import { resolveElementObjectId } from "../element-resolver.js";
 
@@ -12,7 +13,12 @@ import { resolveElementObjectId } from "../element-resolver.js";
  */
 export async function resolveHandle(selectorOrRef) {
   await ensureRefMapForRef(selectorOrRef);
-  return resolveElementObjectId({ sendRaw: cdp }, undefined, browserRefMap, selectorOrRef);
+  return resolveElementObjectId(
+    { sendRaw: cdp },
+    undefined,
+    browserRefMap,
+    selectorOrRef,
+  );
 }
 
 /**
@@ -26,7 +32,8 @@ export async function releaseHandle(objectId, sessionId) {
   if (!objectId) return;
   try {
     await cdp("Runtime.releaseObject", { objectId }, sessionId);
-  } catch {
+  } catch (err) {
+    rethrowIfEgoHardStop(err);
     // Handle/session already invalid; releasing is best-effort.
   }
 }
@@ -55,15 +62,23 @@ export async function withHandle(selectorOrRef, fn) {
  * @param {Array<unknown>} [args=[]] Arguments passed by value.
  * @returns {Promise<{result: any, objectId: string, sessionId?: string}>}
  */
-export async function resolveAndCall(selectorOrRef, functionDeclaration, args = []) {
+export async function resolveAndCall(
+  selectorOrRef,
+  functionDeclaration,
+  args = [],
+) {
   return withHandle(selectorOrRef, async ({ objectId, sessionId }) => {
-    const result = await cdp("Runtime.callFunctionOn", {
-      functionDeclaration,
-      objectId,
-      arguments: args.map((value) => ({ value })),
-      returnByValue: true,
-      awaitPromise: false
-    }, sessionId);
+    const result = await cdp(
+      "Runtime.callFunctionOn",
+      {
+        functionDeclaration,
+        objectId,
+        arguments: args.map((value) => ({ value })),
+        returnByValue: true,
+        awaitPromise: false,
+      },
+      sessionId,
+    );
     return { result, objectId, sessionId };
   });
 }

--- a/package/ego-browser/src/driver/load.ts
+++ b/package/ego-browser/src/driver/load.ts
@@ -1,5 +1,6 @@
 import { cdp, js } from "../cdp-eval.js";
 import { state } from "../state.js";
+import { rethrowIfEgoHardStop } from "../ego-errors.js";
 
 export type WaitForLoadOptions = {
   timeout?: number;
@@ -14,7 +15,8 @@ export async function waitForDocumentLoad(options: WaitForLoadOptions = {}) {
       const tree = await cdp("Page.getFrameTree");
       const url = tree.frameTree?.frame?.url || "";
       committed = url !== "" && url !== ":" && url !== "about:blank";
-    } catch {
+    } catch (err) {
+      rethrowIfEgoHardStop(err);
       // Page.getFrameTree may not be supported in some sessions; fall back to readyState only.
     }
     if (committed && (await js("document.readyState")) === "complete") {

--- a/package/ego-browser/src/driver/nav.ts
+++ b/package/ego-browser/src/driver/nav.ts
@@ -8,7 +8,7 @@ import {
   setPreferredTarget,
 } from "../browser-runtime.js";
 import { cdp, js } from "../cdp-eval.js";
-import { assertNoEgoError } from "../ego-errors.js";
+import { assertNoEgoError, rethrowIfEgoHardStop } from "../ego-errors.js";
 import { state } from "../state.js";
 import { waitForDocumentLoad } from "./load.js";
 
@@ -231,7 +231,10 @@ export async function ensureRealTab() {
   if (tabs.length === 0) {
     return null;
   }
-  const current = await currentTab().catch(() => null);
+  const current = await currentTab().catch((err) => {
+    rethrowIfEgoHardStop(err);
+    return null;
+  });
   if (
     current?.url &&
     !INTERNAL_URL_PREFIXES.some((prefix) => current.url.startsWith(prefix))

--- a/package/ego-browser/src/driver/waits.test.mjs
+++ b/package/ego-browser/src/driver/waits.test.mjs
@@ -3,7 +3,10 @@ import assert from "node:assert/strict";
 
 import { setOverrides } from "../../dist/src/state.js";
 import { cdp } from "../../dist/src/cdp-eval.js";
-import { waitForNetworkIdle } from "../../dist/src/driver/waits.js";
+import {
+  waitForElement,
+  waitForNetworkIdle,
+} from "../../dist/src/driver/waits.js";
 
 test("waitForNetworkIdle enables the Network domain and disables it afterwards", async () => {
   // Regression: nothing used to enable the Network domain, so the helper could
@@ -85,4 +88,66 @@ test("waitForNetworkIdle survives a bridge that rejects Network.enable", async (
   } finally {
     restore();
   }
+});
+
+test("waitForNetworkIdle propagates hard-stop errors from Network.enable", async () => {
+  let t = 0;
+  const restore = setOverrides({
+    cdpOverride: async (method) => {
+      if (method === "Network.enable") {
+        throw Object.assign(new Error("user has control"), {
+          error_code: "EGO_TASK_SPACE_USER_IN_CONTROL",
+        });
+      }
+      return {};
+    },
+    now: () => t,
+    sleep: async (ms) => {
+      t += ms;
+    },
+  });
+  try {
+    await assert.rejects(
+      () => waitForNetworkIdle({ timeout: 5 }),
+      (err) => err.error_code === "EGO_TASK_SPACE_USER_IN_CONTROL",
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("waitForElement propagates hard-stop errors from visibility checks", async () => {
+  let t = 0;
+  const calls = [];
+  const restore = setOverrides({
+    cdpOverride: async (method) => {
+      calls.push(method);
+      if (method === "Runtime.evaluate") {
+        return { result: { objectId: "node-1" } };
+      }
+      if (method === "Runtime.callFunctionOn") {
+        throw Object.assign(new Error("not assigned"), {
+          error_code: "EGO_TASK_SPACE_INACTIVE",
+        });
+      }
+      return {};
+    },
+    now: () => t,
+    sleep: async (ms) => {
+      t += ms;
+    },
+  });
+  try {
+    await assert.rejects(
+      () => waitForElement("#ready", { visible: true, timeout: 5 }),
+      (err) => err.error_code === "EGO_TASK_SPACE_INACTIVE",
+    );
+  } finally {
+    restore();
+  }
+  assert.deepEqual(calls, [
+    "Runtime.evaluate",
+    "Runtime.callFunctionOn",
+    "Runtime.releaseObject",
+  ]);
 });

--- a/package/ego-browser/src/driver/waits.ts
+++ b/package/ego-browser/src/driver/waits.ts
@@ -4,6 +4,7 @@ import { resolveHandle, releaseHandle } from "./element-ops.js";
 import { ElementResolutionError } from "../element-resolver.js";
 import { type WaitForLoadOptions, waitForDocumentLoad } from "./load.js";
 import { drainEvents } from "./observe.js";
+import { rethrowIfEgoHardStop } from "../ego-errors.js";
 
 type WaitForElementOptions = {
   timeout?: number;
@@ -72,7 +73,8 @@ export async function waitForElement(
         handle.sessionId,
       );
       if (response.result?.value) return true;
-    } catch {
+    } catch (err) {
+      rethrowIfEgoHardStop(err);
       // visibility check failed (element raced away); treat as not-ready, keep polling.
     } finally {
       await releaseHandle(handle.objectId, handle.sessionId);
@@ -102,7 +104,8 @@ export async function waitForNetworkIdle(
   let lastActivity = state.now();
   const inflight = new Set();
   const ownsNetworkDomain = !state.networkDomainEnabled;
-  await cdp("Network.enable").catch(() => {
+  await cdp("Network.enable").catch((err) => {
+    rethrowIfEgoHardStop(err);
     // Domain may be unsupported by the bridge; fall back to passive observation.
   });
   try {
@@ -131,7 +134,8 @@ export async function waitForNetworkIdle(
     return false;
   } finally {
     if (ownsNetworkDomain) {
-      await cdp("Network.disable").catch(() => {
+      await cdp("Network.disable").catch((err) => {
+        rethrowIfEgoHardStop(err);
         // Best-effort cleanup; keeps the event buffer from accumulating after the wait.
       });
     }

--- a/package/ego-browser/src/ego-errors.test.mjs
+++ b/package/ego-browser/src/ego-errors.test.mjs
@@ -4,8 +4,10 @@ import assert from "node:assert/strict";
 import {
   assertNoEgoError,
   egoErrorCode,
+  isEgoHardStopError,
   isEgoErrorCode,
   isEgoUserControlError,
+  rethrowIfEgoHardStop,
   resolveEgoError,
 } from "../dist/src/ego-errors.js";
 
@@ -48,6 +50,7 @@ test("resolveEgoError overrides the native error message with the owned wording 
   });
   assert.equal(code, "EGO_TASK_SPACE_INACTIVE");
   // Owned id-less guidance replaces the native "Task space 7 ..." text.
+  assert.match(message, /inactive or not assigned to this agent/);
   assert.match(message, /claimTaskSpace\(id\)/);
   assert.doesNotMatch(message, /\b7\b/);
 });
@@ -128,6 +131,30 @@ test("isEgoUserControlError keys on the stable code, not wording", () => {
   );
 });
 
+test("hard-stop classification includes user-control and inactive task spaces", () => {
+  const userControl = {
+    error_code: "EGO_TASK_SPACE_USER_IN_CONTROL",
+    error: "user has control",
+  };
+  const inactive = {
+    error_code: "EGO_TASK_SPACE_INACTIVE",
+    error: "not assigned",
+  };
+  const notFound = {
+    error_code: "EGO_TASK_SPACE_NOT_FOUND",
+    error: "not found",
+  };
+
+  assert.equal(isEgoHardStopError(userControl), true);
+  assert.equal(isEgoHardStopError(inactive), true);
+  assert.equal(isEgoHardStopError(notFound), false);
+  assert.throws(
+    () => rethrowIfEgoHardStop(userControl),
+    (err) => err === userControl,
+  );
+  assert.doesNotThrow(() => rethrowIfEgoHardStop(notFound));
+});
+
 test("assertNoEgoError resolves the message via the code and attaches error_code", () => {
   try {
     assertNoEgoError(
@@ -153,7 +180,7 @@ test("assertNoEgoError omits the prefix when no op is given", () => {
     assert.fail("expected assertNoEgoError to throw");
   } catch (err) {
     // No op given, so no "<op>: " prefix — the owned block starts the message.
-    assert.match(err.message, /^The user has taken control/);
+    assert.match(err.message, /^This task space is inactive/);
     assert.match(err.message, /claimTaskSpace\(id\)/);
     assert.doesNotMatch(err.message, /\b10\b/);
     assert.equal(err.error_code, "EGO_TASK_SPACE_INACTIVE");

--- a/package/ego-browser/src/ego-errors.ts
+++ b/package/ego-browser/src/ego-errors.ts
@@ -45,8 +45,8 @@ export type EgoErrorCode = (typeof EGO_ERROR_CODES)[number];
  */
 const EGO_ERROR_MESSAGES: Partial<Record<EgoErrorCode, string>> = {
   EGO_TASK_SPACE_INACTIVE: [
-    "The user has taken control of this task space and ended the task, so it is no longer assigned to the agent and browser commands are paused.",
-    "This is a hard stop, not an obstacle to route around — do not retry and do not take ownership back on your own.",
+    "This task space is inactive or not assigned to this agent, so browser commands are paused.",
+    "This is a hard permission boundary, not an obstacle to route around — do not retry and do not claim the space on your own.",
     "Wait until the user explicitly asks you to continue, then claim the space and resume:",
     "  await claimTaskSpace(id)",
     "",
@@ -111,6 +111,23 @@ export function resolveEgoError(err: unknown): {
 /** Whether an ego error means the task is currently under user control. */
 export function isEgoUserControlError(err: unknown): boolean {
   return egoErrorCode(err) === "EGO_TASK_SPACE_USER_IN_CONTROL";
+}
+
+/** Whether claiming the task space would cross a user-owned permission boundary. */
+export function isEgoTaskSpaceInactiveError(err: unknown): boolean {
+  return egoErrorCode(err) === "EGO_TASK_SPACE_INACTIVE";
+}
+
+/** Whether an ego error must stop the current agent script immediately. */
+export function isEgoHardStopError(err: unknown): boolean {
+  return isEgoUserControlError(err) || isEgoTaskSpaceInactiveError(err);
+}
+
+/** Re-throw hard-stop errors before a broad fallback path can swallow them. */
+export function rethrowIfEgoHardStop(err: unknown): void {
+  if (isEgoHardStopError(err)) {
+    throw err;
+  }
 }
 
 /**

--- a/package/ego-browser/src/element-resolver.ts
+++ b/package/ego-browser/src/element-resolver.ts
@@ -1,4 +1,5 @@
 import { parseRef } from "./ref-map.js";
+import { rethrowIfEgoHardStop } from "./ego-errors.js";
 
 export class ElementResolutionError extends Error {
   kind: "transient" | "permanent";
@@ -51,6 +52,7 @@ export async function resolveElementCenter(
           sessionId: effectiveSessionId,
         };
       } catch (error) {
+        rethrowIfEgoHardStop(error);
         if (error instanceof ElementResolutionError) {
           // The node resolved but has no usable box model (not rendered yet).
           // Propagate the retryable state instead of falling back to role/name,
@@ -142,7 +144,8 @@ export async function resolveElementObjectId(
         if (objectId) {
           return { objectId, sessionId: effectiveSessionId };
         }
-      } catch {
+      } catch (error) {
+        rethrowIfEgoHardStop(error);
         // The backend node can become stale after DOM updates; fall back to role/name lookup below.
       }
     }

--- a/package/ego-browser/src/run-hard-stop.test.mjs
+++ b/package/ego-browser/src/run-hard-stop.test.mjs
@@ -1,0 +1,247 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { HARD_STOP_EXIT_CODE, runMain } from "../dist/src/run.js";
+
+const USER_CONTROL_MESSAGE =
+  "The user has taken control of this task space, so browser commands are paused.";
+const INACTIVE_MESSAGE =
+  "Task space 8 is not assigned to an agent. Claim this task space before sending commands.";
+
+async function runScript(code, { ego } = {}) {
+  const previous = globalThis.ego;
+  if (ego === undefined) {
+    delete globalThis.ego;
+  } else {
+    globalThis.ego = ego;
+  }
+  const stdout = captureStream();
+  const stderr = captureStream();
+  try {
+    const exitCode = await runMain({
+      argv: [],
+      stdinText: code,
+      stdout,
+      stderr,
+      services: { printUpdateBanner() {} },
+    });
+    return { exitCode, stdout: stdout.text(), stderr: stderr.text() };
+  } finally {
+    if (previous === undefined) {
+      delete globalThis.ego;
+    } else {
+      globalThis.ego = previous;
+    }
+  }
+}
+
+function captureStream() {
+  const chunks = [];
+  return {
+    write(chunk) {
+      chunks.push(String(chunk));
+    },
+    text() {
+      return chunks.join("");
+    },
+  };
+}
+
+function userControlErrorExpression(message = USER_CONTROL_MESSAGE) {
+  return `Object.assign(new Error(${JSON.stringify(message)}), { error_code: "EGO_TASK_SPACE_USER_IN_CONTROL" })`;
+}
+
+function inactiveErrorExpression(message = INACTIVE_MESSAGE) {
+  return `Object.assign(new Error(${JSON.stringify(message)}), { error_code: "EGO_TASK_SPACE_INACTIVE" })`;
+}
+
+test("ordinary errors can still be handled by user catch blocks", async () => {
+  const result = await runScript(`
+    try {
+      throw new Error("plain page failure");
+    } catch (error) {
+      cliLog("caught: " + error.message);
+    }
+  `);
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stdout, "caught: plain page failure\n");
+  assert.equal(result.stderr, "");
+});
+
+test("hard-stop errors pass through user catch blocks", async () => {
+  const result = await runScript(`
+    try {
+      throw ${userControlErrorExpression()};
+    } catch (error) {
+      cliLog("swallowed: " + error.message);
+    }
+  `);
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /taken control of this task space/);
+  assert.match(result.stderr, /takeOverTaskSpace\(\)/);
+});
+
+test("inactive task-space errors are hard stops with claim guidance", async () => {
+  const result = await runScript(`
+    try {
+      throw ${inactiveErrorExpression()};
+    } catch (error) {
+      cliLog("swallowed: " + error.message);
+    }
+  `);
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /inactive or not assigned to this agent/);
+  assert.match(result.stderr, /hard permission boundary/);
+  assert.match(result.stderr, /claimTaskSpace\(id\)/);
+  assert.doesNotMatch(result.stderr, /\b8\b/);
+});
+
+test("hard-stop errors pass through catch blocks without bindings", async () => {
+  const result = await runScript(`
+    try {
+      throw ${userControlErrorExpression()};
+    } catch {
+      cliLog("swallowed");
+    }
+  `);
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /taken control of this task space/);
+});
+
+test("hard-stop errors pass through destructuring catch bindings", async () => {
+  const result = await runScript(`
+    try {
+      throw ${userControlErrorExpression()};
+    } catch ({ message }) {
+      cliLog("swallowed: " + message);
+    }
+  `);
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /taken control of this task space/);
+});
+
+test("ordinary destructuring catch bindings remain assignable", async () => {
+  const result = await runScript(`
+    try {
+      throw new Error("plain page failure");
+    } catch ({ message }) {
+      message = message.toUpperCase();
+      cliLog("caught: " + message);
+    }
+  `);
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stdout, "caught: PLAIN PAGE FAILURE\n");
+  assert.equal(result.stderr, "");
+});
+
+test("hard-stop errors pass through promise catch handler forms", async () => {
+  const cases = [
+    `await Promise.reject(${userControlErrorExpression()}).catch(() => { cliLog("swallowed") })`,
+    `
+      const handler = (error) => { cliLog("swallowed: " + error.message) };
+      await Promise.reject(${userControlErrorExpression()}).catch(handler);
+    `,
+    `
+      const handler = (error) => { cliLog("swallowed: " + error.message) };
+      await Promise.reject(${userControlErrorExpression()}).catch(handler.bind(null));
+    `,
+    `
+      function makeHandler() {
+        return (error) => { cliLog("swallowed: " + error.message) };
+      }
+      await Promise.reject(${userControlErrorExpression()}).catch(makeHandler());
+    `,
+    `await Promise.reject(${userControlErrorExpression()}).catch((error = {}) => { cliLog("swallowed") })`,
+    `await Promise.reject(${userControlErrorExpression()}).catch(({ message } = {}) => { cliLog("swallowed: " + message) })`,
+  ];
+
+  for (const code of cases) {
+    const result = await runScript(`
+      ${code}
+      cliLog("after");
+    `);
+    assert.equal(result.exitCode, HARD_STOP_EXIT_CODE, code);
+    assert.equal(result.stdout, "", code);
+    assert.match(result.stderr, /taken control of this task space/, code);
+  }
+});
+
+test("ordinary promise catch handlers keep their behavior", async () => {
+  const result = await runScript(`
+    const value = await Promise.reject(new Error("plain page failure")).catch((error = {}) => {
+      cliLog("caught: " + error.message);
+      return "handled";
+    });
+    const other = await Promise.reject(new Error("another failure")).catch(({ message } = {}) => message.toUpperCase());
+    cliLog("value: " + value);
+    cliLog("other: " + other);
+  `);
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(
+    result.stdout,
+    "caught: plain page failure\nvalue: handled\nother: ANOTHER FAILURE\n",
+  );
+  assert.equal(result.stderr, "");
+});
+
+test("ego user-control errors from helpers cannot be swallowed as per-item failures", async () => {
+  const ego = {
+    async listTabs() {
+      return {
+        error: USER_CONTROL_MESSAGE,
+        error_code: "EGO_TASK_SPACE_USER_IN_CONTROL",
+      };
+    },
+  };
+  const result = await runScript(
+    `
+      try {
+        await openOrReuseTab("https://example.com");
+      } catch (error) {
+        cliLog(JSON.stringify({ error: error.message }));
+      }
+    `,
+    { ego },
+  );
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /taken control of this task space/);
+});
+
+test("ego inactive errors from implicit session setup cannot be swallowed", async () => {
+  const ego = {
+    async listTabs() {
+      return {
+        error: INACTIVE_MESSAGE,
+        error_code: "EGO_TASK_SPACE_INACTIVE",
+      };
+    },
+  };
+  const result = await runScript(
+    `
+      try {
+        await pageInfo();
+      } catch (error) {
+        cliLog(JSON.stringify({ error: error.message }));
+      }
+    `,
+    { ego },
+  );
+
+  assert.equal(result.exitCode, HARD_STOP_EXIT_CODE);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /inactive or not assigned to this agent/);
+  assert.match(result.stderr, /claimTaskSpace\(id\)/);
+});

--- a/package/ego-browser/src/run.ts
+++ b/package/ego-browser/src/run.ts
@@ -4,6 +4,9 @@ import {
   stderr as processStderr,
 } from "node:process";
 
+import { parse } from "acorn";
+
+import { isEgoHardStopError, resolveEgoError } from "./ego-errors.js";
 import { formatCliLogValue } from "./format.js";
 import * as helpers from "./helpers.js";
 
@@ -57,6 +60,13 @@ export const USAGE = `Usage:
   JS
 `;
 
+// EX_TEMPFAIL communicates a resumable permission pause rather than a script bug.
+export const HARD_STOP_EXIT_CODE = 75;
+const HARD_STOP_RETHROW_HELPER_PREFIX = "__egoBrowserRethrowHardStop";
+const HARD_STOP_CATCH_PREFIX = "__egoBrowserCaughtError";
+const HARD_STOP_PROMISE_CATCH_PREFIX = "__egoBrowserPromiseCatchError";
+const HARD_STOP_PROMISE_HANDLER_PREFIX = "__egoBrowserPromiseCatchHandler";
+
 export async function runMain(options: RunMainOptions = {}) {
   const argv = options.argv || process.argv.slice(2);
   const stdout = options.stdout || processStdout;
@@ -100,17 +110,36 @@ export async function runMain(options: RunMainOptions = {}) {
   }
 
   services.printUpdateBanner(stderr);
-  await execute(code, stdout);
-  return 0;
+  try {
+    await execute(code, stdout);
+    return 0;
+  } catch (error) {
+    if (isEgoHardStopError(error)) {
+      write(stderr, formatHardStopError(error));
+      return HARD_STOP_EXIT_CODE;
+    }
+    throw error;
+  }
 }
 
 async function execute(code: string, stdout: WritableLike) {
   const context = await executionContext(stdout);
   Object.assign(globalThis, context);
   const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-  const names = Object.keys(context);
-  const values = Object.values(context);
-  const fn = new AsyncFunction(...names, `"use strict";\n${code}`);
+  const internalNames = new Set<string>();
+  const rethrowHelperName = uniqueInternalName(
+    HARD_STOP_RETHROW_HELPER_PREFIX,
+    code,
+    internalNames,
+  );
+  const names = [...Object.keys(context), rethrowHelperName];
+  const values = [...Object.values(context), rethrowHardStop];
+  const transformedCode = rewriteCatchClausesForHardStop(
+    code,
+    rethrowHelperName,
+    internalNames,
+  );
+  const fn = new AsyncFunction(...names, `"use strict";\n${transformedCode}`);
   await fn(...values);
 }
 
@@ -140,4 +169,213 @@ function readAll(stream: ReadableLike) {
 
 function write(stream: WritableLike, text: string) {
   stream.write(text);
+}
+
+function rethrowHardStop(error: unknown) {
+  if (isEgoHardStopError(error)) {
+    throw error;
+  }
+}
+
+function formatHardStopError(error: unknown) {
+  const message = resolveEgoError(error).message;
+  return message.endsWith("\n") ? message : `${message}\n`;
+}
+
+type TextEdit = {
+  start: number;
+  end: number;
+  text: string;
+};
+
+function rewriteCatchClausesForHardStop(
+  code: string,
+  rethrowHelperName: string,
+  internalNames: Set<string>,
+) {
+  const ast = parse(code, {
+    ecmaVersion: "latest",
+    sourceType: "script",
+    allowAwaitOutsideFunction: true,
+    allowReturnOutsideFunction: true,
+  } as any) as any;
+  const edits: TextEdit[] = [];
+  let catchIndex = 0;
+  let promiseCatchIndex = 0;
+
+  walkAst(ast, (node) => {
+    if (node.type === "CatchClause") {
+      appendCatchClauseEdits(
+        edits,
+        node,
+        catchIndex,
+        code,
+        rethrowHelperName,
+        internalNames,
+      );
+      catchIndex += 1;
+    }
+    if (isPromiseCatchCall(node)) {
+      appendPromiseCatchWrapperEdit(
+        edits,
+        node,
+        promiseCatchIndex,
+        code,
+        rethrowHelperName,
+        internalNames,
+      );
+      promiseCatchIndex += 1;
+    }
+  });
+
+  if (edits.length === 0) {
+    return code;
+  }
+  return applyTextEdits(code, edits);
+}
+
+function appendCatchClauseEdits(
+  edits: TextEdit[],
+  node: any,
+  index: number,
+  code: string,
+  rethrowHelperName: string,
+  internalNames: Set<string>,
+) {
+  const caughtErrorName = uniqueInternalName(
+    `${HARD_STOP_CATCH_PREFIX}${index}`,
+    code,
+    internalNames,
+  );
+  const bodyStart = node.body.start + 1;
+  if (!node.param) {
+    edits.push({
+      start: node.start + "catch".length,
+      end: node.start + "catch".length,
+      text: ` (${caughtErrorName})`,
+    });
+    edits.push({
+      start: bodyStart,
+      end: bodyStart,
+      text: `\n${rethrowHelperName}(${caughtErrorName});`,
+    });
+    return;
+  }
+
+  if (node.param.type === "Identifier") {
+    edits.push({
+      start: bodyStart,
+      end: bodyStart,
+      text: `\n${rethrowHelperName}(${node.param.name});`,
+    });
+    return;
+  }
+
+  const originalBinding = code.slice(node.param.start, node.param.end);
+  edits.push({
+    start: node.param.start,
+    end: node.param.end,
+    text: caughtErrorName,
+  });
+  // Preserve destructuring catch bindings while inspecting the original thrown
+  // value before user code can downgrade a hard-stop into an ordinary error.
+  edits.push({
+    start: bodyStart,
+    end: bodyStart,
+    text: `\n${rethrowHelperName}(${caughtErrorName});\nlet ${originalBinding} = ${caughtErrorName};`,
+  });
+}
+
+function appendPromiseCatchWrapperEdit(
+  edits: TextEdit[],
+  node: any,
+  index: number,
+  code: string,
+  rethrowHelperName: string,
+  internalNames: Set<string>,
+) {
+  const firstArg = node.arguments?.[0];
+  if (!firstArg || firstArg.type === "SpreadElement") {
+    return;
+  }
+  const caughtErrorName = uniqueInternalName(
+    `${HARD_STOP_PROMISE_CATCH_PREFIX}${index}`,
+    code,
+    internalNames,
+  );
+  const handlerName = uniqueInternalName(
+    `${HARD_STOP_PROMISE_HANDLER_PREFIX}${index}`,
+    code,
+    internalNames,
+  );
+  const originalHandler = code.slice(firstArg.start, firstArg.end);
+  edits.push({
+    start: firstArg.start,
+    end: firstArg.end,
+    text:
+      `((${handlerName}) => (${caughtErrorName}) => {\n` +
+      `${rethrowHelperName}(${caughtErrorName});\n` +
+      `return typeof ${handlerName} === "function" ? ${handlerName}(${caughtErrorName}) : Promise.reject(${caughtErrorName});\n` +
+      `})(${originalHandler})`,
+  });
+}
+
+function isPromiseCatchCall(node: any) {
+  return (
+    node?.type === "CallExpression" && isCatchMemberExpression(node.callee)
+  );
+}
+
+function isCatchMemberExpression(node: any) {
+  if (node?.type === "ChainExpression") {
+    return isCatchMemberExpression(node.expression);
+  }
+  if (node?.type !== "MemberExpression") {
+    return false;
+  }
+  if (node.computed) {
+    return node.property?.type === "Literal" && node.property.value === "catch";
+  }
+  return node.property?.type === "Identifier" && node.property.name === "catch";
+}
+
+function uniqueInternalName(
+  baseName: string,
+  code: string,
+  reserved: Set<string>,
+) {
+  let candidate = baseName;
+  let suffix = 0;
+  while (reserved.has(candidate) || code.includes(candidate)) {
+    suffix += 1;
+    candidate = `${baseName}${suffix}`;
+  }
+  reserved.add(candidate);
+  return candidate;
+}
+
+function walkAst(node: any, visit: (node: any) => void) {
+  if (!node || typeof node !== "object") {
+    return;
+  }
+  if (typeof node.type === "string") {
+    visit(node);
+  }
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        walkAst(item, visit);
+      }
+    } else if (value && typeof value === "object") {
+      walkAst(value, visit);
+    }
+  }
+}
+
+function applyTextEdits(code: string, edits: TextEdit[]) {
+  let out = code;
+  for (const edit of [...edits].sort((a, b) => b.start - a.start)) {
+    out = `${out.slice(0, edit.start)}${edit.text}${out.slice(edit.end)}`;
+  }
+  return out;
 }

--- a/package/ego-browser/src/taskspace-e2e.test.mjs
+++ b/package/ego-browser/src/taskspace-e2e.test.mjs
@@ -225,13 +225,15 @@ test("taskspace e2e useOrCreateTaskSpace selects user-owned spaces without claim
     },
   ]);
 
-  // Native rejects with error_code EGO_TASK_SPACE_USER_IN_CONTROL, so the agent
-  // sees ego-browser's owned guidance block, not the raw native text.
-  await assert.rejects(
-    () =>
-      runTaskspaceScript(ego, `await useOrCreateTaskSpace("checkout-flow")`),
-    /has taken control of this task space/,
+  // Native rejects with error_code EGO_TASK_SPACE_USER_IN_CONTROL, so the runner
+  // reports a hard-stop pause with ego-browser's owned guidance block.
+  const result = await runTaskspaceScript(
+    ego,
+    `await useOrCreateTaskSpace("checkout-flow")`,
   );
+  assert.equal(result.exitCode, 75);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /has taken control of this task space/);
   assert.deepEqual(ego.calls, [["listTaskSpaces"], ["useTaskSpace", 7]]);
 });
 

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -65,7 +65,7 @@ Use a short name for the active user goal when creating a new task space. Keep r
 
 For any follow-up on the same user goal — including continue, corrections, retries, validation, user-reported problems, or work after `completeTaskSpace(..., { keep: true })` — resume the original task space first if it still exists. Do not create a new task space for the same goal unless the user asks for a fresh space, starts an unrelated goal, or the original space is unavailable after checking. If a new space is necessary, state why.
 
-To continue work from an existing user-owned task space, use `await listTaskSpaces()` to find the space, call `await claimTaskSpace(id)` to take ownership and select it, then use `await listTabs()` and `await switchTab(targetId)` to select the exact tab before acting. This is different from resuming a handoff from your own prior task space, which starts with `await takeOverTaskSpace(nameOrId)`.
+After explicit user confirmation, to continue work from an existing user-owned, inactive, or unassigned task space, use `await listTaskSpaces()` to find the space, call `await claimTaskSpace(id)` to take ownership and select it, then use `await listTabs()` and `await switchTab(targetId)` to select the exact tab before acting.
 
 **Ownership policy** — every task space has `ownership: 'agent' | 'agentDelegatedToUser' | 'user'`; the helpers treat user-owned spaces differently:
 
@@ -94,6 +94,8 @@ When passing a string that may create a new task space, the string should reflec
 Only one side — agent or user — holds control of a task space at any time. While the user holds control, any browser operation by the agent fails with a "user is controlling" message — do not retry it; follow the steps below to resume.
 
 A "user is controlling" error is a hard stop on the whole task — not an obstacle to route around. It means the user has deliberately taken the browser back, often because your current approach is going wrong. Honoring it *is* the correct outcome here; pushing the goal forward anyway is the failure. The only thing you may do is **ask the user and wait**.
+
+An "inactive", "not assigned to an agent", or similar task-space error is also a hard stop with the same confirmation requirement. Resume only after explicit user confirmation, then start with `await claimTaskSpace(id)`.
 
 **Handing off**: When the task requires user intervention (e.g. login, captcha, manual confirmation), call `await handOffTaskSpace([nameOrId])` to give control to the user, and tell them exactly what to do. Omitting `nameOrId` uses the currently selected task space; pass `task.id` across heredoc rounds to avoid ambiguity.
 


### PR DESCRIPTION
## Summary
- Treat `EGO_TASK_SPACE_INACTIVE` as a hard-stop peer of `EGO_TASK_SPACE_USER_IN_CONTROL`, while preserving native `error_code` handling.
- Add runner-level catch and Promise `.catch(...)` rewriting so user scripts cannot accidentally swallow task-space hard stops.
- Guard internal broad fallback catches with `rethrowIfEgoHardStop(...)`.
- Update the ego-browser skill with minimal wording for explicit confirmation and `claimTaskSpace(id)` recovery.

## Verification
- `npm test`
- `npm run validate:site-skills`
- `npm run e2e`
- `git diff --check`
- Prettier check passed for changed code files before the final skill-doc minimal reflow rollback; `SKILL.md` was kept in the existing non-Prettier style to avoid unrelated documentation churn.

Supersedes #55; this branch is rebuilt from the latest `dev`.