### PR TITLE
Add REPL-first runtime flow

### DIFF
--- a/package/ego-browser/README.md
+++ b/package/ego-browser/README.md
@@ -3,7 +3,7 @@
 The Node.js helper layer that runs inside the `ego-browser` Chromium browser. The browser exposes an `ego` runtime (tabs, CDP, snapshots, task spaces); this package bundles the agent-facing helpers that script that runtime.
 
 ```text
-ego-browser (Chromium) → globalThis.ego → helper functions → agent heredoc
+ego-browser (Chromium) → globalThis.ego → helper functions → agent REPL cells
 ```
 
 ## Build and run
@@ -14,17 +14,33 @@ npm run build     # bundle to dist/out/index.js
 npm test          # build + tsc --noEmit + node --test
 ```
 
-The build emits a single ESM file `dist/out/index.js`. The ego-browser browser dispatches `ego-browser nodejs <<'EOF' ... EOF` heredocs to that bundle. Inside the heredoc, all helpers (`snapshot`, `click`, `useOrCreateTaskSpace`, ...) are pre-imported in camelCase.
+The build emits a single ESM file `dist/out/index.js`. The ego-browser app loads that bundle for `ego-browser nodejs` sessions. Inside each REPL cell, all helpers (`snapshot`, `click`, `useOrCreateTaskSpace`, ...) are pre-imported in camelCase.
 
 ```bash
-ego-browser nodejs <<'EOF'
+ego-browser nodejs
+```
+
+```text
+repl> .cell
 await useOrCreateTaskSpace('demo')
 await openOrReuseTab('https://example.com', { wait: true })
 console.log(await snapshot())
-EOF
+.end
 ```
 
-Local invocation without the browser (for debugging the helper bundle itself) reads stdin:
+Local invocation without the browser (for debugging the helper bundle itself) can use interactive cell mode:
+
+```bash
+node dist/out/index.js --repl
+```
+
+```text
+repl> .cell
+console.log(await pageInfo())
+.end
+```
+
+Piped stdin remains supported for scripts and tests:
 
 ```bash
 node dist/out/index.js <<'JS'
@@ -32,7 +48,7 @@ console.log(await pageInfo())
 JS
 ```
 
-Flags: `-h | --help`, `--doctor`, `--reload`, `--debug-clicks`.
+Flags: `-h | --help`, `--doctor`, `--reload`, `--debug-clicks`, `--repl`.
 
 ## Skill workspace
 
@@ -45,9 +61,13 @@ By default the runtime loads agent helpers and site learnings from the sibling s
 Override with `EGO_BROWSER_AGENT_WORKSPACE`:
 
 ```bash
-EGO_BROWSER_AGENT_WORKSPACE=/path/to/skill ego-browser nodejs <<'EOF'
+EGO_BROWSER_AGENT_WORKSPACE=/path/to/skill ego-browser nodejs
+```
+
+```text
+repl> .cell
 console.log(await siteSkills())
-EOF
+.end
 ```
 
 Site learnings under `agentWorkspace()/learnings/<site>/` are always active and read on every helper call. Validate them with:
@@ -60,7 +80,7 @@ npm run validate:site-skills    # alias: validate:learnings
 
 ```
 src/
-  run.ts                 CLI entry; reads stdin, injects helpers, executes
+  run.ts                 CLI entry; REPL cells / stdin compatibility execution
   helpers.ts             public helper surface (re-exports + glue)
   browser-runtime.ts     bridge to globalThis.ego (CDP, sessions, events)
   element-resolver.ts    resolves @eN / CSS / XPath / ARIA targets

--- a/package/ego-browser/scripts/real-browser-e2e/cases/runtime-regression.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/cases/runtime-regression.mjs
@@ -36,7 +36,7 @@ export function runtimeRegressionCase() {
       "transient miss polls until the timeout elapses"
     );
 
