### PR TITLE
test(ego-browser): migrate uncovered regression cases into real-browser e2e

### DIFF
--- a/package/ego-browser/scripts/real-browser-e2e/cases/index.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/cases/index.mjs
@@ -5,7 +5,9 @@ import { navigationCase } from "./navigation.mjs";
 import { observationCase } from "./observation.mjs";
 import { pointerCase } from "./pointer.mjs";
 import { keyboardCase } from "./keyboard.mjs";
+import { keyboardRegressionCase } from "./keyboard-regression.mjs";
 import { runtimeCase } from "./runtime.mjs";
+import { runtimeRegressionCase } from "./runtime-regression.mjs";
 
 export const e2eCases = [
   { name: "environment initialization", body: environmentCase },
@@ -15,5 +17,7 @@ export const e2eCases = [
   { name: "observation helpers", body: observationCase },
   { name: "pointer and scroll helpers", body: pointerCase },
   { name: "keyboard and file helpers", body: keyboardCase },
+  { name: "keyboard regression", body: keyboardRegressionCase },
   { name: "wait, fetch, cdp, js, help", body: runtimeCase },
+  { name: "runtime regression", body: runtimeRegressionCase },
 ];

--- a/package/ego-browser/scripts/real-browser-e2e/cases/keyboard-regression.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/cases/keyboard-regression.mjs
@@ -1,0 +1,50 @@
+export function keyboardRegressionCase() {
+  return `
+    await useOrCreateTaskSpace(taskName);
+    await resetHome();
+
+    /* Issue 1: fillInput on type=email replaces the prior value without crashing.
+       Before the fix, clearFirst's setSelectionRange threw InvalidStateError on
+       type=email/number inputs and the whole fillInput rejected, writing nothing. */
+    await js("document.querySelector('#email-input').value = 'old@example.com'; window.__fixtureState.valueEvents['email-input'] = []; return true;");
+    await fillInput("#email-input", "marcus.hale@example.com", { timeout: 3 });
+    const emailValue = await js("return document.querySelector('#email-input').value");
+    assertEqual(emailValue, "marcus.hale@example.com", "fillInput replaces type=email value (Issue 1)");
+    const emailEvents = await js("return (window.__fixtureState.valueEvents['email-input'] || []).join(',')");
+    assertIncludes(emailEvents, "input", "fillInput fires input on type=email (Issue 1)");
+    assertIncludes(emailEvents, "change", "fillInput fires change on type=email (Issue 1)");
+
+    /* Issue 1: same setSelectionRange crash on type=number. */
+    await js("document.querySelector('#number-input').value = '123'; return true;");
+    await fillInput("#number-input", "456", { timeout: 3 });
+    const numberValue = await js("return document.querySelector('#number-input').value");
+    assertEqual(numberValue, "456", "fillInput replaces type=number value (Issue 1)");
+
+    /* Issue 2: non-bare selectors resolve through the unified element-resolver.
+       Before the fix, the CSS path fed 'xpath=...' straight into querySelector
+       and threw SyntaxError. */
+    await fillInput('xpath=//input[@id="text-input"]', "via-xpath", { timeout: 3 });
+    const xpathValue = await js("return document.querySelector('#text-input').value");
+    assertEqual(xpathValue, "via-xpath", "fillInput resolves xpath= selector (Issue 2)");
+
+    /* Issue 2: dispatchKey shares the same resolver path. */
+    await js("window.__fixtureState.keys = []; return true;");
+    await dispatchKey('xpath=//input[@id="text-input"]', "Enter", "keydown");
+    const keys = await js("return window.__fixtureState.keys.join(',')");
+    assertIncludes(keys, "Enter", "dispatchKey resolves xpath= selector (Issue 2)");
+
+    /* Issue 2: uploadFile shares the same resolver path (the pilot covered
+       fillInput/dispatchKey but left uploadFile out). */
+    await uploadFile('xpath=//input[@id="file-input"]', uploadPath);
+    const xpathFile = await js("return Array.from(document.querySelector('#file-input').files).map((file) => file.name).join(',')");
+    assertEqual(xpathFile, "fixture-upload.txt", "uploadFile resolves xpath= selector (Issue 2)");
+
+    /* fillInput must persist on a react-style controlled input, whose native
+       value-setter writeback fights synthetic value changes. */
+    await fillInput("#controlled-input", "hello-react", { timeout: 3 });
+    const controlledValue = await js("return document.querySelector('#controlled-input').value");
+    assertEqual(controlledValue, "hello-react", "fillInput persists value on a react-style controlled input");
+    const controlledState = await js("return document.querySelector('#controlled-state').textContent");
+    assert(controlledState.startsWith("hello-react"), "controlled state mirror reflects the filled value");
+  `;
+}

--- a/package/ego-browser/scripts/real-browser-e2e/cases/runtime-regression.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/cases/runtime-regression.mjs
@@ -1,0 +1,79 @@
+export function runtimeRegressionCase() {
+  return `
+    await useOrCreateTaskSpace(taskName);
+    await resetHome();
+
+    /* Issue 2: waitForElement shares the unified resolver — xpath= must resolve a
+       static element (official runtime.mjs only exercises CSS selectors here). */
+    assertEqual(
+      await waitForElement('xpath=//button[@id="click-button"]', { timeout: 4 }),
+      true,
+      "waitForElement resolves xpath= selector (Issue 2)"
+    );
+
+    /* Resolver failure classes on waitForElement: a permanent (ambiguous) selector
+       fails fast; a transient (missing) one polls until the timeout, then returns
+       false. Official only covers the happy path. */
+    const permStart = Date.now();
+    await assertRejects(
+      () => waitForElement("loc=css:.duplicate-action", { timeout: 5 }),
+      "matched 2",
+      "waitForElement throws on a permanent ambiguity error"
+    );
+    assert(
+      Date.now() - permStart < 2500,
+      "permanent ambiguity error fails fast, not consuming the full timeout"
+    );
+
+    const missStart = Date.now();
+    assertEqual(
+      await waitForElement("#no-such-element-xyz", { timeout: 1 }),
+      false,
+      "waitForElement returns false for a transient missing element"
+    );
+    assert(
+      Date.now() - missStart >= 700,
+      "transient miss polls until the timeout elapses"
+    );
+
+    /* js runs in the page, not the heredoc: caller closure variables are NOT
+       captured. 'outer' is referenced only inside the serialized function. */
+    const outer = 100;
+    const closureType = await js(function () {
+      return typeof outer;
+    });
+    assertEqual(closureType, "undefined", "js does not capture caller closure variables");
+
+    /* js rejects invalid input types (neither string nor function). */
+    await assertRejectsAny(() => js(123), "js rejects non-string/function input");
+
+    /* serverFetch returns the body and respects exact content length. */
+    const bytes = await serverFetch(baseUrl + "/api/bytes?n=4096", { timeout: 5 });
+    assertEqual(bytes.length, 4096, "serverFetch returns a body of the exact requested length");
+
+    /* serverFetch / browserFetch surface 4xx HTTP errors (official only covers 500). */
+    await assertRejects(
+      () => serverFetch(baseUrl + "/api/status?code=404", { timeout: 5 }),
+      "HTTP 404",
+      "serverFetch reports 4xx HTTP errors"
+    );
+    await assertRejects(
+      () => browserFetch("/api/status?code=404", { timeout: 5 }),
+      "HTTP 404",
+      "browserFetch reports 4xx HTTP errors"
+    );
+
+    /* waitForLoad blocks until a slow-arriving document loads. Navigates away, so
+       keep this last. */
+    const slowStart = Date.now();
+    await gotoUrl(baseUrl + "/slow-page?ms=1200");
+    assert(
+      await waitForLoad({ timeout: 8 }),
+      "waitForLoad resolves true once the slow document arrives"
+    );
+    assert(
+      Date.now() - slowStart >= 1000,
+      "waitForLoad blocks until the slow document loads"
+    );
+  `;
+}

--- a/package/ego-browser/scripts/real-browser-e2e/fixture.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/fixture.mjs
@@ -97,6 +97,24 @@ export async function startFixtureServer(taskName) {
       }, delayMs);
       return;
     }
