### PR TITLE
Fix empty help() in production by embedding docs at build time

### DIFF
--- a/package/ego-browser/scripts/build.mjs
+++ b/package/ego-browser/scripts/build.mjs
@@ -1,4 +1,13 @@
-import { chmod, cp, mkdir, open, readdir, rm } from "node:fs/promises";
+import {
+  chmod,
+  cp,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { builtinModules } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -7,6 +16,10 @@ import { build } from "esbuild";
 import { rollup } from "rollup";
 import resolve from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
+
+import { extractHelpDocs } from "./extract-help-docs.mjs";
+
+const HELP_DOCS_PLACEHOLDER = '"__EGO_EMBEDDED_HELP_DOCS__"';
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = dirname(dirname(root));
@@ -39,7 +52,7 @@ try {
     platform: "node",
     format: "esm",
     target: "node22",
-    logLevel: "info"
+    logLevel: "info",
   };
 
   await build({
@@ -49,7 +62,7 @@ try {
     outbase: ".",
     bundle: false,
     sourcemap: false,
-    absWorkingDir: root
+    absWorkingDir: root,
   });
 
   const rollupConfig = {
@@ -62,14 +75,16 @@ try {
         compilerOptions: {
           noEmit: false,
           declaration: false,
-          removeComments: false
-        }
-      })
-    ]
+          removeComments: false,
+        },
+      }),
+    ],
   };
   const bundle = await rollup(rollupConfig);
   await bundle.write({ file: bundledCli, format: "esm", sourcemap: false });
   await bundle.close();
+
+  await embedHelpDocs(bundledCli, join(distDir, "src", "help-runtime.js"));
 
   await cp(skillSourceDir, bundledSkillDir, { recursive: true });
   await chmod(bundledCli, 0o755);
@@ -78,10 +93,35 @@ try {
   await rm(buildLock, { force: true });
 }
 
+async function embedHelpDocs(...files) {
+  // The docs are extracted from the emitted bundle (it carries every helper's
+  // JSDoc with comments preserved) and injected into each build artifact that
+  // ships help-runtime, replacing the placeholder string constant. Doing this
+  // at build time means the runtime never has to read its own source. See
+  // GitHub issue #84.
+  const bundleSource = await readFile(files[0], "utf-8");
+  const docs = extractHelpDocs(bundleSource);
+  if (docs.length === 0) {
+    throw new Error("embedHelpDocs: extracted 0 helper docs from the bundle");
+  }
+  const injected = JSON.stringify(JSON.stringify(docs));
+  for (const file of files) {
+    const source = await readFile(file, "utf-8");
+    if (!source.includes(HELP_DOCS_PLACEHOLDER)) {
+      throw new Error(`embedHelpDocs: placeholder not found in ${file}`);
+    }
+    // Use a replacer function so `$` sequences in the JSON are inserted literally.
+    await writeFile(
+      file,
+      source.replace(HELP_DOCS_PLACEHOLDER, () => injected),
+    );
+  }
+}
+
 async function tsEntryPoints(dirs) {
   const files = [];
   for (const dir of dirs) {
-    files.push(...await collectTsFiles(join(root, dir), dir));
+    files.push(...(await collectTsFiles(join(root, dir), dir)));
   }
   return files.sort();
 }
