### PR TITLE
docs: drop nightly release references from CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,11 +316,10 @@ Add at least one release-note label so generated releases are grouped correctly:
 
 - CI config: `.github/workflows/ci.yml`
   - Every push / PR: on Node 22 + ubuntu-latest, runs `npm ci` → `npm test` → `npm run validate:site-skills`
-  - After push to `dev`: the `release` job builds a `vX.Y.Z-nightly.YYYYMMDD.SHA` prerelease
   - Tags matching `vX.Y.Z-beta.N`: build a beta prerelease
   - Tags matching `vX.Y.Z`: build a stable release and mark it as latest
 - Release notes are generated automatically from merged PRs and grouped by `.github/release.yml` labels: Features, Fixes, Documentation, Maintenance, and Other Changes.
-- Normal flow: merge features into `dev` for nightly, cut beta tags from `dev`, then merge `dev` to `main` and cut stable `vX.Y.Z` tags from `main`.
+- Normal flow: merge features into `dev`, cut beta tags from `dev`, then merge `dev` to `main` and cut stable `vX.Y.Z` tags from `main`.
 - The build script `scripts/build.mjs` uses `.build.lock` to prevent concurrent builds.
 
 ---


### PR DESCRIPTION
## What
Remove the two stale nightly-release references from the **Release & CI** section of `CONTRIBUTING.md`.

## Why
The nightly channel was removed from CI in #70 (the `release` job now triggers only on `v*` tags). The docs still promised a `vX.Y.Z-nightly.YYYYMMDD.SHA` prerelease on every push to `dev`, which is no longer built — leaving the docs factually wrong.

## Changes
- Drop the "After push to `dev`: ... nightly prerelease" bullet.
- Drop "for nightly" from the normal-flow line.

## How to verify
- `CONTRIBUTING.md` §11 no longer mentions nightly.
- The remaining bullets (beta tags, stable tags) match the current `.github/workflows/ci.yml`.

## Impact
Docs-only. No code or helper-surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)