### PR TITLE
ci(lefthook): reject commits when the branch is behind origin/dev

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,6 +12,15 @@
 pre-commit:
   parallel: false
   commands:
+    branch-up-to-date:
+      run: |
+        git fetch --quiet origin dev 2>/dev/null || { echo "⚠ skip branch-freshness check: cannot fetch origin/dev (offline?)"; exit 0; }
+        if git merge-base --is-ancestor FETCH_HEAD HEAD; then
+          exit 0
+        fi
+        echo "✗ Your branch is behind origin/dev — sync before committing:"
+        echo "    git fetch origin dev && git rebase origin/dev   # or: git merge origin/dev"
+        exit 1
     style-check:
       run: |
         files=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '^package/ego-browser/.*\.(ts|mjs|js|json|md)$' || true)


### PR DESCRIPTION
## What
Add a `branch-up-to-date` pre-commit command (lefthook) that fetches `origin/dev` before each commit and rejects the commit when the current `HEAD` does not yet contain dev's latest commit.

## Why
Surface a "branch is behind dev" situation early — at commit time — instead of discovering it later as merge conflicts when opening a PR into `dev`.

## Behavior
- Runs on **every** commit (no file filter), unlike the existing package-scoped checks.
- Fetches `origin/dev`; if `HEAD` already contains dev's tip it passes, otherwise it blocks with a hint to `rebase`/`merge`.
- Skips gracefully (does **not** block) when `origin/dev` cannot be fetched (offline).
- Adds ~1s per commit for the network fetch.

## Notes
- Placed first (alphabetical order) so it fails fast before the heavier typecheck/test/e2e steps.
- Uses `FETCH_HEAD` rather than the `origin/dev` tracking ref, which may not exist locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
