### PR TITLE
Update macOS download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 **The best browser for both you and your AI agents work in parallel.**
 
 <p>
-  <a href="https://cdn.ego.app/setup/macos/arm64/egolite.dmg"><img src="https://img.shields.io/badge/Download-Apple%20Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for Apple Silicon" /></a>
-  <a href="https://cdn.ego.app/setup/macos/x64/egolite.dmg"><img src="https://img.shields.io/badge/Download-Intel-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for Intel" /></a>
+  <a href="https://cdn.ego.app/channel/github/setup/macos/arm64/egolite.dmg"><img src="https://img.shields.io/badge/Download-Apple%20Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for Apple Silicon" /></a>
+  <a href="https://cdn.ego.app/channel/github/setup/macos/x64/egolite.dmg"><img src="https://img.shields.io/badge/Download-Intel-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for Intel" /></a>
   <a href="https://discord.gg/5eGZVvHbTq"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" /></a>
   <a href="https://x.com/ego_agent"><img src="https://img.shields.io/badge/Follow-%40ego__agent-000000?style=for-the-badge&logo=x&logoColor=white" alt="Follow @ego_agent on X" /></a>
   <a href="https://lite.ego.app/document/"><img src="https://img.shields.io/badge/Docs-lite.ego.app-1E90FF?style=for-the-badge&logo=gitbook&logoColor=white" alt="Docs" /></a>
@@ -33,8 +33,8 @@ Pick whichever fits your flow.
 
 **1.1 Download the macOS app**
 
-<a href="https://cdn.ego.app/setup/macos/arm64/egolite.dmg"><img src="https://img.shields.io/badge/⬇%20Apple%20Silicon-.dmg-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download ego lite for Apple Silicon" /></a>
-<a href="https://cdn.ego.app/setup/macos/x64/egolite.dmg"><img src="https://img.shields.io/badge/⬇%20Intel-.dmg-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download ego lite for Intel" /></a>
+<a href="https://cdn.ego.app/channel/github/setup/macos/arm64/egolite.dmg"><img src="https://img.shields.io/badge/⬇%20Apple%20Silicon-.dmg-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download ego lite for Apple Silicon" /></a>
+<a href="https://cdn.ego.app/channel/github/setup/macos/x64/egolite.dmg"><img src="https://img.shields.io/badge/⬇%20Intel-.dmg-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download ego lite for Intel" /></a>
 
 Click to download, then open it to install. Either way, ego lite adds the `ego-browser` skill to every agent's skills directory on your machine.
 

--- a/skills/ego-browser/scripts/install.sh
+++ b/skills/ego-browser/scripts/install.sh
@@ -4,8 +4,8 @@
 set -eu
 
 # Default package URL and installation paths.
-DMG_URL_ARM64="https://cdn.ego.app/setup/macos/arm64/egolite.dmg"
-DMG_URL_X64="https://cdn.ego.app/setup/macos/x64/egolite.dmg"
+DMG_URL_ARM64="https://cdn.ego.app/channel/github/setup/macos/arm64/egolite.dmg"
+DMG_URL_X64="https://cdn.ego.app/channel/github/setup/macos/x64/egolite.dmg"
 APP_NAME="ego lite"
 APP_BUNDLE_NAME="$APP_NAME.app"
 APP_PATH="/Applications/$APP_BUNDLE_NAME"


### PR DESCRIPTION
## Summary
- Update README macOS download buttons to use the GitHub channel CDN URLs
- Update the ego-browser install script DMG URLs to the same GitHub channel paths

## Testing
- git diff --check
- pre-commit hooks via git commit