### PR TITLE
Relax viewport checks during navigation

### DIFF
--- a/package/ego-browser/src/driver/nav.test.mjs
+++ b/package/ego-browser/src/driver/nav.test.mjs
@@ -16,20 +16,6 @@ import {
 } from "../../dist/src/driver/nav.js";
 import { setOverrides, state } from "../../dist/src/state.js";
 
-function pageInfoPayload(overrides = {}) {
-  return JSON.stringify({
-    url: "https://example.com/",
-    title: "Example",
-    w: 800,
-    h: 600,
-    sx: 0,
-    sy: 0,
-    pw: 800,
-    ph: 1200,
-    ...overrides,
-  });
-}
-
 function runtimeValue(value) {
   return { result: { value } };
 }
@@ -158,14 +144,8 @@ test("newTab throws when the binding returns no targetId", async () => {
   );
 });
 
-test("openOrReuseTab activates newly created tabs and waits for a non-zero viewport", async () => {
+test("openOrReuseTab activates newly created tabs without forcing viewport validation", async () => {
   const calls = [];
-  const sleeps = [];
-  let now = 0;
-  const viewportResponses = [
-    pageInfoPayload({ w: 0, h: 0, pw: 320, ph: 180 }),
-    pageInfoPayload({ w: 640, h: 480, pw: 640, ph: 900 }),
-  ];
 
   await withEgo(
     {
@@ -179,19 +159,8 @@ test("openOrReuseTab activates newly created tabs and waits for a non-zero viewp
     },
     async () => {
       const restore = setOverrides({
-        now: () => now,
-        async sleep(ms) {
-          sleeps.push(ms);
-          now += ms;
-        },
         cdpOverride(method, params, sessionId) {
           calls.push({ method, params, sessionId });
-          if (method === "Runtime.evaluate") {
-            return runtimeValue(
-              viewportResponses.shift() ??
-                pageInfoPayload({ w: 640, h: 480, pw: 640, ph: 900 }),
-            );
-          }
           return {};
         },
       });
@@ -221,10 +190,9 @@ test("openOrReuseTab activates newly created tabs and waits for a non-zero viewp
     params: { targetId: "target-2" },
     sessionId: undefined,
   });
-  assert.deepEqual(sleeps, [100]);
   assert.equal(
     calls.filter((call) => call.method === "Runtime.evaluate").length,
-    2,
+    0,
   );
 });
 
@@ -253,9 +221,6 @@ test("openOrReuseTab calls native ensureTabReady when the bridge provides it", a
       const restore = setOverrides({
         cdpOverride(method, params, sessionId) {
           calls.push({ method, params, sessionId });
-          if (method === "Runtime.evaluate") {
-            return runtimeValue(pageInfoPayload());
-          }
           return {};
         },
       });
@@ -272,7 +237,7 @@ test("openOrReuseTab calls native ensureTabReady when the bridge provides it", a
 
   assert.deepEqual(
     calls.map((call) => call.method),
-    ["Target.activateTarget", "ensureTabReady", "Runtime.evaluate"],
+    ["Target.activateTarget", "ensureTabReady"],
   );
 });
 
@@ -301,9 +266,6 @@ test("openOrReuseTab falls back to native ensureViewport when ensureTabReady is 
       const restore = setOverrides({
         cdpOverride(method, params, sessionId) {
           calls.push({ method, params, sessionId });
-          if (method === "Runtime.evaluate") {
-            return runtimeValue(pageInfoPayload());
-          }
           return {};
         },
       });
@@ -320,7 +282,7 @@ test("openOrReuseTab falls back to native ensureViewport when ensureTabReady is 
 
   assert.deepEqual(
     calls.map((call) => call.method),
-    ["Target.activateTarget", "ensureViewport", "Runtime.evaluate"],
+    ["Target.activateTarget", "ensureViewport"],
   );
 });
 
@@ -370,10 +332,8 @@ test("openOrReuseTab surfaces native ensureTabReady errors", async () => {
   assert.equal(caught?.error_code, "EGO_INVALID_VIEWPORT");
 });
 
-test("openOrReuseTab rejects zero-viewport tabs with a structured error", async () => {
-  let now = 0;
-  let caught;
-
+test("openOrReuseTab leaves viewport validation to viewport-dependent helpers", async () => {
+  const calls = [];
   await withEgo(
     {
       async listTabs() {
@@ -385,49 +345,37 @@ test("openOrReuseTab rejects zero-viewport tabs with a structured error", async 
     },
     async () => {
       const restore = setOverrides({
-        now: () => now,
-        async sleep(ms) {
-          now += ms;
-        },
-        cdpOverride(method) {
-          if (method === "Runtime.evaluate") {
-            return runtimeValue(
-              pageInfoPayload({
-                url: "https://example.com/zero",
-                w: 0,
-                h: 0,
-                pw: 320,
-                ph: 180,
-              }),
-            );
-          }
+        cdpOverride(method, params, sessionId) {
+          calls.push({ method, params, sessionId });
           return {};
         },
       });
       try {
-        await openOrReuseTab("https://example.com/zero", { wait: false });
-      } catch (error) {
-        caught = error;
+        assert.deepEqual(
+          await openOrReuseTab("https://example.com/zero", { wait: false }),
+          {
+            targetId: "target-2",
+            url: "https://example.com/zero",
+            title: "",
+            active: true,
+            reused: false,
+          },
+        );
       } finally {
         restore();
       }
     },
   );
 
-  assert.equal(caught?.code, "EGO_INVALID_VIEWPORT");
-  assert.match(caught?.message || "", /viewport=0x0/);
-  assert.match(caught?.message || "", /https:\/\/example\.com\/zero/);
+  assert.equal(
+    calls.some((call) => call.method === "Runtime.evaluate"),
+    false,
+  );
 });
 
-test("gotoAndWait rejects when navigation finishes with an invalid viewport", async () => {
-  let now = 0;
-  let caught;
+test("gotoAndWait does not turn invalid viewport into a navigation failure", async () => {
   const calls = [];
   const restore = setOverrides({
-    now: () => now,
-    async sleep(ms) {
-      now += ms;
-    },
     cdpOverride(method, params, sessionId) {
       calls.push({ method, params, sessionId });
       if (method === "Page.navigate") {
@@ -440,30 +388,27 @@ test("gotoAndWait rejects when navigation finishes with an invalid viewport", as
         if (params.expression === "document.readyState") {
           return runtimeValue("complete");
         }
-        return runtimeValue(
-          pageInfoPayload({
-            url: "https://example.com/zero",
-            w: 0,
-            h: 0,
-            pw: 320,
-            ph: 180,
-          }),
-        );
       }
       return {};
     },
   });
   try {
-    await gotoAndWait("https://example.com/zero", { timeout: 1 });
-  } catch (error) {
-    caught = error;
+    assert.deepEqual(
+      await gotoAndWait("https://example.com/zero", { timeout: 1 }),
+      {
+        navigation: { frameId: "frame-1" },
+        loaded: true,
+      },
+    );
   } finally {
     restore();
   }
 
-  assert.equal(caught?.code, "EGO_INVALID_VIEWPORT");
-  assert.match(caught?.message || "", /gotoAndWait/);
   assert.equal(calls[0].method, "Page.navigate");
+  assert.equal(
+    calls.filter((call) => call.method === "Runtime.evaluate").length,
+    1,
+  );
 });
 
 test("closeTab closes an explicit target and returns its id", async () => {

--- a/package/ego-browser/src/driver/nav.ts
+++ b/package/ego-browser/src/driver/nav.ts
@@ -8,7 +8,7 @@ import { cdp } from "../cdp-eval.js";
 import { assertNoEgoError } from "../ego-errors.js";
 import { state } from "../state.js";
 import { waitForDocumentLoad } from "./load.js";
-import { readPageInfo, waitForValidViewport } from "./viewport.js";
+import { readPageInfo } from "./viewport.js";
 
 export const INTERNAL_URL_PREFIXES = [
   "chrome://",
@@ -62,9 +62,10 @@ async function callNativeTabReady(targetId: string) {
   }
 }
 
-async function ensureTabReady(targetId: string, context = "tab") {
+async function ensureTabReady(targetId: string) {
+  // Keep viewport assertions in viewport-dependent helpers. Navigation should
+  // not abort the whole task just because the renderer currently reports 0x0.
   await callNativeTabReady(targetId);
-  return waitForValidViewport(`${context} ${targetId}`);
 }
 
 /**
@@ -94,9 +95,6 @@ export async function gotoAndWait(
   const settle = Number(options.settle ?? 0);
   if (settle > 0) {
     await state.sleep(settle * 1000);
-  }
-  if (options.wait !== false) {
-    await waitForValidViewport("gotoAndWait");
   }
   return { navigation, loaded };
 }
@@ -158,7 +156,7 @@ export async function currentTab() {
 export async function switchTab(target: string | { targetId: string }) {
   const targetId = typeof target === "object" ? target.targetId : target;
   await activateTabTarget(targetId);
-  await ensureTabReady(targetId, "switchTab");
+  await ensureTabReady(targetId);
   return targetId;
 }
 
@@ -209,9 +207,6 @@ export async function openOrReuseTab(
   if (settle > 0) {
     await state.sleep(settle * 1000);
   }
-  if (waited || settle > 0) {
-    await ensureTabReady(targetId, "openOrReuseTab");
-  }
   return { targetId, url, title: "", active: true, reused: false };
 }
 
@@ -252,7 +247,6 @@ export async function ensureRealTab() {
     current?.url &&
     !INTERNAL_URL_PREFIXES.some((prefix) => current.url.startsWith(prefix))
   ) {
-    await ensureTabReady(current.targetId, "ensureRealTab");
     return current;
   }
   await switchTab(tabs[0].targetId);

--- a/package/ego-browser/src/driver/viewport.ts
+++ b/package/ego-browser/src/driver/viewport.ts
@@ -4,7 +4,6 @@ import {
   pendingDialog,
 } from "../browser-runtime.js";
 import { js } from "../cdp-eval.js";
-import { state } from "../state.js";
 
 export type PageInfo =
   | {
@@ -18,14 +17,6 @@ export type PageInfo =
       ph: number;
     }
   | { dialog: object };
-
-type WaitForValidViewportOptions = {
-  timeoutMs?: number;
-  intervalMs?: number;
-};
-
-const DEFAULT_VIEWPORT_READY_TIMEOUT_MS = 5000;
-const VIEWPORT_READY_INTERVAL_MS = 100;
 
 export async function readPageInfo(): Promise<PageInfo> {
   if (isBrowserRuntime()) {
@@ -64,36 +55,4 @@ export function assertValidViewport(info: PageInfo, context: string) {
   if (!hasValidViewport(info)) {
     throw invalidViewportError(info, context);
   }
-}
-
-export async function waitForValidViewport(
-  context: string,
-  options: WaitForValidViewportOptions = {},
-) {
-  const timeoutMs = options.timeoutMs ?? DEFAULT_VIEWPORT_READY_TIMEOUT_MS;
-  const intervalMs = options.intervalMs ?? VIEWPORT_READY_INTERVAL_MS;
-  const deadline = state.now() + timeoutMs;
-  let lastInfo: PageInfo | null = null;
-
-  while (state.now() <= deadline) {
-    lastInfo = await readPageInfo();
-    if (hasDialog(lastInfo) || hasValidViewport(lastInfo)) {
-      return lastInfo;
-    }
-    await state.sleep(intervalMs);
-  }
-
-  throw invalidViewportError(
-    lastInfo ?? {
-      url: "",
-      title: "",
-      w: 0,
-      h: 0,
-      sx: 0,
-      sy: 0,
-      pw: 0,
-      ph: 0,
-    },
-    context,
-  );
 }


### PR DESCRIPTION
## Summary
- stop navigation helpers from polling/throwing on renderer-reported 0x0 viewport
- keep native tab-ready hooks on tab activation, but leave viewport assertions to helpers that actually depend on viewport metrics
- update nav tests so open/switch/goto do not abort a task before viewport-dependent work runs

## Why
The previous viewport guard fixed screenshot failures, but placing the guard inside navigation made `openOrReuseTab`/`gotoAndWait` fail early with `EGO_INVALID_VIEWPORT`. Higher-level agents can interpret that as a failed task attempt and restart with a new taskspace, which creates many taskspaces during one user task.

## Validation
- `npm test`
- `npm run validate:site-skills`
- `git diff --check && npx prettier --check package/ego-browser/src/driver/nav.ts package/ego-browser/src/driver/viewport.ts package/ego-browser/src/driver/nav.test.mjs`
- pre-commit: typecheck, taskspace e2e, site-skill validation, smoke test, style check, npm audit
- runtime ego-browser smoke: reused one fixed taskspace while opening local normal/hydration pages 6 times; `openOrReuseTab` succeeded each time, only one taskspace existed, and `captureScreenshot` still failed fast with `EGO_INVALID_VIEWPORT` on a 0x0 viewport