### PR TITLE
Guard browser helpers against invalid viewports

### DIFF
--- a/package/ego-browser/src/driver/nav.test.mjs
+++ b/package/ego-browser/src/driver/nav.test.mjs
@@ -7,12 +7,32 @@ import {
   pendingDialog,
 } from "../../dist/src/browser-runtime.js";
 import {
+  gotoAndWait,
   listTabs,
   newTab,
+  openOrReuseTab,
   pageInfo,
   closeTab,
 } from "../../dist/src/driver/nav.js";
 import { setOverrides, state } from "../../dist/src/state.js";
+
+function pageInfoPayload(overrides = {}) {
+  return JSON.stringify({
+    url: "https://example.com/",
+    title: "Example",
+    w: 800,
+    h: 600,
+    sx: 0,
+    sy: 0,
+    pw: 800,
+    ph: 1200,
+    ...overrides,
+  });
+}
+
+function runtimeValue(value) {
+  return { result: { value } };
+}
 
 function withEgo(ego, fn) {
   const previous = globalThis.ego;
@@ -136,6 +156,314 @@ test("newTab throws when the binding returns no targetId", async () => {
       );
     },
   );
+});
+
+test("openOrReuseTab activates newly created tabs and waits for a non-zero viewport", async () => {
+  const calls = [];
+  const sleeps = [];
+  let now = 0;
+  const viewportResponses = [
+    pageInfoPayload({ w: 0, h: 0, pw: 320, ph: 180 }),
+    pageInfoPayload({ w: 640, h: 480, pw: 640, ph: 900 }),
+  ];
+
+  await withEgo(
+    {
+      async listTabs() {
+        return { tabs: [] };
+      },
+      async createTab(url) {
+        calls.push({ method: "createTab", url });
+        return { targetId: "target-2" };
+      },
+    },
+    async () => {
+      const restore = setOverrides({
+        now: () => now,
+        async sleep(ms) {
+          sleeps.push(ms);
+          now += ms;
+        },
+        cdpOverride(method, params, sessionId) {
+          calls.push({ method, params, sessionId });
+          if (method === "Runtime.evaluate") {
+            return runtimeValue(
+              viewportResponses.shift() ??
+                pageInfoPayload({ w: 640, h: 480, pw: 640, ph: 900 }),
+            );
+          }
+          return {};
+        },
+      });
+      try {
+        assert.deepEqual(
+          await openOrReuseTab("https://example.com/new", { wait: false }),
+          {
+            targetId: "target-2",
+            url: "https://example.com/new",
+            title: "",
+            active: true,
+            reused: false,
+          },
+        );
+      } finally {
+        restore();
+      }
+    },
+  );
+
+  assert.deepEqual(calls[0], {
+    method: "createTab",
+    url: "https://example.com/new",
+  });
+  assert.deepEqual(calls[1], {
+    method: "Target.activateTarget",
+    params: { targetId: "target-2" },
+    sessionId: undefined,
+  });
+  assert.deepEqual(sleeps, [100]);
+  assert.equal(
+    calls.filter((call) => call.method === "Runtime.evaluate").length,
+    2,
+  );
+});
+
+test("openOrReuseTab calls native ensureTabReady when the bridge provides it", async () => {
+  const calls = [];
+  await withEgo(
+    {
+      async listTabs() {
+        return {
+          tabs: [
+            {
+              targetId: "target-1",
+              active: false,
+              title: "Example",
+              url: "https://example.com/",
+            },
+          ],
+        };
+      },
+      async ensureTabReady(targetId) {
+        calls.push({ method: "ensureTabReady", targetId });
+        return { ok: true };
+      },
+    },
+    async () => {
+      const restore = setOverrides({
+        cdpOverride(method, params, sessionId) {
+          calls.push({ method, params, sessionId });
+          if (method === "Runtime.evaluate") {
+            return runtimeValue(pageInfoPayload());
+          }
+          return {};
+        },
+      });
+      try {
+        const tab = await openOrReuseTab("https://example.com/", {
+          wait: false,
+        });
+        assert.equal(tab.reused, true);
+      } finally {
+        restore();
+      }
+    },
+  );
+
+  assert.deepEqual(
+    calls.map((call) => call.method),
+    ["Target.activateTarget", "ensureTabReady", "Runtime.evaluate"],
+  );
+});
+
+test("openOrReuseTab falls back to native ensureViewport when ensureTabReady is absent", async () => {
+  const calls = [];
+  await withEgo(
+    {
+      async listTabs() {
+        return {
+          tabs: [
+            {
+              targetId: "target-1",
+              active: false,
+              title: "Example",
+              url: "https://example.com/",
+            },
+          ],
+        };
+      },
+      async ensureViewport(targetId) {
+        calls.push({ method: "ensureViewport", targetId });
+        return { ok: true };
+      },
+    },
+    async () => {
+      const restore = setOverrides({
+        cdpOverride(method, params, sessionId) {
+          calls.push({ method, params, sessionId });
+          if (method === "Runtime.evaluate") {
+            return runtimeValue(pageInfoPayload());
+          }
+          return {};
+        },
+      });
+      try {
+        const tab = await openOrReuseTab("https://example.com/", {
+          wait: false,
+        });
+        assert.equal(tab.reused, true);
+      } finally {
+        restore();
+      }
+    },
+  );
+
+  assert.deepEqual(
+    calls.map((call) => call.method),
+    ["Target.activateTarget", "ensureViewport", "Runtime.evaluate"],
+  );
+});
+
+test("openOrReuseTab surfaces native ensureTabReady errors", async () => {
+  let caught;
+  await withEgo(
+    {
+      async listTabs() {
+        return {
+          tabs: [
+            {
+              targetId: "target-1",
+              active: false,
+              title: "Example",
+              url: "https://example.com/",
+            },
+          ],
+        };
+      },
+      async ensureTabReady() {
+        return {
+          error: "native viewport repair failed",
+          error_code: "EGO_INVALID_VIEWPORT",
+        };
+      },
+    },
+    async () => {
+      const restore = setOverrides({
+        cdpOverride() {
+          return {};
+        },
+      });
+      try {
+        await openOrReuseTab("https://example.com/", { wait: false });
+      } catch (error) {
+        caught = error;
+      } finally {
+        restore();
+      }
+    },
+  );
+
+  assert.match(
+    caught?.message || "",
+    /ensureTabReady: native viewport repair failed/,
+  );
+  assert.equal(caught?.error_code, "EGO_INVALID_VIEWPORT");
+});
+
+test("openOrReuseTab rejects zero-viewport tabs with a structured error", async () => {
+  let now = 0;
+  let caught;
+
+  await withEgo(
+    {
+      async listTabs() {
+        return { tabs: [] };
+      },
+      async createTab() {
+        return { targetId: "target-2" };
+      },
+    },
+    async () => {
+      const restore = setOverrides({
+        now: () => now,
+        async sleep(ms) {
+          now += ms;
+        },
+        cdpOverride(method) {
+          if (method === "Runtime.evaluate") {
+            return runtimeValue(
+              pageInfoPayload({
+                url: "https://example.com/zero",
+                w: 0,
+                h: 0,
+                pw: 320,
+                ph: 180,
+              }),
+            );
+          }
+          return {};
+        },
+      });
+      try {
+        await openOrReuseTab("https://example.com/zero", { wait: false });
+      } catch (error) {
+        caught = error;
+      } finally {
+        restore();
+      }
+    },
+  );
+
+  assert.equal(caught?.code, "EGO_INVALID_VIEWPORT");
+  assert.match(caught?.message || "", /viewport=0x0/);
+  assert.match(caught?.message || "", /https:\/\/example\.com\/zero/);
+});
+
+test("gotoAndWait rejects when navigation finishes with an invalid viewport", async () => {
+  let now = 0;
+  let caught;
+  const calls = [];
+  const restore = setOverrides({
+    now: () => now,
+    async sleep(ms) {
+      now += ms;
+    },
+    cdpOverride(method, params, sessionId) {
+      calls.push({ method, params, sessionId });
+      if (method === "Page.navigate") {
+        return { frameId: "frame-1" };
+      }
+      if (method === "Page.getFrameTree") {
+        return { frameTree: { frame: { url: "https://example.com/zero" } } };
+      }
+      if (method === "Runtime.evaluate") {
+        if (params.expression === "document.readyState") {
+          return runtimeValue("complete");
+        }
+        return runtimeValue(
+          pageInfoPayload({
+            url: "https://example.com/zero",
+            w: 0,
+            h: 0,
+            pw: 320,
+            ph: 180,
+          }),
+        );
+      }
+      return {};
+    },
+  });
+  try {
+    await gotoAndWait("https://example.com/zero", { timeout: 1 });
+  } catch (error) {
+    caught = error;
+  } finally {
+    restore();
+  }
+
+  assert.equal(caught?.code, "EGO_INVALID_VIEWPORT");
+  assert.match(caught?.message || "", /gotoAndWait/);
+  assert.equal(calls[0].method, "Page.navigate");
 });
 
 test("closeTab closes an explicit target and returns its id", async () => {

--- a/package/ego-browser/src/driver/nav.ts
+++ b/package/ego-browser/src/driver/nav.ts
@@ -1,16 +1,14 @@
 import {
   browserEgo,
   clearPreferredTarget,
-  ensureSession,
   invalidateSession,
-  isBrowserRuntime,
-  pendingDialog,
   setPreferredTarget,
 } from "../browser-runtime.js";
-import { cdp, js } from "../cdp-eval.js";
+import { cdp } from "../cdp-eval.js";
 import { assertNoEgoError } from "../ego-errors.js";
 import { state } from "../state.js";
 import { waitForDocumentLoad } from "./load.js";
+import { readPageInfo, waitForValidViewport } from "./viewport.js";
 
 export const INTERNAL_URL_PREFIXES = [
   "chrome://",
@@ -49,6 +47,26 @@ type OpenOrReuseTabOptions = {
 
 type TabTarget = string | { targetId: string };
 
+async function activateTabTarget(targetId: string) {
+  await cdp("Target.activateTarget", { targetId });
+  invalidateSession();
+  setPreferredTarget(targetId);
+}
+
+async function callNativeTabReady(targetId: string) {
+  const ego = globalThis.ego as any;
+  if (ego && typeof ego.ensureTabReady === "function") {
+    assertNoEgoError(await ego.ensureTabReady(targetId), "ensureTabReady");
+  } else if (ego && typeof ego.ensureViewport === "function") {
+    assertNoEgoError(await ego.ensureViewport(targetId), "ensureViewport");
+  }
+}
+
+async function ensureTabReady(targetId: string, context = "tab") {
+  await callNativeTabReady(targetId);
+  return waitForValidViewport(`${context} ${targetId}`);
+}
+
 /**
  * Navigate the current tab to a URL using CDP Page.navigate.
  * @param {string} url Absolute or browser-supported URL to load.
@@ -77,6 +95,9 @@ export async function gotoAndWait(
   if (settle > 0) {
     await state.sleep(settle * 1000);
   }
+  if (options.wait !== false) {
+    await waitForValidViewport("gotoAndWait");
+  }
   return { navigation, loaded };
 }
 
@@ -85,16 +106,7 @@ export async function gotoAndWait(
  * @returns {Promise<{url:string,title:string,w:number,h:number,sx:number,sy:number,pw:number,ph:number}|{dialog:object}>}
  */
 export async function pageInfo() {
-  if (isBrowserRuntime()) {
-    await ensureSession();
-    const dialog = pendingDialog();
-    if (dialog) {
-      return { dialog };
-    }
-  }
-  const expression =
-    "JSON.stringify({url:location.href,title:document.title,w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY,pw:document.documentElement.scrollWidth,ph:document.documentElement.scrollHeight})";
-  return JSON.parse(await js(expression));
+  return readPageInfo();
 }
 
 /**
@@ -145,9 +157,8 @@ export async function currentTab() {
  */
 export async function switchTab(target: string | { targetId: string }) {
   const targetId = typeof target === "object" ? target.targetId : target;
-  await cdp("Target.activateTarget", { targetId });
-  invalidateSession();
-  setPreferredTarget(targetId);
+  await activateTabTarget(targetId);
+  await ensureTabReady(targetId, "switchTab");
   return targetId;
 }
 
@@ -189,12 +200,17 @@ export async function openOrReuseTab(
     return { ...existing, active: true, reused: true };
   }
   const targetId = await newTab(url);
-  if (options.wait !== false) {
+  await switchTab(targetId);
+  const waited = options.wait !== false;
+  if (waited) {
     await waitForDocumentLoad({ timeout: options.timeout ?? 20 });
   }
   const settle = Number(options.settle ?? 0);
   if (settle > 0) {
     await state.sleep(settle * 1000);
+  }
+  if (waited || settle > 0) {
+    await ensureTabReady(targetId, "openOrReuseTab");
   }
   return { targetId, url, title: "", active: true, reused: false };
 }
@@ -236,6 +252,7 @@ export async function ensureRealTab() {
     current?.url &&
     !INTERNAL_URL_PREFIXES.some((prefix) => current.url.startsWith(prefix))
   ) {
+    await ensureTabReady(current.targetId, "ensureRealTab");
     return current;
   }
   await switchTab(tabs[0].targetId);

--- a/package/ego-browser/src/driver/observe.test.mjs
+++ b/package/ego-browser/src/driver/observe.test.mjs
@@ -8,6 +8,10 @@ import {
 import { captureScreenshot } from "../../dist/src/driver/observe.js";
 import { setOverrides } from "../../dist/src/state.js";
 
+function runtimeValue(value) {
+  return { result: { value } };
+}
+
 function withCdpRuntime(fn) {
   const previous = globalThis.ego;
   const sent = [];
@@ -96,4 +100,116 @@ test("captureScreenshot skips page metric JavaScript while a native dialog is pe
 
   assert.equal(writes.length, 1);
   assert.equal(writes[0].path, "/tmp/ego-browser-dialog-shot.png");
+});
+
+test("captureScreenshot rejects zero viewport before calling Page.captureScreenshot", async () => {
+  const calls = [];
+  const restore = setOverrides({
+    cdpOverride(method, params, sessionId) {
+      calls.push({ method, params, sessionId });
+      if (method === "Runtime.evaluate") {
+        if (params.expression === "window.devicePixelRatio") {
+          return runtimeValue(1);
+        }
+        return runtimeValue(
+          JSON.stringify({
+            url: "https://example.com/zero",
+            title: "Zero",
+            w: 0,
+            h: 0,
+            sx: 0,
+            sy: 0,
+            pw: 320,
+            ph: 180,
+          }),
+        );
+      }
+      return {};
+    },
+  });
+  try {
+    await assert.rejects(
+      () => captureScreenshot("/tmp/ego-browser-zero-shot.png"),
+      (error) => {
+        assert.equal(error.code, "EGO_INVALID_VIEWPORT");
+        assert.match(error.message, /captureScreenshot/);
+        assert.match(error.message, /viewport=0x0/);
+        return true;
+      },
+    );
+  } finally {
+    restore();
+  }
+
+  assert.equal(
+    calls.some((call) => call.method === "Page.captureScreenshot"),
+    false,
+  );
+});
+
+test("captureScreenshot rejects explicit clips on zero viewport unless raw", async () => {
+  const calls = [];
+  const writes = [];
+  const restore = setOverrides({
+    async writeFile(path, data) {
+      writes.push({ path, data });
+    },
+    cdpOverride(method, params, sessionId) {
+      calls.push({ method, params, sessionId });
+      if (method === "Runtime.evaluate") {
+        if (params.expression === "window.devicePixelRatio") {
+          return runtimeValue(1);
+        }
+        return runtimeValue(
+          JSON.stringify({
+            url: "https://example.com/zero",
+            title: "Zero",
+            w: 0,
+            h: 0,
+            sx: 0,
+            sy: 0,
+            pw: 320,
+            ph: 180,
+          }),
+        );
+      }
+      if (method === "Page.captureScreenshot") {
+        return { data: Buffer.from("png").toString("base64") };
+      }
+      return {};
+    },
+  });
+  try {
+    await assert.rejects(
+      () =>
+        captureScreenshot("/tmp/ego-browser-zero-clip.png", {
+          clip: { x: 0, y: 0, width: 100, height: 100 },
+        }),
+      /EGO_INVALID_VIEWPORT/,
+    );
+
+    assert.equal(
+      calls.some((call) => call.method === "Page.captureScreenshot"),
+      false,
+    );
+
+    await captureScreenshot("/tmp/ego-browser-zero-raw-clip.png", {
+      raw: true,
+      clip: { x: 0, y: 0, width: 100, height: 100 },
+    });
+  } finally {
+    restore();
+  }
+
+  const rawScreenshot = calls.find(
+    (call) => call.method === "Page.captureScreenshot",
+  );
+  assert.deepEqual(rawScreenshot?.params.clip, {
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+  });
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].path, "/tmp/ego-browser-zero-raw-clip.png");
 });

--- a/package/ego-browser/src/driver/observe.ts
+++ b/package/ego-browser/src/driver/observe.ts
@@ -18,6 +18,7 @@ import {
   ensureRefMapForRef,
   registerSnapshotForRefRefresh,
 } from "../ref-state.js";
+import { assertValidViewport } from "./viewport.js";
 
 type SnapshotOptions = {
   scope?: "only_within_viewport" | "full_page";
@@ -106,13 +107,14 @@ export async function captureScreenshot(
     if (!pendingDialog()) {
       const dpr = Number(await js("window.devicePixelRatio")) || 1;
       const cssScale = 1 / dpr;
+      const info = await pageInfo();
+      if ("dialog" in info) {
+        return captureScreenshot(path, { ...options, raw: true });
+      }
+      assertValidViewport(info, "captureScreenshot");
       if (options.clip) {
         params.clip = { scale: cssScale, ...options.clip };
       } else {
-        const info = await pageInfo();
-        if ("dialog" in info) {
-          return captureScreenshot(path, { ...options, raw: true });
-        }
         params.clip = {
           x: 0,
           y: 0,

--- a/package/ego-browser/src/driver/viewport.ts
+++ b/package/ego-browser/src/driver/viewport.ts
@@ -1,0 +1,99 @@
+import {
+  ensureSession,
+  isBrowserRuntime,
+  pendingDialog,
+} from "../browser-runtime.js";
+import { js } from "../cdp-eval.js";
+import { state } from "../state.js";
+
+export type PageInfo =
+  | {
+      url: string;
+      title: string;
+      w: number;
+      h: number;
+      sx: number;
+      sy: number;
+      pw: number;
+      ph: number;
+    }
+  | { dialog: object };
+
+type WaitForValidViewportOptions = {
+  timeoutMs?: number;
+  intervalMs?: number;
+};
+
+const DEFAULT_VIEWPORT_READY_TIMEOUT_MS = 5000;
+const VIEWPORT_READY_INTERVAL_MS = 100;
+
+export async function readPageInfo(): Promise<PageInfo> {
+  if (isBrowserRuntime()) {
+    await ensureSession();
+    const dialog = pendingDialog();
+    if (dialog) {
+      return { dialog };
+    }
+  }
+  const expression =
+    "JSON.stringify({url:location.href,title:document.title,w:innerWidth,h:innerHeight,sx:scrollX,sy:scrollY,pw:document.documentElement.scrollWidth,ph:document.documentElement.scrollHeight})";
+  return JSON.parse(await js(expression));
+}
+
+export function hasDialog(info: PageInfo): info is { dialog: object } {
+  return Object.hasOwn(info, "dialog");
+}
+
+export function hasValidViewport(info: PageInfo) {
+  return !hasDialog(info) && info.w > 0 && info.h > 0;
+}
+
+export function invalidViewportError(info: PageInfo, context: string) {
+  const details = hasDialog(info)
+    ? "a native JavaScript dialog is pending"
+    : `viewport=${info.w}x${info.h}, page=${info.pw}x${info.ph}, url=${info.url}`;
+  const error: any = new Error(
+    `EGO_INVALID_VIEWPORT: ${context} requires a non-zero viewport; ${details}`,
+  );
+  error.code = "EGO_INVALID_VIEWPORT";
+  error.details = { context, pageInfo: info };
+  return error;
+}
+
+export function assertValidViewport(info: PageInfo, context: string) {
+  if (!hasValidViewport(info)) {
+    throw invalidViewportError(info, context);
+  }
+}
+
+export async function waitForValidViewport(
+  context: string,
+  options: WaitForValidViewportOptions = {},
+) {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_VIEWPORT_READY_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? VIEWPORT_READY_INTERVAL_MS;
+  const deadline = state.now() + timeoutMs;
+  let lastInfo: PageInfo | null = null;
+
+  while (state.now() <= deadline) {
+    lastInfo = await readPageInfo();
+    if (hasDialog(lastInfo) || hasValidViewport(lastInfo)) {
+      return lastInfo;
+    }
+    await state.sleep(intervalMs);
+  }
+
+  throw invalidViewportError(
+    lastInfo ?? {
+      url: "",
+      title: "",
+      w: 0,
+      h: 0,
+      sx: 0,
+      sy: 0,
+      pw: 0,
+      ph: 0,
+    },
+    context,
+  );
+}

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -435,13 +435,18 @@ export async function siteSkillsForUrl(url) {
   });
 }
 
+async function currentPageUrl() {
+  const info = await nav.pageInfo();
+  return "url" in info ? info.url : "";
+}
+
 /**
  * Return site skills matching a URL, or the current page URL when omitted.
  * @param {string} [url] URL to inspect for site skills.
  * @returns {Promise<Array<object|string>>}
  */
 export async function siteSkills(url = undefined) {
-  const targetUrl = url ?? (await nav.pageInfo()).url ?? "";
+  const targetUrl = url ?? (await currentPageUrl());
   return siteSkillsForUrl(targetUrl);
 }
 
@@ -479,7 +484,7 @@ export async function runSiteBrowserTool(siteId, toolName, args: any = {}) {
  * @returns {Promise<object>} Learned context with knowledge and tool signatures.
  */
 export async function learnContext(url = undefined) {
-  const targetUrl = url ?? (await nav.pageInfo()).url ?? "";
+  const targetUrl = url ?? (await currentPageUrl());
   return loadLearnedContext(targetUrl, {
     agentWorkspace: state.agentWorkspace(),
   });


### PR DESCRIPTION
## Summary

- add an internal viewport readiness module that centralizes `pageInfo()` reads, non-zero viewport checks, and structured `EGO_INVALID_VIEWPORT` errors
- route tab activation/navigation helpers through internal readiness checks while keeping the agent-facing API unchanged
- allow future native `ego.ensureTabReady()` / `ego.ensureViewport()` integrations without exposing new helper calls to agents
- fail screenshots fast on invalid viewports, while preserving `raw: true` as the low-level escape hatch

## Tests

- `npm test`
- `npm run validate:site-skills`
- `git diff --check`
- `npx prettier --check package/ego-browser/src/driver/nav.ts package/ego-browser/src/driver/viewport.ts package/ego-browser/src/driver/observe.ts package/ego-browser/src/helpers.ts package/ego-browser/src/driver/nav.test.mjs package/ego-browser/src/driver/observe.test.mjs`

Pre-commit also ran typecheck, taskspace e2e, site-skill validation, full test suite, style-check, and audit.