-    /* js runs in the page, not the heredoc: caller closure variables are NOT
+    /* js runs in the page, not the Node-side script: caller closure variables are NOT
        captured. 'outer' is referenced only inside the serialized function. */
     const outer = 100;
     const closureType = await evaluate(function () {

--- a/package/ego-browser/scripts/real-browser-e2e/runner.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/runner.mjs
@@ -35,6 +35,7 @@ export async function runRealBrowserE2e() {
   );
   const availableCaseNames = [
     "nodejs bridge smoke",
+    "nodejs repl cell smoke",
     ...e2eCases.map((testCase) => testCase.name),
   ];
   const unknownOnlyCases = [...onlyCases].filter(
@@ -118,6 +119,53 @@ export async function runRealBrowserE2e() {
 
   async function maybeRunNodeBridgeSmoke() {
     await runNodeBridgeSmoke();
+  }
+
+  async function runNodeReplCellSmoke(timeoutMs = 15000) {
+    const name = "nodejs repl cell smoke";
+    console.log(`-- ${name}`);
+    const startedAt = Date.now();
+    const marker = `EGO_NODEJS_REPL_CELL_SMOKE_${Date.now()}`;
+    const script = [
+      "set timeout 15",
+      `spawn ego-browser nodejs --sdk-path ${tclBrace(egoBrowserSdkPath)}`,
+      'expect "repl> "',
+      tclSend(".cell\r"),
+      tclSend(`console.log(${JSON.stringify(marker)})\r`),
+      tclSend("console.log(typeof snapshot)\r"),
+      tclSend("21 + 21\r"),
+      tclSend(".end\r"),
+      `expect ${tclBrace(marker)}`,
+      'expect "function"',
+      'expect "42"',
+      'expect "repl> "',
+      tclSend(".exit\r"),
+      "expect eof",
+    ].join("\n");
+    try {
+      await runCommand("expect", ["-c", script], {
+        cwd: packageDir,
+        egoBrowserSdkPath,
+        echo: verboseCaseOutput,
+        timeoutMs,
+      });
+      const durationMs = Date.now() - startedAt;
+      recordResult(name, "pass", durationMs, 3);
+      console.log(
+        `-- ${name} passed (${formatDuration(durationMs)}, 3 assertions)`,
+      );
+    } catch (error) {
+      const durationMs = Date.now() - startedAt;
+      const message = error?.message || String(error);
+      recordResult(name, "fail", durationMs, 0, message);
+      console.error(
+        `[FAIL] ${name} (${formatDuration(durationMs)}): ${message}`,
+      );
+    }
+  }
+
+  async function maybeRunNodeReplCellSmoke() {
+    await runNodeReplCellSmoke();
   }
 
   async function runEgoCase(name, body, timeoutMs = 45000, options = {}) {
@@ -244,9 +292,13 @@ export async function runRealBrowserE2e() {
     console.log(`sdk: ${egoBrowserSdkPath}`);
 
     await maybeRunNodeBridgeSmoke();
+    await maybeRunNodeReplCellSmoke();
     if (
       caseResults.some(
-        (r) => r.name === "nodejs bridge smoke" && r.status === "fail",
+        (r) =>
+          (r.name === "nodejs bridge smoke" ||
+            r.name === "nodejs repl cell smoke") &&
+          r.status === "fail",
       )
     ) {
       context.skipCleanup = true;
@@ -347,6 +399,14 @@ function parseNodeBridgeSmoke(stdout, marker) {
       `nodejs bridge smoke printed invalid runtime probe data: ${payload}`,
     );
   }
+}
+
+function tclBrace(value) {
+  return `{${String(value).replace(/[\\{}]/g, "\\$&")}}`;
+}
+
+function tclSend(value) {
+  return `send ${JSON.stringify(value)}`;
 }
 
 function caseResultPath(tempDir) {

--- a/package/ego-browser/src/index.ts
+++ b/package/ego-browser/src/index.ts
@@ -9,8 +9,13 @@ import {
 } from "./browser-runtime.js";
 import { formatCliLogValue } from "./format.js";
 import {
+  beginOutputBoundary,
   bufferOutput,
+  finishOutputBoundary,
   installLifecycleFlush,
+  isInsideOutputBoundary,
+  outputCaptureFromTarget,
+  flushSink,
   resetSink,
   setNoticeTrailer,
 } from "./output-sink.js";
@@ -40,6 +45,7 @@ const SYNC_HELPERS = new Set(["help"]);
 // Marks an ego runtime whose mutating methods have already been wrapped, so a
 // second installEgoSdk call cannot double-wrap createTab / task-space methods.
 const EGO_WRAPPED = Symbol.for("egoBrowser.sdkWrapped");
+const OUTPUT_BOUNDARY_WRAPPED = Symbol.for("egoBrowser.outputBoundaryWrapped");
 
 export function installEgoSdk(
   target: InstallTarget = globalThis,
@@ -77,17 +83,19 @@ export function installEgoSdk(
     installed[name] = exposed as HelperFunction;
   }
   const usingDefaultLog = !options.cliLog;
-  // The agent's primary output channel is console.log. Route it through the host's
-  // sink (options.cliLog) when provided, otherwise the buffered default. There is no
-  // dedicated cliLog global anymore; console.error/warn are left untouched. Each
-  // heredoc runs in its own short-lived process, so overriding the global is per-run.
-  console.log = options.cliLog || createBufferedLog();
-  if (usingDefaultLog) {
-    // SDK path: the host runs each heredoc in a fresh short-lived process and never
-    // calls execute(), so reset the per-run sink and flush it on process teardown.
-    resetSink();
-    installLifecycleFlush(process.stdout);
+  if (options.cliLog) {
+    console.log = options.cliLog;
+  } else {
+    // Buffer console.log so a hard stop can collapse noisy business output into one
+    // owned message. In app REPL mode, __egoCompleteReplEvaluation flushes this once
+    // per cell; in short-lived SDK hosts, lifecycle hooks are the fallback.
+    console.log = createBufferedLog();
   }
+  resetSink();
+  installLifecycleFlush(process.stdout);
+  wrapEvaluationBoundary(target, "__egoEvaluateScript");
+  wrapReplEvaluationBoundary(target);
+  wrapReplCompleteBoundary(target);
   if (target.ego && typeof target.ego === "object") {
     // Fire-and-forget update hint. Route the resolved line to the same channel the
     // command's own output uses: the buffered-sink path registers it as a trailer the
@@ -134,6 +142,120 @@ function createBufferedLog() {
     // discard everything logged so far. The buffer is flushed on process teardown.
     bufferOutput(`${args.map(formatCliLogValue).join(" ")}\n`);
   };
+}
+
+function wrapEvaluationBoundary(target: InstallTarget, name: string) {
+  const original = target[name];
+  if (typeof original !== "function") return;
+  if (
+    (original as unknown as Record<symbol, unknown>)[OUTPUT_BOUNDARY_WRAPPED]
+  ) {
+    return;
+  }
+  const wrapped = function (this: unknown, ...args: unknown[]) {
+    beginOutputBoundary(outputCaptureFromTarget(target));
+    try {
+      const result = (original as HelperFunction).apply(this, args);
+      if (result && typeof (result as Promise<unknown>).then === "function") {
+        return (result as Promise<unknown>).then(
+          (value) => {
+            finishOutputBoundary(process.stdout, false);
+            return value;
+          },
+          (error) => {
+            finishOutputBoundary(process.stdout, true);
+            throw error;
+          },
+        );
+      }
+      finishOutputBoundary(process.stdout, false);
+      return result;
+    } catch (error) {
+      finishOutputBoundary(process.stdout, true);
+      throw error;
+    }
+  };
+  Object.defineProperty(wrapped, OUTPUT_BOUNDARY_WRAPPED, {
+    value: true,
+    enumerable: false,
+  });
+  Object.defineProperty(target, name, {
+    value: wrapped,
+    writable: true,
+    configurable: true,
+    enumerable: false,
+  });
+}
+
+function wrapReplEvaluationBoundary(target: InstallTarget) {
+  const original = target.__egoEvaluateReplScript;
+  if (typeof original !== "function") return;
+  if (
+    (original as unknown as Record<symbol, unknown>)[OUTPUT_BOUNDARY_WRAPPED]
+  ) {
+    return;
+  }
+  const wrapped = function (this: unknown, ...args: unknown[]) {
+    beginOutputBoundary(outputCaptureFromTarget(target));
+    try {
+      const result = (original as HelperFunction).apply(this, args);
+      if (result && typeof (result as Promise<unknown>).then === "function") {
+        return (result as Promise<unknown>).then(
+          (value) => value,
+          (error) => {
+            finishOutputBoundary(process.stdout, true);
+            throw error;
+          },
+        );
+      }
+      return result;
+    } catch (error) {
+      finishOutputBoundary(process.stdout, true);
+      throw error;
+    }
+  };
+  Object.defineProperty(wrapped, OUTPUT_BOUNDARY_WRAPPED, {
+    value: true,
+    enumerable: false,
+  });
+  Object.defineProperty(target, "__egoEvaluateReplScript", {
+    value: wrapped,
+    writable: true,
+    configurable: true,
+    enumerable: false,
+  });
+}
+
+function wrapReplCompleteBoundary(target: InstallTarget) {
+  const original = target.__egoCompleteReplEvaluation;
+  if (typeof original !== "function") return;
+  if (
+    (original as unknown as Record<symbol, unknown>)[OUTPUT_BOUNDARY_WRAPPED]
+  ) {
+    return;
+  }
+  const wrapped = function (this: unknown, ...args: unknown[]) {
+    let flush = { hardStop: false, wrote: false };
+    if (!isInsideOutputBoundary()) {
+      flush = flushSink(process.stdout, false);
+    } else {
+      flush = finishOutputBoundary(process.stdout, false);
+    }
+    if (flush.hardStop) {
+      resetSink();
+    }
+    return (original as HelperFunction).apply(this, args);
+  };
+  Object.defineProperty(wrapped, OUTPUT_BOUNDARY_WRAPPED, {
+    value: true,
+    enumerable: false,
+  });
+  Object.defineProperty(target, "__egoCompleteReplEvaluation", {
+    value: wrapped,
+    writable: true,
+    configurable: true,
+    enumerable: false,
+  });
 }
 
 function isDirectCli() {

--- a/package/ego-browser/src/output-sink.test.mjs
+++ b/package/ego-browser/src/output-sink.test.mjs
@@ -8,6 +8,7 @@ import {
   flushSink,
   markHardStop,
   resetSink,
+  setNoticeTrailer,
 } from "../dist/src/output-sink.js";
 
 function fakeStream() {
@@ -90,6 +91,43 @@ test("output boundaries isolate hard stops between REPL cells", () => {
   assert.deepEqual(first, { hardStop: true, wrote: true });
   assert.deepEqual(second, { hardStop: false, wrote: true });
   assert.equal(out.text(), "CELL ONE HARD STOP\ncell two normal output\n");
+});
+
+test("a notice trailer set before the boundary begins flushes once, as a footer", () => {
+  resetSink();
+  // The fire-and-forget probe typically resolves during REPL bootstrap, long before
+  // the first cell arrives — the pending trailer must survive the per-cell reset.
+  setNoticeTrailer("[ego-browser:notice] update available");
+  const out = fakeStream();
+
+  beginOutputBoundary();
+  bufferOutput("cell one output\n");
+  finishOutputBoundary(out, false);
+
+  beginOutputBoundary();
+  bufferOutput("cell two output\n");
+  finishOutputBoundary(out, false);
+
+  assert.equal(
+    out.text(),
+    "cell one output\n[ego-browser:notice] update available\ncell two output\n",
+  );
+});
+
+test("the notice trailer still trails the owned message on a hard stop", () => {
+  resetSink();
+  setNoticeTrailer("[ego-browser:notice] update available\n");
+  const out = fakeStream();
+
+  beginOutputBoundary();
+  bufferOutput("business output to discard\n");
+  markHardStop("HARD STOP MESSAGE");
+  finishOutputBoundary(out, false);
+
+  assert.equal(
+    out.text(),
+    "HARD STOP MESSAGE\n[ego-browser:notice] update available\n",
+  );
 });
 
 test("output boundaries flush host stdout capture on clean completion", () => {

--- a/package/ego-browser/src/output-sink.test.mjs
+++ b/package/ego-browser/src/output-sink.test.mjs
@@ -2,7 +2,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  beginOutputBoundary,
   bufferOutput,
+  finishOutputBoundary,
   flushSink,
   markHardStop,
   resetSink,
@@ -71,4 +73,57 @@ test("a message that already ends in a newline is not double-terminated", () => 
   const out = fakeStream();
   flushSink(out, false);
   assert.equal(out.text(), "already terminated\n");
+});
+
+test("output boundaries isolate hard stops between REPL cells", () => {
+  const out = fakeStream();
+
+  beginOutputBoundary();
+  bufferOutput("cell one business output\n");
+  markHardStop("CELL ONE HARD STOP");
+  const first = finishOutputBoundary(out, false);
+
+  beginOutputBoundary();
+  bufferOutput("cell two normal output\n");
+  const second = finishOutputBoundary(out, false);
+
+  assert.deepEqual(first, { hardStop: true, wrote: true });
+  assert.deepEqual(second, { hardStop: false, wrote: true });
+  assert.equal(out.text(), "CELL ONE HARD STOP\ncell two normal output\n");
+});
+
+test("output boundaries flush host stdout capture on clean completion", () => {
+  let captured = "captured console output\n";
+  const capture = {
+    clear() {
+      captured = "";
+    },
+    take() {
+      return captured || "captured after clear\n";
+    },
+  };
+  const out = fakeStream();
+
+  beginOutputBoundary(capture);
+  const result = finishOutputBoundary(out, false);
+
+  assert.deepEqual(result, { hardStop: false, wrote: true });
+  assert.equal(out.text(), "captured after clear\n");
+});
+
+test("output boundaries discard host stdout capture on hard stop", () => {
+  const capture = {
+    clear() {},
+    take() {
+      return "captured business output\n";
+    },
+  };
+  const out = fakeStream();
+
+  beginOutputBoundary(capture);
+  markHardStop("CAPTURE HARD STOP");
+  const result = finishOutputBoundary(out, false);
+
+  assert.deepEqual(result, { hardStop: true, wrote: true });
+  assert.equal(out.text(), "CAPTURE HARD STOP\n");
 });

--- a/package/ego-browser/src/output-sink.ts
+++ b/package/ego-browser/src/output-sink.ts
@@ -1,33 +1,42 @@
 /**
- * Output sink for the agent-facing heredoc runtime.
+ * Output sink for the agent-facing runtime.
  *
- * `console.log` is the only channel an agent reads (the runtime routes it here). A
- * single user takeover turns that channel into noise: while the user holds control,
- * every browser command re-reports the same hard-stop error, so a script that loops
- * over work and swallows each error (try/catch, `.catch()`) prints the same guidance
- * on every iteration, buried under its own business logging and success rows.
+ * `console.log` is the primary channel an agent reads. A single user takeover turns
+ * that channel into noise: while the user holds control, every browser command
+ * re-reports the same hard-stop error, so a script that loops over work and swallows
+ * each error (try/catch, `.catch()`) prints the same guidance on every iteration,
+ * buried under its own business logging and success rows.
  *
- * To collapse that to one clean line we buffer console.log output instead of writing it
- * straight through. When a hard-stop error is born (see `buildEgoError`) we record its
- * owned message once. At the end of the run we either:
- *   - a hard stop occurred -> discard the whole buffer and emit the owned message once
- *   - otherwise            -> flush the buffered output verbatim
+ * To collapse that to one clean line, execution runs inside an output boundary. When
+ * a hard-stop error is born (see `buildEgoError`) we record its owned message once.
+ * At the end of the boundary we either:
+ *   - a hard stop occurred -> discard boundary output and emit the owned message once
+ *   - otherwise            -> flush the captured output verbatim
  * and in both cases append the update-notice trailer (if any) last, so an out-of-band
  * "ego lite update available" hint reads as a footer after the command's own output.
  *
- * Buffering is the price of discarding pre-stop output: bytes already written cannot be
- * recalled, so nothing may be written until we know the run did not hard-stop. Each
- * heredoc runs in its own short-lived process, so this module state is per-run and needs
- * no cross-round reset; `resetSink()` exists only so in-process tests can reuse the run.
+ * The boundary is one stdin script in compatibility mode, or one REPL cell in
+ * interactive mode. That distinction matters: a long-lived REPL process must not let
+ * one cell's hard-stop state pollute the next cell.
  */
 
 type WritableLike = { write(chunk: string): unknown };
+type OutputCapture = {
+  clear(): unknown;
+  take(): unknown;
+};
+type FlushResult = {
+  hardStop: boolean;
+  wrote: boolean;
+};
 
 let buffer: string[] = [];
 let hardStopMessage: string | null = null;
 let noticeTrailer: string | null = null;
 let flushed = false;
 let lifecycleHooked = false;
+let boundaryDepth = 0;
+let boundaryCapture: OutputCapture | null = null;
 
 /** Buffer one already-formatted console.log chunk (the trailing newline is included). */
 export function bufferOutput(chunk: string): void {
@@ -54,6 +63,30 @@ export function markHardStop(message: string): void {
   }
 }
 
+/** Start an output boundary for one stdin script or one REPL cell. */
+export function beginOutputBoundary(capture?: OutputCapture | null): void {
+  if (boundaryDepth === 0) {
+    resetSink();
+    boundaryCapture = capture || null;
+    boundaryCapture?.clear();
+  }
+  boundaryDepth += 1;
+}
+
+/** Finish the active output boundary and flush or discard its output. */
+export function finishOutputBoundary(
+  stream: WritableLike,
+  thrown: boolean,
+): FlushResult {
+  if (boundaryDepth > 0) {
+    boundaryDepth -= 1;
+    if (boundaryDepth > 0) {
+      return { hardStop: hardStopMessage !== null, wrote: false };
+    }
+  }
+  return flushSink(stream, thrown);
+}
+
 /**
  * Emit the run's output exactly once.
  *
@@ -63,9 +96,12 @@ export function markHardStop(message: string): void {
  * so we stay silent and only drop the buffer. Non-hard-stop output is flushed either way,
  * so an ordinary failure still shows what the script logged before it threw.
  */
-export function flushSink(stream: WritableLike, thrown: boolean): void {
-  if (flushed) return;
+export function flushSink(stream: WritableLike, thrown: boolean): FlushResult {
+  if (flushed) return { hardStop: hardStopMessage !== null, wrote: false };
   flushed = true;
+  let wrote = false;
+  const captured = boundaryCapture ? String(boundaryCapture.take() ?? "") : "";
+  boundaryCapture = null;
   if (hardStopMessage !== null) {
     // Drop every buffered line — business logs, success rows, and the repeated error
     // echoes — so the owned guidance is all that remains.
@@ -75,9 +111,17 @@ export function flushSink(stream: WritableLike, thrown: boolean): void {
           ? hardStopMessage
           : `${hardStopMessage}\n`,
       );
+      wrote = true;
     }
   } else {
-    for (const chunk of buffer) stream.write(chunk);
+    for (const chunk of buffer) {
+      stream.write(chunk);
+      wrote = true;
+    }
+    if (captured) {
+      stream.write(captured);
+      wrote = true;
+    }
   }
   // The update hint is independent of the run's own output (and of a hard stop), so it
   // is appended last in every case — after the business output or the owned guidance.
@@ -86,7 +130,11 @@ export function flushSink(stream: WritableLike, thrown: boolean): void {
       noticeTrailer.endsWith("\n") ? noticeTrailer : `${noticeTrailer}\n`,
     );
   }
+  const hardStop = hardStopMessage !== null;
   buffer = [];
+  hardStopMessage = null;
+  boundaryDepth = 0;
+  return { hardStop, wrote };
 }
 
 /** Clear sink state. Real runs get a fresh process; this is only for in-process tests. */
@@ -95,11 +143,32 @@ export function resetSink(): void {
   hardStopMessage = null;
   noticeTrailer = null;
   flushed = false;
+  boundaryDepth = 0;
+  boundaryCapture = null;
+}
+
+export function isInsideOutputBoundary(): boolean {
+  return boundaryDepth > 0;
+}
+
+export function outputCaptureFromTarget(
+  target: Record<string, unknown>,
+): OutputCapture | null {
+  const capture = target.__egoNodeOutputCapture;
+  if (
+    capture &&
+    typeof capture === "object" &&
+    typeof (capture as OutputCapture).clear === "function" &&
+    typeof (capture as OutputCapture).take === "function"
+  ) {
+    return capture as OutputCapture;
+  }
+  return null;
 }
 
 /**
- * Flush on process teardown for the SDK path, where the host runs each heredoc directly
- * and never calls the CLI `execute()` wrapper, so lifecycle events are our only hook.
+ * Flush on process teardown for SDK hosts that run code directly and never call the
+ * CLI `execute()` wrapper, so lifecycle events are our last-resort hook.
  *
  * A clean finish drains the event loop and reaches `beforeExit`; an uncaught async
  * rejection skips `beforeExit` but still reaches `exit` (`thrown: true`, so a hard stop

--- a/package/ego-browser/src/output-sink.ts
+++ b/package/ego-browser/src/output-sink.ts
@@ -66,7 +66,12 @@ export function markHardStop(message: string): void {
 /** Start an output boundary for one stdin script or one REPL cell. */
 export function beginOutputBoundary(capture?: OutputCapture | null): void {
   if (boundaryDepth === 0) {
+    // The update-notice probe is fire-and-forget and typically resolves between
+    // boundaries (REPL bootstrap runs it long before the first cell arrives), so a
+    // pending trailer belongs to the next flush and must survive the per-cell reset.
+    const pendingNotice = noticeTrailer;
     resetSink();
+    noticeTrailer = pendingNotice;
     boundaryCapture = capture || null;
     boundaryCapture?.clear();
   }
@@ -125,10 +130,14 @@ export function flushSink(stream: WritableLike, thrown: boolean): FlushResult {
   }
   // The update hint is independent of the run's own output (and of a hard stop), so it
   // is appended last in every case — after the business output or the owned guidance.
+  // Cleared once written: a long-lived REPL process flushes once per cell, and the
+  // hint must not repeat as a footer on every subsequent cell.
   if (noticeTrailer !== null) {
     stream.write(
       noticeTrailer.endsWith("\n") ? noticeTrailer : `${noticeTrailer}\n`,
     );
+    noticeTrailer = null;
+    wrote = true;
   }
   const hardStop = hardStopMessage !== null;
   buffer = [];

--- a/package/ego-browser/src/run-repl.test.mjs
+++ b/package/ego-browser/src/run-repl.test.mjs
@@ -1,0 +1,181 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runMain } from "../dist/src/run.js";
+
+function captureStream() {
+  const chunks = [];
+  return {
+    write(chunk) {
+      chunks.push(String(chunk));
+    },
+    text() {
+      return chunks.join("");
+    },
+  };
+}
+
+function hardStopEgo(error_code) {
+  return {
+    calls: 0,
+    async listTaskSpaces() {
+      this.calls += 1;
+      return {
+        error: "native wording that should not leak",
+        error_code,
+      };
+    },
+  };
+}
+
+async function runRepl(input, ego) {
+  const previousEgo = globalThis.ego;
+  if (ego === undefined) {
+    delete globalThis.ego;
+  } else {
+    globalThis.ego = ego;
+  }
+  const stdout = captureStream();
+  const stderr = captureStream();
+  try {
+    const exitCode = await runMain({
+      argv: ["--repl"],
+      stdinText: input,
+      stdout,
+      stderr,
+      services: { printUpdateBanner() {} },
+    });
+    return { exitCode, stdout: stdout.text(), stderr: stderr.text() };
+  } finally {
+    if (previousEgo === undefined) {
+      delete globalThis.ego;
+    } else {
+      globalThis.ego = previousEgo;
+    }
+  }
+}
+
+test("interactive cell mode preserves REPL state and prints expression results", async () => {
+  const result = await runRepl(`
+.cell
+var count = 2
+console.log('count=' + count)
+count + 3
+.end
+.cell
+count += 5
+count
+.end
+.cell
+const { value } = { value: 9 }
+value
+.end
+.cell
+value
+.end
+.exit
+`);
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /ego-browser nodejs REPL/);
+  assert.match(result.stdout, /count=2\n5\nrepl> 7\nrepl> 9\nrepl> 9\nrepl> $/);
+  assert.equal(result.stderr, "");
+});
+
+test("interactive cell mode supports cancel without running the discarded code", async () => {
+  const result = await runRepl(`
+.cell
+console.log('discarded')
+.cancel
+.cell
+console.log('after cancel')
+.end
+.exit
+`);
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /after cancel/);
+  assert.doesNotMatch(result.stdout, /discarded/);
+});
+
+test("interactive cell mode reports syntax errors and keeps the REPL usable", async () => {
+  const result = await runRepl(`
+.cell
+return 1
+.end
+.cell
+console.log('after syntax')
+.end
+.exit
+`);
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stderr, /Uncaught SyntaxError: Illegal return statement/);
+  assert.match(result.stdout, /after syntax/);
+});
+
+test("interactive cell mode returns usage error for EOF before .end", async () => {
+  const result = await runRepl(`
+.cell
+console.log('unfinished')
+`);
+
+  assert.equal(result.exitCode, 2);
+  assert.match(result.stderr, /Expected \.end before EOF/);
+  assert.doesNotMatch(result.stdout, /unfinished/);
+});
+
+test("interactive hard stop prints user-control guidance once and resets for the next cell", async () => {
+  const ego = hardStopEgo("EGO_TASK_SPACE_USER_IN_CONTROL");
+  const result = await runRepl(
+    `
+.cell
+console.log('before hard stop')
+try {
+  await listTaskSpaces()
+} catch (error) {
+  console.log('caught: ' + error.message)
+}
+'suppressed expression'
+.end
+.cell
+console.log('after hard stop')
+.end
+.exit
+`,
+    ego,
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /taken control of this task space/);
+  assert.match(result.stdout, /takeOverTaskSpace\(\)/);
+  assert.equal(result.stdout.match(/takeOverTaskSpace\(\)/g).length, 1);
+  assert.doesNotMatch(result.stdout, /before hard stop|caught:|suppressed/);
+  assert.match(result.stdout, /after hard stop/);
+  assert.equal(result.stderr, "");
+  assert.equal(ego.calls, 1);
+});
+
+test("interactive inactive task guidance uses claimTaskSpace and resets for the next cell", async () => {
+  const ego = hardStopEgo("EGO_TASK_SPACE_INACTIVE");
+  const result = await runRepl(
+    `
+.cell
+try {
+  await listTaskSpaces()
+} catch {}
+.end
+.cell
+console.log('after inactive')
+.end
+.exit
+`,
+    ego,
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /no longer assigned to the agent/);
+  assert.match(result.stdout, /claimTaskSpace\(id\)/);
+  assert.match(result.stdout, /after inactive/);
+  assert.equal(result.stderr, "");
+});

--- a/package/ego-browser/src/run.ts
+++ b/package/ego-browser/src/run.ts
@@ -3,16 +3,24 @@ import {
   stdout as processStdout,
   stderr as processStderr,
 } from "node:process";
+import { start as startNodeRepl } from "node:repl";
+import { PassThrough, Readable } from "node:stream";
 
 import { formatCliLogValue } from "./format.js";
 import * as helpers from "./helpers.js";
-import { bufferOutput, flushSink, resetSink } from "./output-sink.js";
+import {
+  beginOutputBoundary,
+  bufferOutput,
+  finishOutputBoundary,
+  flushSink,
+} from "./output-sink.js";
 
 type WritableLike = {
   write(chunk: string): unknown;
 };
 
 type ReadableLike = {
+  isTTY?: boolean;
   setEncoding(encoding: BufferEncoding): unknown;
   on(event: "data", listener: (chunk: string) => void): unknown;
   on(event: "end", listener: () => void): unknown;
@@ -40,26 +48,30 @@ export const HELP = `ego-browser
 Read the ego-browser skill for the default workflow and examples.
 
 Typical usage:
-  ego-browser <<'JS'
-  await waitForLoadState()
-  console.log(await pageInfo())
-  JS
+  ego-browser
+  repl> .cell
+  repl> await waitForLoadState()
+  repl> console.log(await pageInfo())
+  repl> .end
 
 Helpers are pre-imported and the browser connection is prepared automatically.
 
 Commands:
   ego-browser --doctor         inspect browser and connection state
   ego-browser --reload         reset the browser connection on next call
+  ego-browser --repl           start interactive cell mode
 `;
 
 export const USAGE = `Usage:
-  ego-browser <<'JS'
+  ego-browser
+  ego-browser --repl
+  ego-browser <<'JS'           # compatibility mode for piped scripts
   console.log(await pageInfo())
   JS
 `;
 
 export async function runMain(options: RunMainOptions = {}) {
-  const argv = options.argv || process.argv.slice(2);
+  const argv = [...(options.argv || process.argv.slice(2))];
   const stdout = options.stdout || processStdout;
   const stderr = options.stderr || processStderr;
   const env = options.env || process.env;
@@ -82,19 +94,38 @@ export async function runMain(options: RunMainOptions = {}) {
     write(stdout, "browser connection reset on next call\n");
     return 0;
   }
-  if (argv[0] === "--debug-clicks") {
-    env.EGO_BROWSER_DEBUG_CLICKS = "1";
-    argv.shift();
+  let interactive = false;
+  while (argv.length > 0) {
+    if (argv[0] === "--debug-clicks") {
+      env.EGO_BROWSER_DEBUG_CLICKS = "1";
+      argv.shift();
+      continue;
+    }
+    if (argv[0] === "--repl" || argv[0] === "--interactive") {
+      interactive = true;
+      argv.shift();
+      continue;
+    }
+    break;
   }
   if (argv.length > 0) {
     write(stderr, USAGE);
     return 2;
   }
 
+  const stdin = options.stdin || processStdin;
+  if (interactive || (options.stdinText === undefined && stdin.isTTY)) {
+    services.printUpdateBanner(stderr);
+    return runInteractive({
+      stdin,
+      stdinText: options.stdinText,
+      stdout,
+      stderr,
+    });
+  }
+
   const code =
-    options.stdinText !== undefined
-      ? options.stdinText
-      : await readAll(options.stdin || processStdin);
+    options.stdinText !== undefined ? options.stdinText : await readAll(stdin);
   if (!code.trim()) {
     write(stderr, USAGE);
     return 2;
@@ -106,22 +137,167 @@ export async function runMain(options: RunMainOptions = {}) {
 }
 
 async function execute(code: string, stdout: WritableLike) {
-  resetSink();
   const context = await executionContext();
   Object.assign(globalThis, context);
   const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
   const names = Object.keys(context);
   const values = Object.values(context);
   const fn = new AsyncFunction(...names, `"use strict";\n${code}`);
+  beginOutputBoundary();
   try {
     await fn(...values);
   } catch (error) {
     // The thrown Error surfaces the hard-stop message on its own, so flush as a thrown
     // completion (drop the buffer, stay silent) and let it propagate.
-    flushSink(stdout, true);
+    finishOutputBoundary(stdout, true);
     throw error;
   }
-  flushSink(stdout, false);
+  finishOutputBoundary(stdout, false);
+}
+
+async function runInteractive(options: {
+  stdin: ReadableLike;
+  stdinText?: string;
+  stdout: WritableLike;
+  stderr: WritableLike;
+}) {
+  const evaluator = await createReplEvaluator();
+  const input =
+    options.stdinText !== undefined
+      ? Readable.from([options.stdinText])
+      : (options.stdin as any);
+  const readline = await import("node:readline");
+  const rl = readline.createInterface({ input, crlfDelay: Infinity });
+  let collecting = false;
+  let buffer: string[] = [];
+
+  write(
+    options.stdout,
+    "ego-browser nodejs REPL. Type .exit to quit, .cell/.end for multiline.\n",
+  );
+  writePrompt(options.stdout);
+
+  try {
+    for await (const line of rl) {
+      const command = line.trim();
+      if (command === ".exit") {
+        rl.close();
+        return 0;
+      }
+
+      if (collecting) {
+        if (command === ".cancel") {
+          collecting = false;
+          buffer = [];
+          writePrompt(options.stdout);
+          continue;
+        }
+        if (command === ".end") {
+          collecting = false;
+          await evaluateInteractiveCell(buffer.join("\n"), evaluator, options);
+          buffer = [];
+          writePrompt(options.stdout);
+          continue;
+        }
+        buffer.push(line);
+        continue;
+      }
+
+      if (command === "") {
+        writePrompt(options.stdout);
+        continue;
+      }
+      if (command === ".cell") {
+        collecting = true;
+        buffer = [];
+        continue;
+      }
+      if (command === ".cancel" || command === ".end") {
+        write(options.stderr, "Use .cell to start a multiline block\n");
+        writePrompt(options.stdout);
+        continue;
+      }
+
+      await evaluateInteractiveCell(line, evaluator, options);
+      writePrompt(options.stdout);
+    }
+  } finally {
+    rl.close();
+    evaluator.close();
+  }
+
+  if (collecting) {
+    write(options.stderr, "Expected .end before EOF\n");
+    return 2;
+  }
+  return 0;
+}
+
+async function createReplEvaluator() {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const server = startNodeRepl({
+    prompt: "",
+    input,
+    output,
+    terminal: false,
+    useGlobal: true,
+  });
+  const context = await executionContext();
+  Object.assign(globalThis, context);
+  Object.assign(server.context, context);
+  return {
+    async evaluate(code: string): Promise<{ error: Error | null; value: any }> {
+      return new Promise((resolve) => {
+        server.eval(code, server.context, "repl", (error, value) => {
+          resolve({ error: error || null, value });
+        });
+      });
+    },
+    writer(value: any): string {
+      return server.writer(value);
+    },
+    close() {
+      server.close();
+      input.destroy();
+      output.destroy();
+    },
+  };
+}
+
+async function evaluateInteractiveCell(
+  code: string,
+  evaluator: Awaited<ReturnType<typeof createReplEvaluator>>,
+  options: { stdout: WritableLike; stderr: WritableLike },
+) {
+  if (!code.trim()) {
+    return;
+  }
+  beginOutputBoundary();
+  const { error, value } = await evaluator.evaluate(code);
+  const flush = finishOutputBoundary(options.stdout, Boolean(error));
+  if (error) {
+    write(options.stderr, `${formatReplError(error)}\n`);
+    return;
+  }
+  if (!flush.hardStop && value !== undefined) {
+    write(options.stdout, `${evaluator.writer(value)}\n`);
+  }
+}
+
+function formatReplError(error: Error) {
+  if (error?.stack) {
+    const headline = `${error.name}: ${error.message}`;
+    if (error.stack.includes(headline)) {
+      return error.stack.replace(headline, `Uncaught ${headline}`);
+    }
+    return `Uncaught ${error.stack}`;
+  }
+  return `Uncaught ${error?.message || String(error)}`;
+}
+
+function writePrompt(stdout: WritableLike) {
+  write(stdout, "repl> ");
 }
 
 export async function executionContext() {
@@ -131,9 +307,8 @@ export async function executionContext() {
   // cannot drift apart (and `help` exists in both).
   const context: Record<string, any> = helpers.helperContext(agentHelpers);
   // Route the agent's primary output channel (console.log) through the output sink:
-  // execute() flushes (or discards on hard stop) once the script settles, keeping the
-  // CLI path identical to the SDK path. console.error/warn are left untouched. Each
-  // heredoc runs in its own short-lived process, so overriding the global is per-run.
+  // each stdin script or REPL cell flushes (or discards on hard stop) when it settles.
+  // console.error/warn are left untouched.
   console.log = (...args: unknown[]) => {
     bufferOutput(`${args.map(formatCliLogValue).join(" ")}\n`);
   };

--- a/package/ego-browser/src/sdk-repl-boundary.test.mjs
+++ b/package/ego-browser/src/sdk-repl-boundary.test.mjs
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { installEgoSdk } from "../dist/src/index.js";
+import { markHardStop } from "../dist/src/output-sink.js";
+
+function hostCapture() {
+  return {
+    text: "",
+    clear() {
+      this.text = "";
+    },
+    take() {
+      const value = this.text;
+      this.text = "";
+      return value;
+    },
+    append(text) {
+      this.text += text;
+    },
+  };
+}
+
+async function withCapturedProcessStdout(fn) {
+  const originalWrite = process.stdout.write;
+  const originalConsoleLog = console.log;
+  let stdout = "";
+  process.stdout.write = function (chunk, encodingOrCallback, callback) {
+    stdout += String(chunk);
+    if (typeof encodingOrCallback === "function") encodingOrCallback();
+    if (typeof callback === "function") callback();
+    return true;
+  };
+  try {
+    await fn(() => stdout);
+  } finally {
+    process.stdout.write = originalWrite;
+    console.log = originalConsoleLog;
+  }
+}
+
+test("installEgoSdk flushes host REPL stdout capture after each clean evaluation", async () => {
+  await withCapturedProcessStdout(async (stdout) => {
+    const capture = hostCapture();
+    const target = {
+      ego: {},
+      __egoNodeOutputCapture: capture,
+      async __egoEvaluateReplScript(source) {
+        capture.append(`captured ${source}\n`);
+      },
+      __egoCompleteReplEvaluation() {},
+    };
+
+    installEgoSdk(target);
+    await target.__egoEvaluateReplScript("one");
+    target.__egoCompleteReplEvaluation();
+    await target.__egoEvaluateReplScript("two");
+    target.__egoCompleteReplEvaluation();
+
+    assert.equal(stdout(), "captured one\ncaptured two\n");
+  });
+});
+
+test("installEgoSdk discards host REPL capture and prints one hard-stop message", async () => {
+  await withCapturedProcessStdout(async (stdout) => {
+    const capture = hostCapture();
+    const target = {
+      ego: {},
+      __egoNodeOutputCapture: capture,
+      async __egoEvaluateReplScript(source) {
+        capture.append(`business ${source}\n`);
+        markHardStop("SDK HARD STOP");
+      },
+      __egoCompleteReplEvaluation() {},
+    };
+
+    installEgoSdk(target);
+    await target.__egoEvaluateReplScript("cell");
+    target.__egoCompleteReplEvaluation();
+
+    assert.equal(stdout(), "SDK HARD STOP\n");
+  });
+});
+
+test("installEgoSdk flushes ordinary output before a thrown REPL evaluation error", async () => {
+  await withCapturedProcessStdout(async (stdout) => {
+    const capture = hostCapture();
+    const target = {
+      ego: {},
+      __egoNodeOutputCapture: capture,
+      async __egoEvaluateReplScript() {
+        capture.append("before ordinary throw\n");
+        throw new Error("ordinary throw");
+      },
+      __egoCompleteReplEvaluation() {},
+    };
+
+    installEgoSdk(target);
+    await assert.rejects(
+      () => target.__egoEvaluateReplScript("cell"),
+      /ordinary throw/,
+    );
+
+    assert.equal(stdout(), "before ordinary throw\n");
+  });
+});
+
+test("installEgoSdk keeps thrown hard stops silent for the host error printer", async () => {
+  await withCapturedProcessStdout(async (stdout) => {
+    const capture = hostCapture();
+    const target = {
+      ego: {},
+      __egoNodeOutputCapture: capture,
+      async __egoEvaluateReplScript() {
+        capture.append("before hard stop throw\n");
+        markHardStop("SDK HARD STOP THROW");
+        throw new Error("hard stop throw");
+      },
+      __egoCompleteReplEvaluation() {},
+    };
+
+    installEgoSdk(target);
+    await assert.rejects(
+      () => target.__egoEvaluateReplScript("cell"),
+      /hard stop throw/,
+    );
+
+    assert.equal(stdout(), "");
+  });
+});

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -12,24 +12,28 @@ ego-browser gives AI agents a CLI-accessible Node.js runtime, with built-in help
 
 For setup, install, or connection problems, read `references/install.md`.
 
-Use the `Bash` tool to run all browser operations via `ego-browser nodejs <<'EOF' ... EOF` heredoc. Do not write code to a `.js` file first.
+Use the `Bash` tool to start one interactive `ego-browser nodejs` session, then run browser operations as REPL cells with `.cell` and `.end`. Do not write code to a `.js` file first.
 
 
 ## Quick start
 
 ```bash
-ego-browser nodejs <<'EOF'
-// Name the task space for the whole user task, then reuse that space across heredoc rounds.
+ego-browser nodejs
+```
+
+```text
+repl> .cell
+// Name the task space for the whole user task, then reuse that space across cells.
 const task = await useOrCreateTaskSpace('inspect example page')
 console.log('task space id: ' + task.id)
 
 await openOrReuseTab('https://example.com', { wait: true, timeout: 20000 })
 
 console.log(await snapshot())
-EOF
+.end
 ```
 
-The heredoc body runs as a Node.js script that controls the selected ego-browser task space. All ego-browser helpers are preloaded into that script.
+Each REPL cell runs as JavaScript that controls the selected ego-browser task space. All ego-browser helpers are preloaded into the REPL. `.cell`, `.end`, `.cancel`, and `.exit` are REPL commands, not JavaScript syntax.
 
 ## Common helpers
 
@@ -45,7 +49,7 @@ The heredoc body runs as a Node.js script that controls the selected ego-browser
 - Output: `console.log`, `help`
 
 Notes:
-- `console.log(value)` — prints to the terminal; it is the only output mechanism inside a heredoc, and all final results must go through it.
+- `console.log(value)` — prints to the terminal; it is the primary output mechanism inside a cell, and all final results must go through it.
 - `await pageInfo()` — normally resolves to `{ url, title, w, h, sx, sy, pw, ph }`; if a native browser dialog is open, resolves to `{ dialog: ... }` instead because page JavaScript is blocked.
 - If `await pageInfo()` resolves to `{ dialog: ... }`, handle the dialog with `await cdp('Page.handleJavaScriptDialog', { accept: true })` or `accept: false` before running page JavaScript.
 - `await ensureRealTab()` — switches to an existing non-internal page tab if needed and resolves to it; resolves to `null` when none exists. It does not create a tab — use `await openOrReuseTab(...)` for that.
@@ -62,11 +66,11 @@ A task space is an **isolated browsing context** that ego-browser provides for A
 
 Closing all tabs in a task space is equivalent to closing that task space.
 
-A task often takes multiple heredoc rounds to complete. Because the Node.js runtime exits after each heredoc and retains no state, normal working heredocs should start with an explicit call to `useOrCreateTaskSpace(nameOrId)` to reuse the same space — this lets you operate continuously and reuse tabs across rounds. The exception is resuming after a handoff: once the user confirms "continue" (through an Ask or in chat), start the next heredoc with `takeOverTaskSpace(nameOrId)` instead.
+A task often takes multiple cells to complete. The REPL keeps JavaScript state between cells, but normal working cells should still start with or rely on an explicit `useOrCreateTaskSpace(nameOrId)` result for the active task — this lets you operate continuously and reuse tabs across cells. The exception is resuming after a handoff: once the user confirms "continue" (through an Ask or in chat), start the next cell with `takeOverTaskSpace(nameOrId)` instead.
 
 `nameOrId` can be a task space name, numeric id, or digit-only numeric id string. String values match `name`/`taskId` first, then digit-only strings fall back to numeric id. Number values match existing numeric ids only; if no matching id exists, `useOrCreateTaskSpace` fails instead of creating a new space.
 
-Use a short name for the active user goal when creating a new task space. Keep reusing that task space for follow-up questions, corrections, refinements, re-checks, and result validation, even if you previously thought the task was complete. Choose a new task space only when the user clearly starts a separate, unrelated goal. Prefer using the numeric `id` returned by `useOrCreateTaskSpace` (for example, `task.id`) to resume a known task in later rounds and avoid name collisions.
+Use a short name for the active user goal when creating a new task space. Keep reusing that task space for follow-up questions, corrections, refinements, re-checks, and result validation, even if you previously thought the task was complete. Choose a new task space only when the user clearly starts a separate, unrelated goal. Prefer using the numeric `id` returned by `useOrCreateTaskSpace` (for example, `task.id`) to resume a known task in later cells and avoid name collisions.
 
 For any follow-up on the same user goal — including continue, corrections, retries, validation, user-reported problems, or work after `completeTaskSpace(..., { keep: true })` — resume the original task space first if it still exists. Do not create a new task space for the same goal unless the user asks for a fresh space, starts an unrelated goal, or the original space is unavailable after checking. If a new space is necessary, state why.
 
@@ -85,7 +89,7 @@ After explicit user confirmation, to continue work from an existing user-owned, 
 
 `handOffTaskSpace` and `completeTaskSpace` resolve `{ done: true }` when the operation actually happened. Check `done` before telling the user the handoff/cleanup is finished — a `skipped` result usually means you targeted a space that was never yours.
 
-**`completeTaskSpace(nameOrId, { keep })` must occupy its own dedicated final heredoc, and run only after a prior heredoc's output has confirmed the task is genuinely done.** `keep` is required and defaults by policy to `false`: close the task space after completion unless there is a concrete reason to leave the live page visible.
+**`completeTaskSpace(nameOrId, { keep })` must occupy its own dedicated final cell, and run only after a prior cell's output has confirmed the task is genuinely done.** `keep` is required and defaults by policy to `false`: close the task space after completion unless there is a concrete reason to leave the live page visible.
 
 Use `{ keep: true }` only when the user explicitly asks to keep the page open, the task needs manual user action in that exact page, or the result cannot be delivered well as a URL, file, artifact, or summary. Do not keep a task space open merely because a page was visited, a document was created, or a screenshot was used for verification.
 
@@ -102,13 +106,13 @@ A "user is controlling" error is a hard stop on the whole task — not an obstac
 
 An "inactive", "not assigned to an agent", or similar task-space error is also a hard stop with the same confirmation requirement. Resume only after explicit user confirmation, then start with `await claimTaskSpace(id)`.
 
-**Handing off**: When the task requires user intervention (e.g. login, captcha, manual confirmation), call `await handOffTaskSpace([nameOrId])` to give control to the user, and tell them exactly what to do. Omitting `nameOrId` uses the currently selected task space; pass `task.id` across heredoc rounds to avoid ambiguity.
+**Handing off**: When the task requires user intervention (e.g. login, captcha, manual confirmation), call `await handOffTaskSpace([nameOrId])` to give control to the user, and tell them exactly what to do. Omitting `nameOrId` uses the currently selected task space; pass `task.id` across cells to avoid ambiguity.
 
-**Regaining control**: Take control back *only* after the user explicitly confirms — through an Ask (your harness's button/option prompt, e.g. "Continue" vs "Finish task") or a "continue" message in chat. Then start a new heredoc with `await takeOverTaskSpace([nameOrId])` and resume; if the user chooses to finish, close out with `await completeTaskSpace(nameOrId, { keep })`. Never call `takeOverTaskSpace` on your own to grab control back — it has no ownership check and will seize the browser away from the user.
+**Regaining control**: Take control back *only* after the user explicitly confirms — through an Ask (your harness's button/option prompt, e.g. "Continue" vs "Finish task") or a "continue" message in chat. Then start a new cell with `await takeOverTaskSpace([nameOrId])` and resume; if the user chooses to finish, close out with `await completeTaskSpace(nameOrId, { keep })`. Never call `takeOverTaskSpace` on your own to grab control back — it has no ownership check and will seize the browser away from the user.
 
 **Unexpected takeover**: The user can take over at any time via the browser GUI — the same effect as the agent calling `handOffTaskSpace`. Do not retry the failed operation and do not auto-takeover; surface the Ask above (Continue / Finish) and resume only when the user picks Continue.
 
-`await waitForAgentControl(nameOrId)` is a read-only blocking poll (it never takes control); use it only to wait inside the current heredoc for a handoff you initiated.
+`await waitForAgentControl(nameOrId)` is a read-only blocking poll (it never takes control); use it only to wait inside the current cell for a handoff you initiated.
 
 
 ### Scroll / mouse
@@ -187,7 +191,7 @@ Before writing substantial content into a rich editor, perform a tiny write prob
    - Keep browser-side logic in one explicit IIFE and return once.
    - Use `await cdp(...)` for browser protocol operations that helpers do not cover.
 
-These workflows can be combined. A task may take multiple heredoc rounds when the next step depends on fresh page state or user handoff. In each round, write a coherent script that advances the task: observe, act or extract, verify, and report with `console.log(...)`. Avoid tiny probe scripts, but don't force the whole task into one oversized script.
+These workflows can be combined. A task may take multiple cells when the next step depends on fresh page state or user handoff. In each cell, write coherent code that advances the task: observe, act or extract, verify, and report with `console.log(...)`. Avoid tiny probe cells, but don't force the whole task into one oversized cell.
 
 
 ## Caveats
@@ -199,8 +203,8 @@ These workflows can be combined. A task may take multiple heredoc rounds when th
 - Inside a `evaluate(...)` template string, regex backslashes must be doubled (e.g. `\\d`, `\\s`), or use `String.raw`.
 - If the source passed to `evaluate()` contains a top-level `return`, it will be auto-wrapped in an IIFE; `return` inside nested callbacks can also trigger this accidentally. For complex expressions, prefer the explicit `(() => { ... })()` form.
 - If `await pageInfo()` reports `w: 0` or `h: 0`, do not continue coordinate actions or screenshots until the viewport is fixed. Try switching to the real tab, reloading, or using CDP viewport metrics, then verify with `await pageInfo()` and `await screenshot()`.
-- Code in the heredoc body runs in Node.js; code inside `evaluate(...)` runs in the browser page. Navigation, waits, and `console.log(...)` belong in the heredoc body; `document`, `window`, and page selectors belong inside `evaluate(...)`.
+- Code in a REPL cell runs in Node.js; code inside `evaluate(...)` runs in the browser page. Navigation, waits, and `console.log(...)` belong in the cell; `document`, `window`, and page selectors belong inside `evaluate(...)`.
 - Always call `completeTaskSpace(name, { keep })` when the task is done — do not leave the space hanging. Default to `{ keep: false }`; use `{ keep: true }` only for the concrete live-page cases described in Task spaces.
 - When the user explicitly asks to use ego-browser, assume both `ego-browser` and the repo runtime are ready. Do not pre-check `which ego-browser`, `node -v`, package metadata, or help output. Only investigate environment issues if the first run produces an error.
-- If the first run reports `command not found` / a missing environment (most likely ego lite isn't installed yet), or the user explicitly asks to install ego lite, first read `references/install.md` and follow its flow to complete the install, then return to the original task — do not give up, and do not keep retrying the same heredoc.
+- If the first run reports `command not found` / a missing environment (most likely ego lite isn't installed yet), or the user explicitly asks to install ego lite, first read `references/install.md` and follow its flow to complete the install, then return to the original task — do not give up, and do not keep retrying the same command.
 - A trailing `[ego-browser:notice]` line means an ego lite update is available/required — it is an out-of-band hint appended after the command's own output, not an error or part of the result. Do not act on it mid-task; keep working toward the user's goal. Once the current browser task stops or completes (including right before/after `completeTaskSpace`), tell the user about the update and ask whether they want to run `ego-browser upgrade` and restart ego lite now.


### PR DESCRIPTION
## Summary
- Add the REPL-first nodejs runtime flow with interactive cell handling.
- Isolate output boundaries so hard-stop guidance is printed once and buffered output is discarded correctly.
- Update docs and real-browser/unit coverage for the REPL flow.

## Testing
- npm test
- pre-commit: code-check, e2e-test, site-skill-validation, smoke-test, style-check, vulnerability-audit