### PR TITLE
docs(skill): treat inactive/unassigned task spaces as hard stops

### DIFF
--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -65,7 +65,7 @@ Use a short name for the active user goal when creating a new task space. Keep r
 
 For any follow-up on the same user goal — including continue, corrections, retries, validation, user-reported problems, or work after `completeTaskSpace(..., { keep: true })` — resume the original task space first if it still exists. Do not create a new task space for the same goal unless the user asks for a fresh space, starts an unrelated goal, or the original space is unavailable after checking. If a new space is necessary, state why.
 
-To continue work from an existing user-owned task space, use `await listTaskSpaces()` to find the space, call `await claimTaskSpace(id)` to take ownership and select it, then use `await listTabs()` and `await switchTab(targetId)` to select the exact tab before acting. This is different from resuming a handoff from your own prior task space, which starts with `await takeOverTaskSpace(nameOrId)`.
+After explicit user confirmation, to continue work from an existing user-owned, inactive, or unassigned task space, use `await listTaskSpaces()` to find the space, call `await claimTaskSpace(id)` to take ownership and select it, then use `await listTabs()` and `await switchTab(targetId)` to select the exact tab before acting.
 
 **Ownership policy** — every task space has `ownership: 'agent' | 'agentDelegatedToUser' | 'user'`; the helpers treat user-owned spaces differently:
 
@@ -94,6 +94,8 @@ When passing a string that may create a new task space, the string should reflec
 Only one side — agent or user — holds control of a task space at any time. While the user holds control, any browser operation by the agent fails with a "user is controlling" message — do not retry it; follow the steps below to resume.
 
 A "user is controlling" error is a hard stop on the whole task — not an obstacle to route around. It means the user has deliberately taken the browser back, often because your current approach is going wrong. Honoring it *is* the correct outcome here; pushing the goal forward anyway is the failure. The only thing you may do is **ask the user and wait**.
+
+An "inactive", "not assigned to an agent", or similar task-space error is also a hard stop with the same confirmation requirement. Resume only after explicit user confirmation, then start with `await claimTaskSpace(id)`.
 
 **Handing off**: When the task requires user intervention (e.g. login, captcha, manual confirmation), call `await handOffTaskSpace([nameOrId])` to give control to the user, and tell them exactly what to do. Omitting `nameOrId` uses the currently selected task space; pass `task.id` across heredoc rounds to avoid ambiguity.
 


### PR DESCRIPTION
## What

Lands the `skills/ego-browser/SKILL.md` documentation changes from #56 as a standalone PR, independent of that PR's runtime hard-stop code.

Two hunks, identical to #56's SKILL.md diff:
- Resuming an existing user-owned / **inactive** / **unassigned** task space now requires **explicit user confirmation** before `claimTaskSpace`.
- Adds a note that an `"inactive"` / `"not assigned to an agent"` task-space error is a **hard stop** with the same confirmation requirement.

## Why split it out

The doc guidance is safe to merge now: it only references `claimTaskSpace`, which already exists on `dev` (#52). #56 stays open so its runtime changes can be reviewed/merged separately; once it rebases on `dev`, this SKILL.md hunk will already be applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)