@@ -93,7 +133,7 @@ async function collectTsFiles(absDir, relativeDir) {
     const relativePath = `${relativeDir}/${entry.name}`;
     const absPath = join(absDir, entry.name);
     if (entry.isDirectory()) {
-      files.push(...await collectTsFiles(absPath, relativePath));
+      files.push(...(await collectTsFiles(absPath, relativePath)));
     } else if (entry.isFile() && entry.name.endsWith(".ts")) {
       files.push(relativePath);
     }

--- a/package/ego-browser/scripts/extract-help-docs.mjs
+++ b/package/ego-browser/scripts/extract-help-docs.mjs
@@ -1,0 +1,206 @@
+import { parse } from "acorn";
+
+// Build-time helper-doc extraction.
+//
+// Historically this ran at runtime inside help-runtime.ts by reading the
+// module's own source (fileURLToPath(import.meta.url) + readFileSync). That
+// only works when the SDK is loaded from a real file. In the shipped browser
+// the SDK is loaded from a compiled .pak resource whose import.meta.url is
+// "ego://services/node/resources/index.js", so fileURLToPath throws and the
+// docs map was permanently empty. The extraction now happens at build time
+// against the emitted bundle and the result is embedded as data, so the
+// runtime never touches its own source. See GitHub issue #84.
+
+/**
+ * Parse bundled JS source and return the helper docs used by help()/formatHelp().
+ * @param {string} source Bundled JavaScript with comments preserved.
+ * @returns {Array<{name: string, signature: string, description: string | null, params: Array<object>, returns: string | null, async: boolean}>}
+ */
+export function extractHelpDocs(source) {
+  const docs = new Map();
+
+  const comments = [];
+  const ast = parse(source, {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    onComment: comments,
+    locations: true,
+  });
+
+  const commentsByEndLine = new Map();
+  for (const c of comments) {
+    if (c.type === "Block") {
+      commentsByEndLine.set(c.loc.end.line, c);
+    }
+  }
+
+  walkFunctions(ast, (node) => {
+    const name = extractFunctionName(node);
+    if (!name) return;
+
+    const startLine = node.loc.start.line;
+    const jsDoc = commentsByEndLine.get(startLine - 1);
+    const parsed = jsDoc ? parseJSDoc(jsDoc.value) : null;
+
+    const params = extractParams(node, parsed);
+    const isAsync = node.async === true;
+    const paramSig = params
+      .map((p) => {
+        const rest = p.rest ? "..." : "";
+        const opt = p.optional ? "?" : "";
+        return `${rest}${p.name}${opt}`;
+      })
+      .join(", ");
+    const retStr = parsed?.returns || (isAsync ? "Promise<...>" : null);
+    const signature = `${name}(${paramSig})${retStr ? ` → ${retStr}` : ""}`;
+
+    docs.set(name, {
+      name,
+      signature,
+      description: parsed?.description || null,
+      params,
+      returns: retStr,
+      async: isAsync,
+    });
+  });
+
+  walkAliases(ast, (name, target) => {
+    const existing = docs.get(target);
+    if (existing && !docs.has(name)) {
+      docs.set(name, { ...existing, name });
+    }
+  });
+
+  return [...docs.values()];
+}
+
+function walkFunctions(node, visitor) {
+  if (!node || typeof node !== "object") return;
+  if (
+    node.type === "FunctionDeclaration" ||
+    node.type === "FunctionExpression"
+  ) {
+    visitor(node);
+  }
+  for (const key of Object.keys(node)) {
+    if (key === "type" || key === "loc" || key === "start" || key === "end")
+      continue;
+    const child = node[key];
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        if (item && typeof item.type === "string") walkFunctions(item, visitor);
+      }
+    } else if (child && typeof child.type === "string") {
+      walkFunctions(child, visitor);
+    }
+  }
+}
+
+function walkAliases(node, visitor) {
+  if (!node || typeof node !== "object") return;
+  if (node.type === "VariableDeclaration") {
+    for (const decl of node.declarations || []) {
+      if (decl.id?.type === "Identifier" && decl.init?.type === "Identifier") {
+        visitor(decl.id.name, decl.init.name);
+      }
+    }
+  }
+  for (const key of Object.keys(node)) {
+    if (key === "type" || key === "loc" || key === "start" || key === "end")
+      continue;
+    const child = node[key];
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        if (item && typeof item.type === "string") walkAliases(item, visitor);
+      }
+    } else if (child && typeof child.type === "string") {
+      walkAliases(child, visitor);
+    }
+  }
+}
+
+function extractFunctionName(node) {
+  if (node.id?.name) return node.id.name;
+  return null;
+}
+
+function extractParams(node, jsdoc) {
+  return (node.params || []).map((p) => {
+    const info = resolveParam(p);
+    const jsdocParam = jsdoc?.params.find((jp) => jp.name === info.name);
+    return {
+      ...info,
+      type: jsdocParam?.type || null,
+      description: jsdocParam?.description || null,
+    };
+  });
+}
+
+function parseJSDoc(raw) {
+  const lines = raw.split("\n").map((l) => l.replace(/^\s*\*\s?/, "").trim());
+  const descLines = [];
+  const params = [];
+  let returns = null;
+
+  for (const line of lines) {
+    const paramMatch = line.match(
+      /^@param\s+(?:\{([^}]*)\}\s+)?(\[?\w+\]?)(?:(?:\s+[-–—]\s*|\s+)(.+))?\s*$/,
+    );
+    if (paramMatch) {
+      const name = paramMatch[2].replace(/^\[|\]$/g, "");
+      params.push({
+        name,
+        type: paramMatch[1] || null,
+        description: paramMatch[3] || null,
+      });
+      continue;
+    }
+    const returnsMatch = line.match(/^@returns?\s+(?:\{([^}]*)\}\s*)?(.*)/);
+    if (returnsMatch) {
+      returns = returnsMatch[1] || returnsMatch[2] || null;
+      continue;
+    }
+    if (line.startsWith("@")) continue;
+    if (line) descLines.push(line);
+  }
+
+  return {
+    description: descLines.join(" ").trim() || null,
+    params,
+    returns,
+  };
+}
+
+function resolveParam(node) {
+  if (node.type === "RestElement") {
+    const inner = resolveParam(node.argument);
+    return { ...inner, rest: true, optional: true };
+  }
+  if (node.type === "AssignmentPattern") {
+    const inner = resolveParam(node.left);
+    const defStr = nodeToString(node.right);
+    return { ...inner, optional: true, default: defStr };
+  }
+  if (node.type === "Identifier") {
+    return { name: node.name, optional: false, rest: false, default: null };
+  }
+  if (node.type === "ObjectPattern") {
+    const props = (node.properties || [])
+      .map((p) => p.key?.name || "?")
+      .join(", ");
+    return { name: `{${props}}`, optional: false, rest: false, default: null };
+  }
+  if (node.type === "ArrayPattern") {
+    return { name: "[...]", optional: false, rest: false, default: null };
+  }
+  return { name: "?", optional: false, rest: false, default: null };
+}
+
+function nodeToString(node) {
+  if (!node) return "?";
+  if (node.type === "Literal") return JSON.stringify(node.value);
+  if (node.type === "ObjectExpression") return "{}";
+  if (node.type === "ArrayExpression") return "[]";
+  if (node.type === "Identifier") return node.name;
+  return "...";
+}