+    if (url.pathname === "/api/status") {
+      const code = Number(url.searchParams.get("code") || 200);
+      res.writeHead(code, {
+        "content-type": "text/plain",
+        "access-control-allow-origin": "*",
+      });
+      res.end(`status ${code}`);
+      return;
+    }
+    if (url.pathname === "/api/bytes") {
+      const n = Math.max(0, Number(url.searchParams.get("n") || 0));
+      res.writeHead(200, {
+        "content-type": "text/plain",
+        "access-control-allow-origin": "*",
+      });
+      res.end("a".repeat(n));
+      return;
+    }
     if (req.method === "OPTIONS") {
       res.writeHead(204, {
         "access-control-allow-origin": "*",
@@ -119,6 +137,17 @@ export async function startFixtureServer(taskName) {
     if (url.pathname === "/secondary") {
       res.writeHead(200, { "content-type": "text/html" });
       res.end(pageHtml("secondary"));
+      return;
+    }
+    if (url.pathname === "/slow-page") {
+      const delayMs = Number(url.searchParams.get("ms") || 250);
+      setTimeout(() => {
+        res.writeHead(200, { "content-type": "text/html" });
+        res.end(
+          "<!doctype html><html><head><title>slow page</title></head>" +
+            '<body><h1 id="slow-marker">slow document loaded</h1></body></html>',
+        );
+      }, delayMs);
       return;
     }
     if (url.pathname === "/favicon.ico") {
@@ -253,6 +282,10 @@ function pageHtml(kind) {
       <iframe id="fixture-frame" src="/frame.html"></iframe>
       <div id="inner-scroll"><div id="inner-scroll-content">Inner scroll marker</div></div>
       <section id="scroll-area"><div id="bottom-marker">Bottom marker</div></section>
+      <label>Email input <input id="email-input" type="email" value="old@example.com"></label>
+      <label>Number input <input id="number-input" type="number" value="123"></label>
+      <label>Controlled input <input id="controlled-input" type="text"></label>
+      <span id="controlled-state"></span>
       ${kind === "frame" ? '<div id="iframe-marker" data-iframe="true" style="border:2px solid #44f;padding:8px;margin-top:8px;">iframe target</div>' : ""}
     </main>
     <script>
@@ -271,6 +304,7 @@ function pageHtml(kind) {
         tabOrder: [],
         checkboxChecked: false,
         dropdownValue: "alpha",
+        valueEvents: {},
       };
       const count = document.querySelector("#click-count");
       const clickButton = document.querySelector("#click-button");
@@ -333,6 +367,41 @@ function pageHtml(kind) {
         document.querySelector("#file-name").textContent =
           Array.from(event.target.files).map((file) => file.name).join(",");
       });
+
+      /* value inputs (email/number) — track input/change for fillInput regressions */
+      for (const id of ["email-input", "number-input"]) {
+        const valueInput = document.querySelector("#" + id);
+        for (const type of ["input", "change"]) {
+          valueInput.addEventListener(type, () => {
+            (window.__fixtureState.valueEvents[id] ||= []).push(type);
+          });
+        }
+      }
+
+      /* react-style controlled input — every input event writes value back through
+         the native prototype setter, mirroring React/Vue controlled components.
+         Guards fillInput's persistence on inputs that fight back. */
+      (function () {
+        const el = document.querySelector("#controlled-input");
+        const stateEl = document.querySelector("#controlled-state");
+        const setter = Object.getOwnPropertyDescriptor(
+          HTMLInputElement.prototype,
+          "value",
+        ).set;
+        let state = "";
+        function render() {
+          if (el.value !== state) setter.call(el, state);
+          stateEl.textContent = state;
+        }
+        el.addEventListener("input", () => {
+          state = el.value;
+          render();
+        });
+        el.addEventListener("change", () => {
+          stateEl.textContent = state + " (change)";
+        });
+        render();
+      })();
 
       /* context menu zone — captures right-click */
       const contextZone = document.querySelector("#context-menu-zone");


### PR DESCRIPTION
## Summary

Port the net-new coverage from the local `test/` suite into the official `real-browser-e2e` suite. A per-`test()` diff against the official suite showed most local cases are already covered by `runtime.mjs` / `observation.mjs` / `keyboard.mjs`; this PR migrates only what was genuinely uncovered.

### Keyboard regression (`cases/keyboard-regression.mjs`)
- `fillInput` on `type=email` / `type=number` without the `setSelectionRange` crash
- `fillInput` / `dispatchKey` / `uploadFile` via `xpath=` selector
- `fillInput` persistence on a react-style controlled input

### Runtime regression (`cases/runtime-regression.mjs`)
- `waitForElement` `xpath=` plus permanent-fails-fast vs transient-returns-false
- `js` closure-not-captured and invalid-input rejection
- `serverFetch` exact content-length
- `serverFetch` / `browserFetch` 4xx
- `waitForLoad` on a slow-arriving document

### Fixture (`fixture.mjs`)
- New endpoints: `/api/status`, `/api/bytes`, `/slow-page`
- New controlled input element, appended **after** `#scroll-area` so the new DOM does not shift the pointer case's wheel target

## Test plan
- Full suite: **10/10 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)