--- a/package/ego-browser/src/help-runtime.test.mjs
+++ b/package/ego-browser/src/help-runtime.test.mjs
@@ -1,5 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { help, formatHelp } from "../dist/src/help-runtime.js";
 
@@ -36,4 +40,33 @@ test("formatHelp renders the signature for an embedded doc", () => {
   const doc = help({ click: () => {} }, "click");
   const text = formatHelp(doc);
   assert.ok(text.includes("click("), `expected signature in:\n${text}`);
+});
+
+test("help works when the shipped bundle runs as an eval module", () => {
+  // The app executes the SDK from an in-memory string, so its import.meta.url
+  // ("file:///...[eval1]") is not a readable file — the exact condition that
+  // broke the old self-introspection. Feed the real dist/out bundle to node
+  // the same way and query help through the installed global, like an agent
+  // script (a separate eval module sharing only globals) would. The file://
+  // imports above cannot catch a regression of this class.
+  const root = dirname(dirname(fileURLToPath(import.meta.url)));
+  const bundle = readFileSync(join(root, "dist", "out", "index.js"), "utf-8");
+  // globalThis, not a bare identifier: appended source shares the bundle's
+  // module scope, where the raw help(helpers, ...names) export would shadow
+  // the installed global wrapper.
+  const probe = 'console.log(globalThis.help("click"))';
+  const result = spawnSync(process.execPath, ["--input-type=module"], {
+    input: `${bundle}\n${probe}\n`,
+    encoding: "utf-8",
+    timeout: 30_000,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(
+    !result.stdout.includes("Unknown helper"),
+    `docs map was empty under eval loading:\n${result.stdout}`,
+  );
+  assert.ok(
+    result.stdout.includes("click("),
+    `expected the click signature in:\n${result.stdout}`,
+  );
 });

--- a/package/ego-browser/src/help-runtime.test.mjs
+++ b/package/ego-browser/src/help-runtime.test.mjs
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { help, formatHelp } from "../dist/src/help-runtime.js";
+
+// Regression test for GitHub issue #84: the runtime used to build its docs map
+// by reading its own source, which produced an empty map whenever the SDK was
+// not loaded from a real file (the shipped .pak resource). Docs are now
+// embedded at build time, so these assertions exercise the injected data.
+
+test("help(name) returns the embedded doc instead of an empty result", () => {
+  const doc = help({ click: () => {} }, "click");
+  assert.equal(typeof doc, "object");
+  assert.equal(doc.name, "click");
+  assert.ok(
+    doc.description && doc.description.length > 0,
+    `expected a non-empty description, got: ${JSON.stringify(doc)}`,
+  );
+});
+
+test("help() lists the helpers present in the context", () => {
+  const list = help({ click: () => {}, waitFor: () => {} });
+  assert.ok(Array.isArray(list));
+  assert.ok(list.length > 0, "expected embedded docs to be non-empty");
+  assert.ok(list.some((d) => d.name === "click"));
+});
+
+test("help(unknown) reports the unknown helper", () => {
+  assert.equal(
+    help({}, "definitelyNotAHelper"),
+    "Unknown helper: definitelyNotAHelper",
+  );
+});
+
+test("formatHelp renders the signature for an embedded doc", () => {
+  const doc = help({ click: () => {} }, "click");
+  const text = formatHelp(doc);
+  assert.ok(text.includes("click("), `expected signature in:\n${text}`);
+});

--- a/package/ego-browser/src/help-runtime.ts
+++ b/package/ego-browser/src/help-runtime.ts
@@ -1,7 +1,3 @@
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { parse } from "acorn";
-
 type ParamInfo = {
   name: string;
   type: string | null;
@@ -20,9 +16,21 @@ type HelperDoc = {
   async: boolean;
 };
 
+// Helper docs are extracted from the bundle at build time and injected here by
+// scripts/build.mjs, which replaces the placeholder below with a JSON string.
+// The runtime must never introspect its own source: in the shipped browser the
+// SDK is loaded from a compiled .pak resource whose import.meta.url is
+// "ego://services/node/resources/index.js", which is not a readable file, so
+// the previous readFileSync(fileURLToPath(import.meta.url)) approach silently
+// produced an empty docs map. See GitHub issue #84.
+const EMBEDDED_DOCS_JSON = "__EGO_EMBEDDED_HELP_DOCS__";
+
 let cache: Map<string, HelperDoc> | null = null;
 
-export function help(helpers: Record<string, unknown>, ...names: string[]): HelperDoc | HelperDoc[] | string {
+export function help(
+  helpers: Record<string, unknown>,
+  ...names: string[]
+): HelperDoc | HelperDoc[] | string {
   const docs = getDocsMap();
   if (names.length === 0) {
     const all = [...docs.values()].filter((d) => d.name in helpers);
@@ -33,7 +41,17 @@ export function help(helpers: Record<string, unknown>, ...names: string[]): Help
     if (!doc) return `Unknown helper: ${names[0]}`;
     return doc;
   }
-  return names.map((n) => docs.get(n) || { name: n, signature: n, description: null, params: [], returns: null, async: false });
+  return names.map(
+    (n) =>
+      docs.get(n) || {
+        name: n,
+        signature: n,
+        description: null,
+        params: [],
+        returns: null,
+        async: false,
+      },
+  );
 }
 
 export function formatHelp(doc: HelperDoc): string {
@@ -46,7 +64,9 @@ export function formatHelp(doc: HelperDoc): string {
     const type = p.type ? `: ${p.type}` : "";
     const desc = p.description ? ` — ${p.description}` : "";
     const def = p.default ? ` (default: ${p.default})` : "";
-    lines.push(`@param ${p.rest ? "..." : ""}${p.name}${opt}${type}${desc}${def}`);
+    lines.push(
+      `@param ${p.rest ? "..." : ""}${p.name}${opt}${type}${desc}${def}`,
+    );
   }
   if (doc.returns) {
     lines.push(`@returns ${doc.returns}`);
@@ -59,196 +79,19 @@ export function formatHelp(doc: HelperDoc): string {
 function getDocsMap(): Map<string, HelperDoc> {
   if (cache) return cache;
   cache = new Map();
-  const source = readSelf();
-  if (!source) return cache;
-
-  const comments: any[] = [];
-  let ast: any;
-  try {
-    ast = parse(source, {
-      ecmaVersion: "latest",
-      sourceType: "module",
-      onComment: comments,
-      locations: true
-    });
-  } catch {
-    return cache;
+  for (const doc of parseEmbeddedDocs(EMBEDDED_DOCS_JSON)) {
+    cache.set(doc.name, doc);
   }
-
-  const commentsByEndLine = new Map<number, any>();
-  for (const c of comments) {
-    if (c.type === "Block") {
-      commentsByEndLine.set(c.loc.end.line, c);
-    }
-  }
-
-  walkFunctions(ast, (node: any) => {
-    const name = extractFunctionName(node);
-    if (!name) return;
-
-    const startLine = node.loc.start.line;
-    const jsDoc = commentsByEndLine.get(startLine - 1);
-    const parsed = jsDoc ? parseJSDoc(jsDoc.value) : null;
-
-    const params = extractParams(node, parsed);
-    const isAsync = node.async === true;
-    const paramSig = params.map((p) => {
-      const rest = p.rest ? "..." : "";
-      const opt = p.optional ? "?" : "";
-      return `${rest}${p.name}${opt}`;
-    }).join(", ");
-    const retStr = parsed?.returns || (isAsync ? "Promise<...>" : null);
-    const signature = `${name}(${paramSig})${retStr ? ` → ${retStr}` : ""}`;
-
-    cache!.set(name, {
-      name,
-      signature,
-      description: parsed?.description || null,
-      params,
-      returns: retStr,
-      async: isAsync
-    });
-  });
-
-  walkAliases(ast, (name: string, target: string) => {
-    const existing = cache!.get(target);
-    if (existing && !cache!.has(name)) {
-      cache!.set(name, { ...existing, name });
-    }
-  });
-
   return cache;
 }
 
-function readSelf(): string | null {
+function parseEmbeddedDocs(raw: string): HelperDoc[] {
+  // If the build injection did not run (e.g. importing raw TypeScript), `raw`
+  // is still the placeholder and JSON.parse throws; there are simply no docs.
   try {
-    const selfPath = fileURLToPath(import.meta.url);
-    return readFileSync(selfPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
   } catch {
-    return null;
+    return [];
   }
-}
-
-function walkFunctions(node: any, visitor: (node: any) => void) {
-  if (!node || typeof node !== "object") return;
-  if (node.type === "FunctionDeclaration" || node.type === "FunctionExpression") {
-    visitor(node);
-  }
-  for (const key of Object.keys(node)) {
-    if (key === "type" || key === "loc" || key === "start" || key === "end") continue;
-    const child = node[key];
-    if (Array.isArray(child)) {
-      for (const item of child) {
-        if (item && typeof item.type === "string") walkFunctions(item, visitor);
-      }
-    } else if (child && typeof child.type === "string") {
-      walkFunctions(child, visitor);
-    }
-  }
-}
-
-function walkAliases(node: any, visitor: (name: string, target: string) => void) {
-  if (!node || typeof node !== "object") return;
-  if (node.type === "VariableDeclaration") {
-    for (const decl of node.declarations || []) {
-      if (decl.id?.type === "Identifier" && decl.init?.type === "Identifier") {
-        visitor(decl.id.name, decl.init.name);
-      }
-    }
-  }
-  for (const key of Object.keys(node)) {
-    if (key === "type" || key === "loc" || key === "start" || key === "end") continue;
-    const child = node[key];
-    if (Array.isArray(child)) {
-      for (const item of child) {
-        if (item && typeof item.type === "string") walkAliases(item, visitor);
-      }
-    } else if (child && typeof child.type === "string") {
-      walkAliases(child, visitor);
-    }
-  }
-}
-
-function extractFunctionName(node: any): string | null {
-  if (node.id?.name) return node.id.name;
-  return null;
-}
-
-function extractParams(node: any, jsdoc: ParsedJSDoc | null): ParamInfo[] {
-  return (node.params || []).map((p: any) => {
-    const info = resolveParam(p);
-    const jsdocParam = jsdoc?.params.find((jp) => jp.name === info.name);
-    return {
-      ...info,
-      type: jsdocParam?.type || null,
-      description: jsdocParam?.description || null
-    };
-  });
-}
-
-type ParsedJSDoc = {
-  description: string | null;
-  params: Array<{ name: string; type: string | null; description: string | null }>;
-  returns: string | null;
-};
-
-function parseJSDoc(raw: string): ParsedJSDoc {
-  const lines = raw.split("\n").map((l) => l.replace(/^\s*\*\s?/, "").trim());
-  const descLines: string[] = [];
-  const params: ParsedJSDoc["params"] = [];
-  let returns: string | null = null;
-
-  for (const line of lines) {
-    const paramMatch = line.match(/^@param\s+(?:\{([^}]*)\}\s+)?(\[?\w+\]?)(?:(?:\s+[-–—]\s*|\s+)(.+))?\s*$/);
-    if (paramMatch) {
-      const name = paramMatch[2].replace(/^\[|\]$/g, "");
-      params.push({ name, type: paramMatch[1] || null, description: paramMatch[3] || null });
-      continue;
-    }
-    const returnsMatch = line.match(/^@returns?\s+(?:\{([^}]*)\}\s*)?(.*)/);
-    if (returnsMatch) {
-      returns = returnsMatch[1] || returnsMatch[2] || null;
-      continue;
-    }
-    if (line.startsWith("@")) continue;
-    if (line) descLines.push(line);
-  }
-
-  return {
-    description: descLines.join(" ").trim() || null,
-    params,
-    returns
-  };
-}
-
-function resolveParam(node: any): { name: string; optional: boolean; rest: boolean; default: string | null } {
-  if (node.type === "RestElement") {
-    const inner = resolveParam(node.argument);
-    return { ...inner, rest: true, optional: true };
-  }
-  if (node.type === "AssignmentPattern") {
-    const inner = resolveParam(node.left);
-    const defStr = nodeToString(node.right);
-    return { ...inner, optional: true, default: defStr };
-  }
-  if (node.type === "Identifier") {
-    return { name: node.name, optional: false, rest: false, default: null };
-  }
-  if (node.type === "ObjectPattern") {
-    const props = (node.properties || []).map((p: any) => p.key?.name || "?").join(", ");
-    return { name: `{${props}}`, optional: false, rest: false, default: null };
-  }
-  if (node.type === "ArrayPattern") {
-    return { name: "[...]", optional: false, rest: false, default: null };
-  }
-  return { name: "?", optional: false, rest: false, default: null };
-}
-
-function nodeToString(node: any): string {
-  if (!node) return "?";
-  if (node.type === "Literal") return JSON.stringify(node.value);
-  if (node.type === "ObjectExpression") return "{}";
-  if (node.type === "ArrayExpression") return "[]";
-  if (node.type === "Identifier") return node.name;
-  return "...";
 }


### PR DESCRIPTION
## Problem

`help()` returns `""` and every helper reports `Unknown helper: <name>` when the SDK runs inside the shipped browser (issue #84).

`help-runtime.ts` built its docs map by reading the module's **own source at runtime**:

```ts
const selfPath = fileURLToPath(import.meta.url);
return readFileSync(selfPath, "utf-8"); // then acorn-parse for JSDoc
```

This only works when the SDK is loaded from a real file on disk. The shipped browser executes the SDK from an in-memory string (an eval module), so its `import.meta.url` is an `[eval]`-style URL that doesn't correspond to a readable file: `fileURLToPath` returns a path that doesn't exist, `readFileSync` fails with `ENOENT`, the `catch` swallowed it, and the empty docs map got cached permanently — every helper lookup misses and `help()` formats to an empty string.

(An earlier analysis attributed this to `ERR_INVALID_URL_SCHEME` on a custom URL scheme; runtime tracing showed the actual failure is the swallowed `ENOENT` above. The conclusion is the same either way: under eval loading the module can never read its own source.)

Reproduces against the shipped app with `ego-browser nodejs` running `cliLog(help('click'))` → `Unknown helper: click`. It never showed up in dev because running the CLI directly loads the SDK from a file, where the self-read works.

## Why a runtime patch can't fix it

Under eval loading there is no file to read — the source only exists as a string in memory. No amount of `import.meta.url` handling recovers it. The correct fix is to stop introspecting source at runtime.

## Fix

Extract the docs from the emitted bundle **at build time** and embed them as data:

- `help-runtime.ts` is now a pure data consumer (no `fs` / `url` / `acorn`); it parses a build-injected JSON constant. No dependence on `import.meta.url`, so it works identically under file and eval loading.
- `scripts/extract-help-docs.mjs` holds the AST extraction (moved verbatim from the old runtime path — identical output).
- `scripts/build.mjs` extracts docs from the bundle and injects them into the shipped artifacts (`dist/out/index.js` and `dist/src/help-runtime.js`), and **fails the build** if zero docs are extracted or the placeholder is missing — turning the old silent-empty failure into a loud one.
- Added `help-runtime.test.mjs`: embedded-docs assertions plus an eval-module regression test that feeds the built `dist/out/index.js` to node as an in-memory module (`--input-type=module` on stdin) — the exact loading mode that broke the old code — and asserts `help("click")` returns the real doc. The pre-fix bundle fails this test; the file-URL-based tests alone cannot catch this class of regression.

Side effect: `acorn` is no longer bundled into the runtime (it is now build-only), shrinking the shipped bundle.

## Verification

- `npm test` — 208/208 pass (incl. 5 help-runtime tests); `tsc --noEmit` clean; real-browser e2e suite green.
- Manual A/B/C matrix: old bundle + file URL → works (why dev never caught it); old bundle + eval → `Unknown helper: click` (reproduces the bug); new bundle + eval → full doc with description, params, `@returns`, signature.
- End-to-end confirmation inside the shipped app requires the next release that embeds the rebuilt SDK; the eval-module test reproduces the app's loading mode 1:1 at the package level.

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)
