### PR TITLE
Improve runtime reliability and X site tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This repo contains the open-source harness and the agent skill package — **not
 - Both paths expose the same helper surface, built by `helperContext()` in `src/helpers.ts` — the single source of truth for what agents can call (including `help()` and `agent_helpers.js` extensions).
 - `src/run.ts` executes stdin JavaScript inside an async function with the helpers injected as parameters.
 - `src/browser-runtime.ts` owns CDP transport over `ego.sendCDPMessage`, session attach/caching (2s TTL, auto re-attach on session loss), the buffered event queue (10k cap), and JS dialog tracking.
-- `src/cdp-eval.ts` provides `cdp()` and `js()` (string-expression evaluation; top-level `return` is auto-wrapped in an IIFE).
+- `src/cdp-eval.ts` provides `cdp()` and `evaluate()` (string-expression evaluation; top-level `return` is auto-wrapped in an IIFE).
 - `src/element-resolver.ts` resolves all target forms — `@N` refs, `loc=css:` / `loc=role:` / `loc=href:` locators, `xpath=`, raw CSS — and classifies failures as `transient` (retryable) or `permanent`.
 - `src/ref-map.ts` + `src/ref-state.ts`: refs are numeric `backendNodeId`s (`@21`, not `@e21`). The map is rebuilt on every snapshot; using a ref while the map is empty triggers an automatic re-snapshot, which is what makes refs work across heredoc rounds.
 - `src/driver/` — `nav` (tabs, navigation), `pointer` (click/scroll/drag), `keyboard`, `observe` (snapshot/screenshot), `waits`, `files` (upload), `element-ops` (objectId handles), `load`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to the open-source ego-browser harness and bundled site learnings are documented here.
+
+## Unreleased — 2026-07-10
+
+### Added
+
+- Added an X bookmarks collector that handles virtualized scrolling, deduplication, login redirects, bounded idle detection, and stable post ids/URLs.
+- Added an X post/article reader that selects the requested status and extracts bounded long-form article content.
+- Added integration coverage for the Playwright-style Google and X Node site tools.
+- Added an explicit ESM package boundary for bundled site learnings.
+
+### Changed
+
+- Changed the CDP event buffer to use an advancing head and batched compaction, avoiding repeated 10,000-element array shifts under sustained event traffic.
+- Split transport-facing runtime state into a dependency-free module, removing the build-time circular dependency.
+- Expanded X timeline results with post ids, canonical URLs, handles, and inline links.
+
+### Fixed
+
+- Fixed temporary CDP sessions created by `evaluate(expression, targetId)` not being detached after success or ordinary failure.
+- Preserved task-space hard-stop semantics by skipping cleanup commands after user takeover or task deactivation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ ego-lite/
 │   │   ├── helpers.ts          # Public helper surface composition
 │   │   ├── browser-runtime.ts  # CDP transport and session cache
 │   │   ├── element-resolver.ts # @eN / CSS / XPath / ARIA resolution
-│   │   ├── cdp-eval.ts         # cdp() / js() helpers
+│   │   ├── cdp-eval.ts         # cdp() / evaluate() helpers
 │   │   ├── state.ts            # Shared mutable runtime state (singleton)
 │   │   ├── env.ts              # Environment variables
 │   │   ├── driver/             # Capability-scoped driver modules
@@ -155,7 +155,7 @@ JS
            │ helpers.ts (public API)      │
            │  ├─ task-space helpers       │
            │  ├─ driver/* capabilities    │
-           │  ├─ cdp() / js()             │
+           │  ├─ cdp() / evaluate()       │
            │  └─ learning helpers         │
            └──────────────┬───────────────┘
                           │
@@ -196,7 +196,7 @@ Control (`agent` ↔ `user`) is handed off via the `handOffTaskSpace` / `takeOve
 | `src/helpers.ts` | Composes and exports the helper set exposed to heredocs |
 | `src/browser-runtime.ts` | Maintains the CDP connection, session cache, and event buffer for the browser's ego runtime |
 | `src/element-resolver.ts` | Resolves `@eN` refs, CSS, XPath, and ARIA/role to backend nodeIds |
-| `src/cdp-eval.ts` | `cdp()` raw CDP calls + `js()` in-page evaluation |
+| `src/cdp-eval.ts` | `cdp()` raw CDP calls + `evaluate()` in-page evaluation |
 | `src/state.ts` | Shared mutable state singleton (`send`, `platform`, `agentWorkspace`, session caches). Tests can inject stubs via `setOverrides()` |
 | `src/driver/*` | Minimal-dependency primitives per capability; only call into `cdp()` |
 | `src/learning/index.ts` | Discovers and loads `learnings/<site>/`, exposes `runSiteTool` / `runSiteBrowserTool` |

--- a/package/ego-browser/src/browser-runtime.test.mjs
+++ b/package/ego-browser/src/browser-runtime.test.mjs
@@ -303,6 +303,27 @@ test("drainBrowserEvents caps at MAX_BUFFERED_EVENTS (10000)", async () => {
   }
 });
 
+test("drainBrowserEvents stays capped after internal buffer compaction", async () => {
+  const calls = installManualEgo();
+  try {
+    const p = browserCdp("Target.getVersion", {}, undefined, 5000);
+    globalThis.ego.onCDPMessage(
+      JSON.stringify({ id: calls[0].id, result: {} }),
+    );
+    await p;
+
+    for (let i = 0; i < 25050; i++) {
+      fireEvent(`evt.${i}`, {});
+    }
+    const evts = drainBrowserEvents();
+    assert.equal(evts.length, 10000, "buffer remains capped after compaction");
+    assert.equal(evts[0].method, "evt.15050", "oldest events are dropped");
+    assert.equal(evts[evts.length - 1].method, "evt.25049");
+  } finally {
+    cleanup();
+  }
+});
+
 /* ------------------------------------------------------------------ */
 /*  Dialog tracking                                                   */
 /* ------------------------------------------------------------------ */

--- a/package/ego-browser/src/browser-runtime.ts
+++ b/package/ego-browser/src/browser-runtime.ts
@@ -1,4 +1,4 @@
-import { state } from "./state.js";
+import { runtimeState as state } from "./runtime-state.js";
 import { assertNoEgoError, buildEgoError } from "./ego-errors.js";
 
 const RESPONSE_TIMEOUT_MS = 15000;
@@ -6,6 +6,10 @@ const SESSION_TTL_MS = 2000;
 // Upper bound for buffered CDP events. The runtime can be long-lived (installEgoSdk
 // inside the browser); without a cap, undrained events grow without bound.
 const MAX_BUFFERED_EVENTS = 10000;
+// Dropped events are represented by an advancing head index so sustained CDP
+// traffic does not shift a 10k-element array on every new event. Compact in
+// batches to keep retained memory bounded while preserving an exact 10k cap.
+const EVENT_COMPACTION_THRESHOLD = 1024;
 const SESSION_LOST =
   /Session (?:with given id )?not found|Target closed|No session/i;
 const BROWSER_LEVEL = (method) =>
@@ -14,6 +18,7 @@ let nextMessageId = 1;
 const pending = new Map();
 const events = [];
 const eventWaiters = [];
+let eventHead = 0;
 const pageEnabledSessions = new Set();
 const pendingDialogs = new Map();
 export function isBrowserRuntime() {
@@ -156,7 +161,9 @@ export function clearPreferredTarget() {
 }
 
 export function drainBrowserEvents() {
-  const out = events.splice(0, events.length);
+  const out = events.slice(eventHead);
+  events.length = 0;
+  eventHead = 0;
   return out;
 }
 
@@ -259,8 +266,12 @@ function handleMessage(message) {
     }
   }
   events.push(data);
-  if (events.length > MAX_BUFFERED_EVENTS) {
-    events.splice(0, events.length - MAX_BUFFERED_EVENTS);
+  if (events.length - eventHead > MAX_BUFFERED_EVENTS) {
+    eventHead += 1;
+  }
+  if (eventHead >= EVENT_COMPACTION_THRESHOLD) {
+    events.splice(0, eventHead);
+    eventHead = 0;
   }
   for (const waiter of [...eventWaiters]) {
     let matched = false;

--- a/package/ego-browser/src/cdp-eval.test.mjs
+++ b/package/ego-browser/src/cdp-eval.test.mjs
@@ -412,6 +412,61 @@ test("evaluate attaches to a target session when legacy target id is given", asy
       "(function(){return document.title})()",
     );
     assert.equal(calls[1][2], "sess-123");
+    assert.equal(calls[2][0], "Target.detachFromTarget");
+    assert.deepEqual(calls[2][1], { sessionId: "sess-123" });
+  } finally {
+    restore();
+  }
+});
+
+test("evaluate detaches a target session when evaluation fails", async () => {
+  const calls = [];
+  const restore = setOverrides({
+    cdpOverride: async (method, params, sessionId) => {
+      calls.push([method, params, sessionId]);
+      if (method === "Target.attachToTarget") {
+        return { sessionId: "sess-failed" };
+      }
+      if (method === "Runtime.evaluate") {
+        throw new Error("evaluation failed");
+      }
+      return {};
+    },
+  });
+  try {
+    await assert.rejects(
+      () => evaluate("document.title", "target-abc"),
+      /evaluation failed/,
+    );
+    assert.equal(calls.at(-1)[0], "Target.detachFromTarget");
+    assert.deepEqual(calls.at(-1)[1], { sessionId: "sess-failed" });
+  } finally {
+    restore();
+  }
+});
+
+test("evaluate does not detach after a task-space hard stop", async () => {
+  const calls = [];
+  const restore = setOverrides({
+    cdpOverride: async (method, params, sessionId) => {
+      calls.push([method, params, sessionId]);
+      if (method === "Target.attachToTarget") {
+        return { sessionId: "sess-user-control" };
+      }
+      const error = new Error("user is controlling");
+      error.error_code = "EGO_TASK_SPACE_USER_IN_CONTROL";
+      throw error;
+    },
+  });
+  try {
+    await assert.rejects(
+      () => evaluate("document.title", "target-abc"),
+      (error) => error.error_code === "EGO_TASK_SPACE_USER_IN_CONTROL",
+    );
+    assert.deepEqual(
+      calls.map(([method]) => method),
+      ["Target.attachToTarget", "Runtime.evaluate"],
+    );
   } finally {
     restore();
   }

--- a/package/ego-browser/src/cdp-eval.ts
+++ b/package/ego-browser/src/cdp-eval.ts
@@ -1,4 +1,5 @@
 import { send, state } from "./state.js";
+import { isEgoHardStopError } from "./ego-errors.js";
 
 class TimeoutError extends Error {}
 
@@ -61,7 +62,28 @@ export async function evaluate(pageFunction, arg = undefined) {
   if (hasReturnStatement(expression) && !expression.trim().startsWith("(")) {
     expression = `(function(){${expression}})()`;
   }
-  return runtimeEvaluate(expression, sessionId, true);
+  let shouldDetach = true;
+  try {
+    return await runtimeEvaluate(expression, sessionId, true);
+  } catch (error) {
+    // A user takeover/inactive task is a hard stop. Do not issue a cleanup
+    // command after it; the session will be reclaimed with the task context.
+    shouldDetach = !isEgoHardStopError(error);
+    throw error;
+  } finally {
+    if (sessionId && shouldDetach) {
+      await detachTemporarySession(sessionId);
+    }
+  }
+}
+
+async function detachTemporarySession(sessionId) {
+  try {
+    await cdp("Target.detachFromTarget", { sessionId });
+  } catch {
+    // The target or browser may already be gone. Cleanup must not replace the
+    // evaluation result (or its original error) with a secondary detach error.
+  }
 }
 
 async function runtimeEvaluate(

--- a/package/ego-browser/src/runtime-state.ts
+++ b/package/ego-browser/src/runtime-state.ts
@@ -1,0 +1,19 @@
+/**
+ * Mutable state shared by the CDP runtime and the wider helper surface.
+ *
+ * Keeping the transport-facing fields in this dependency-free module prevents
+ * state.ts and browser-runtime.ts from importing each other. state.ts augments
+ * this same object with filesystem, platform, and test hooks.
+ */
+export const runtimeState = {
+  cdpOverride: null,
+  now: () => Date.now(),
+  sessionId: null,
+  sessionTargetId: null,
+  sessionAt: 0,
+  sessionInflight: null,
+  preferredTargetId: null,
+  defaultTimeout: 10000,
+  // Last observed Network domain state on the default session (tracked in cdp()).
+  networkDomainEnabled: false,
+};

--- a/package/ego-browser/src/site-tools.test.mjs
+++ b/package/ego-browser/src/site-tools.test.mjs
@@ -1,0 +1,196 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { searchAndExtract } from "../../../skills/ego-browser/learnings/google/tools/search-extract.js";
+import { getBookmarks } from "../../../skills/ego-browser/learnings/x-com/tools/bookmarks.js";
+import { getPost } from "../../../skills/ego-browser/learnings/x-com/tools/post.js";
+import { searchUsers } from "../../../skills/ego-browser/learnings/x-com/tools/search-users.js";
+import { getTimelinePosts } from "../../../skills/ego-browser/learnings/x-com/tools/timeline.js";
+
+test("Node site tools use the Playwright-style helper facades", async () => {
+  const opened = [];
+  let evaluations = 0;
+  const ctx = {
+    browser: {
+      async openOrReuseTab(url) {
+        opened.push(url);
+      },
+    },
+    page: {
+      async waitForLoadState() {},
+      locator() {
+        return {
+          async evaluateAll() {
+            evaluations += 1;
+            return [];
+          },
+        };
+      },
+    },
+  };
+
+  await searchAndExtract(ctx, { query: "browser agent" });
+  await searchUsers(ctx, { query: "openai" });
+  await getTimelinePosts(ctx, { maxPosts: 10 });
+
+  assert.equal(opened.length, 2);
+  assert.equal(evaluations, 3);
+  assert.equal("evaluate" in ctx, false);
+  assert.equal("openOrReuseTab" in ctx, false);
+});
+
+test("getBookmarks scrolls, deduplicates, and stops at the item limit", async () => {
+  const first = post("1", "first");
+  const second = post("2", "second");
+  const third = post("3", "third");
+  const batches = [
+    [first, second],
+    [second, third],
+  ];
+  let batchIndex = 0;
+  let openedUrl = "";
+  const ctx = {
+    browser: {
+      async openOrReuseTab(url) {
+        openedUrl = url;
+      },
+    },
+    page: {
+      async url() {
+        return "https://x.com/i/bookmarks";
+      },
+      async evaluate() {},
+      locator() {
+        return {
+          async evaluateAll() {
+            return batches[batchIndex];
+          },
+        };
+      },
+      mouse: {
+        async wheel() {
+          batchIndex = Math.min(batchIndex + 1, batches.length - 1);
+        },
+      },
+      async waitForTimeout() {},
+    },
+  };
+
+  const result = await getBookmarks(ctx, {
+    maxPosts: 3,
+    maxScrolls: 10,
+    waitMs: 100,
+  });
+
+  assert.equal(openedUrl, "https://x.com/i/bookmarks");
+  assert.deepEqual(
+    result.items.map((item) => item.id),
+    ["1", "2", "3"],
+  );
+  assert.deepEqual(
+    { count: result.count, scrolls: result.scrolls, reason: result.reason },
+    { count: 3, scrolls: 1, reason: "limit" },
+  );
+});
+
+test("getBookmarks reports login redirects instead of an empty collection", async () => {
+  const ctx = {
+    browser: { async openOrReuseTab() {} },
+    page: {
+      async url() {
+        return "https://x.com/i/flow/login";
+      },
+    },
+  };
+
+  await assert.rejects(() => getBookmarks(ctx), /requires a signed-in session/);
+});
+
+test("getBookmarks stops after bounded idle scrolls", async () => {
+  const ctx = {
+    browser: { async openOrReuseTab() {} },
+    page: {
+      async url() {
+        return "https://x.com/i/bookmarks";
+      },
+      locator() {
+        return {
+          async evaluateAll() {
+            return [post("1", "only bookmark")];
+          },
+        };
+      },
+      mouse: { async wheel() {} },
+      async waitForTimeout() {},
+    },
+  };
+
+  const result = await getBookmarks(ctx, {
+    maxPosts: 10,
+    maxScrolls: 10,
+    idleScrolls: 2,
+    fromTop: false,
+  });
+  assert.deepEqual(
+    { count: result.count, scrolls: result.scrolls, reason: result.reason },
+    { count: 1, scrolls: 2, reason: "idle" },
+  );
+});
+
+test("getPost selects the requested status and returns article content", async () => {
+  const posts = [post("1", "reply"), post("2", "requested")];
+  const article = {
+    title: "Long article",
+    body: "Article body",
+    truncated: false,
+    images: [],
+  };
+  const ctx = {
+    browser: { async openOrReuseTab() {} },
+    page: {
+      async url() {
+        return "https://x.com/example/status/2";
+      },
+      locator() {
+        return {
+          async evaluateAll() {
+            return posts;
+          },
+        };
+      },
+      async evaluate() {
+        return article;
+      },
+    },
+  };
+
+  const result = await getPost(ctx, {
+    url: "https://x.com/example/status/2",
+  });
+  assert.equal(result.id, "2");
+  assert.equal(result.text, "requested");
+  assert.deepEqual(result.article, article);
+});
+
+test("getPost rejects lookalike non-X hosts", async () => {
+  await assert.rejects(
+    () =>
+      getPost(
+        { browser: { async openOrReuseTab() {} } },
+        { url: "https://x.com.example.org/user/status/1" },
+      ),
+    /valid X URL required/,
+  );
+});
+
+function post(id, text) {
+  return {
+    id,
+    url: `https://x.com/example/status/${id}`,
+    text,
+    author: "Example",
+    handle: "@example",
+    timestamp: "2026-07-10T00:00:00.000Z",
+    links: [],
+  };
+}

--- a/package/ego-browser/src/state.ts
+++ b/package/ego-browser/src/state.ts
@@ -2,6 +2,7 @@ import { writeFile } from "node:fs/promises";
 
 import { agentWorkspace, loadEnv } from "./env.js";
 import { browserCdp } from "./browser-runtime.js";
+import { runtimeState } from "./runtime-state.js";
 
 loadEnv();
 
@@ -21,23 +22,13 @@ async function defaultSend(req) {
   return { result: response.result || {} };
 }
 
-export const state = {
+export const state = Object.assign(runtimeState, {
   send: defaultSend,
-  cdpOverride: null,
-  now: () => Date.now(),
   sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   platform: process.platform,
   agentWorkspace: () => agentWorkspace(),
   writeFile,
-  sessionId: null,
-  sessionTargetId: null,
-  sessionAt: 0,
-  sessionInflight: null,
-  preferredTargetId: null,
-  defaultTimeout: 10000,
-  // Last observed Network domain state on the default session (tracked in cdp()).
-  networkDomainEnabled: false,
-};
+});
 
 export async function send(req) {
   return state.send(req);

--- a/skills/ego-browser/learnings/package.json
+++ b/skills/ego-browser/learnings/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "ego-browser-learnings",
+  "private": true,
+  "type": "module"
+}

--- a/skills/ego-browser/learnings/x-com/manifest.json
+++ b/skills/ego-browser/learnings/x-com/manifest.json
@@ -2,8 +2,65 @@
   "id": "x-com",
   "name": "X (Twitter)",
   "domains": ["x.com", "*.x.com", "twitter.com", "*.twitter.com"],
-  "notes": ["notes/overview.md", "notes/timeline.md"],
+  "notes": ["notes/overview.md", "notes/timeline.md", "notes/bookmarks.md"],
   "nodeTools": {
+    "get_bookmarks": {
+      "description": "Collect signed-in X bookmarks across virtualized scrolling with deduplication and bounded work.",
+      "path": "tools/bookmarks.js",
+      "callable": "getBookmarks",
+      "args": {
+        "maxPosts": {
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of unique bookmarks to collect (1-500)."
+        },
+        "maxScrolls": {
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of timeline scrolls (1-200)."
+        },
+        "idleScrolls": {
+          "type": "integer",
+          "required": false,
+          "description": "Stop after this many scrolls produce no new bookmarks (1-10)."
+        },
+        "waitMs": {
+          "type": "integer",
+          "required": false,
+          "description": "Wait between virtual-list scrolls in milliseconds (100-5000)."
+        },
+        "fromTop": {
+          "type": "boolean",
+          "required": false,
+          "description": "Start from the newest bookmarks at the top of the page."
+        }
+      },
+      "returns": {
+        "type": "object",
+        "description": "Object with items, count, scrolls, and stop reason."
+      }
+    },
+    "get_post": {
+      "description": "Extract a specific X post and any expanded long-form article content.",
+      "path": "tools/post.js",
+      "callable": "getPost",
+      "args": {
+        "url": {
+          "type": "string",
+          "required": false,
+          "description": "X post or article URL; defaults to the current X page."
+        },
+        "maxArticleChars": {
+          "type": "integer",
+          "required": false,
+          "description": "Maximum long-form article characters to return (1000-200000)."
+        }
+      },
+      "returns": {
+        "type": "object",
+        "description": "Post metadata and optional expanded article content."
+      }
+    },
     "get_timeline_posts": {
       "description": "Extract posts from the current X timeline using the anti-click-wrap pattern.",
       "path": "tools/timeline.js",
@@ -17,7 +74,7 @@
       },
       "returns": {
         "type": "array",
-        "description": "Array of post objects with text, author, and timestamp."
+        "description": "Array of post objects with id, URL, text, author, handle, timestamp, and links."
       }
     },
     "search_users": {

--- a/skills/ego-browser/learnings/x-com/notes/bookmarks.md
+++ b/skills/ego-browser/learnings/x-com/notes/bookmarks.md
@@ -1,0 +1,21 @@
+# X Bookmarks and Articles
+
+## Reading bookmarks
+
+- X bookmarks live at `https://x.com/i/bookmarks` and require the active browser profile to be signed in.
+- The page is a virtualized timeline: only the visible posts and a small buffer remain in the DOM.
+- Use `runSiteTool("x-com", "get_bookmarks", { maxPosts: 100 })` to scroll, deduplicate by status id/URL, and stop after bounded idle rounds.
+- Results include stable post ids and URLs so callers can persist a cursor and avoid reprocessing older bookmarks.
+
+## Reading a post or long article
+
+- Use `runSiteTool("x-com", "get_post", { url })` for a status or article page.
+- The tool matches the main status id instead of assuming the first conversation card is the requested post.
+- Expanded X Articles are returned under `article`; ordinary posts return `article: null`.
+- Article bodies are bounded by `maxArticleChars` to prevent unexpectedly large model inputs.
+
+## Safety and reliability
+
+- These tools only read content available to the signed-in profile; they do not call private credentials or expose cookies.
+- Login redirects are reported as errors instead of being mistaken for empty bookmark collections.
+- Bookmark collection stops on an item limit, scroll limit, or repeated scrolls with no new ids.

--- a/skills/ego-browser/learnings/x-com/tools/bookmarks.js
+++ b/skills/ego-browser/learnings/x-com/tools/bookmarks.js
@@ -1,0 +1,91 @@
+import { boundedInteger, extractVisiblePosts } from "./post-data.js";
+
+const BOOKMARKS_URL = "https://x.com/i/bookmarks";
+
+export async function getBookmarks(ctx, args = {}) {
+  const maxPosts = boundedInteger(args.maxPosts, 100, 500);
+  const maxScrolls = boundedInteger(args.maxScrolls, 30, 200);
+  const idleScrolls = boundedInteger(args.idleScrolls, 3, 10);
+  const waitMs = boundedInteger(args.waitMs, 800, 5000, 100);
+  const fromTop = args.fromTop !== false;
+
+  await ctx.browser.openOrReuseTab(BOOKMARKS_URL, {
+    match: "origin+path",
+    wait: true,
+    timeout: 20000,
+  });
+  const currentUrl = await ctx.page.url();
+  if (!isBookmarksPage(currentUrl)) {
+    throw new Error(
+      `X bookmarks requires a signed-in session; current page is ${JSON.stringify(currentUrl || "unknown")}`,
+    );
+  }
+
+  if (fromTop) {
+    await ctx.page.evaluate(() =>
+      window.scrollTo({ top: 0, behavior: "auto" }),
+    );
+    await ctx.page.waitForTimeout(waitMs);
+  }
+
+  const posts = new Map();
+  let scrolls = 0;
+  let idleRounds = 0;
+  let reason = "scroll-limit";
+
+  for (let round = 0; round <= maxScrolls; round += 1) {
+    const batch = await extractVisiblePosts(ctx.page, maxPosts);
+    const sizeBefore = posts.size;
+    for (const post of batch || []) {
+      const key = postKey(post);
+      if (key && !posts.has(key)) posts.set(key, post);
+      if (posts.size >= maxPosts) break;
+    }
+
+    if (posts.size >= maxPosts) {
+      reason = "limit";
+      break;
+    }
+    if (round === maxScrolls) break;
+
+    idleRounds = posts.size === sizeBefore ? idleRounds + 1 : 0;
+    if (idleRounds >= idleScrolls) {
+      reason = "idle";
+      break;
+    }
+
+    await ctx.page.mouse.wheel(0, 1200);
+    scrolls += 1;
+    await ctx.page.waitForTimeout(waitMs);
+  }
+
+  const items = [...posts.values()].slice(0, maxPosts);
+  return { items, count: items.length, scrolls, reason };
+}
+
+function isBookmarksPage(value) {
+  try {
+    const url = new URL(value);
+    return isXHostname(url.hostname) && url.pathname.startsWith("/i/bookmarks");
+  } catch {
+    return false;
+  }
+}
+
+function isXHostname(hostname) {
+  return (
+    hostname === "x.com" ||
+    hostname.endsWith(".x.com") ||
+    hostname === "twitter.com" ||
+    hostname.endsWith(".twitter.com")
+  );
+}
+
+function postKey(post) {
+  if (!post || typeof post !== "object") return "";
+  return (
+    post.id ||
+    post.url ||
+    [post.handle, post.timestamp, post.text].filter(Boolean).join("\u0000")
+  );
+}

--- a/skills/ego-browser/learnings/x-com/tools/post-data.js
+++ b/skills/ego-browser/learnings/x-com/tools/post-data.js
@@ -1,0 +1,86 @@
+export function boundedInteger(value, fallback, max, min = 1) {
+  const number = value === undefined ? fallback : Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.max(min, Math.min(max, Math.trunc(number)));
+}
+
+export function extractVisiblePosts(page, maxPosts = 100) {
+  const limit = boundedInteger(maxPosts, 100, 500);
+  return page
+    .locator('[data-testid="tweet"]')
+    .evaluateAll((articles, itemLimit) => {
+      const absoluteUrl = (value) => {
+        if (!value) return "";
+        try {
+          return new URL(value, location.origin).href;
+        } catch {
+          return "";
+        }
+      };
+      return articles
+        .slice(0, itemLimit)
+        .map((el) => {
+          const textEl = el.querySelector('[data-testid="tweetText"]');
+          const userNameEl = el.querySelector('[data-testid="User-Name"]');
+          const labels = [...(userNameEl?.querySelectorAll("span") || [])]
+            .map((span) => span.innerText?.trim() || "")
+            .filter(Boolean);
+          const time = el.querySelector("time");
+          const statusLink =
+            time?.closest("a") ||
+            [...el.querySelectorAll('a[href*="/status/"]')][0];
+          const statusPath = statusLink?.getAttribute("href") || "";
+          const statusMatch = statusPath.match(/\/([^/]+)\/status\/(\d+)/);
+          const links = [...(textEl?.querySelectorAll("a") || [])]
+            .map((link) => ({
+              text: link.innerText?.trim() || "",
+              url: absoluteUrl(link.getAttribute("href")),
+            }))
+            .filter((link) => link.url);
+          return {
+            id: statusMatch?.[2] || "",
+            url: absoluteUrl(statusPath),
+            text: textEl?.innerText?.trim() || "",
+            author: labels.find((label) => !label.startsWith("@")) || "",
+            handle:
+              labels.find((label) => label.startsWith("@")) ||
+              (statusMatch?.[1] ? `@${statusMatch[1]}` : ""),
+            timestamp: time?.getAttribute("datetime") || "",
+            links,
+          };
+        })
+        .filter((post) => post.id || post.url || post.text || post.author);
+    }, limit);
+}
+
+export function extractArticle(page, maxChars = 50000) {
+  const limit = boundedInteger(maxChars, 50000, 200000, 1000);
+  return page.evaluate((articleLimit) => {
+    const bodyRoot = document.querySelector(
+      '[data-testid="twitterArticleRichTextView"], [data-testid="longformRichText"], [data-testid="articleBody"]',
+    );
+    const readRoot = document.querySelector(
+      '[data-testid="twitterArticleReadView"]',
+    );
+    const root = readRoot || bodyRoot;
+    if (!root) return null;
+    const title =
+      (readRoot || document)
+        .querySelector('[data-testid="twitterArticleTitle"], h1')
+        ?.innerText?.trim() || "";
+    const fullText = (bodyRoot || root).innerText?.trim() || "";
+    const images = [...root.querySelectorAll("img")]
+      .map((img) => ({
+        src: img.currentSrc || img.src || "",
+        alt: img.alt || "",
+      }))
+      .filter((image) => image.src)
+      .slice(0, 20);
+    return {
+      title,
+      body: fullText.slice(0, articleLimit),
+      truncated: fullText.length > articleLimit,
+      images,
+    };
+  }, limit);
+}

--- a/skills/ego-browser/learnings/x-com/tools/post.js
+++ b/skills/ego-browser/learnings/x-com/tools/post.js
@@ -1,0 +1,63 @@
+import {
+  boundedInteger,
+  extractArticle,
+  extractVisiblePosts,
+} from "./post-data.js";
+
+export async function getPost(ctx, args = {}) {
+  const requestedUrl = String(args.url || "").trim();
+  if (requestedUrl) {
+    assertXUrl(requestedUrl);
+    await ctx.browser.openOrReuseTab(requestedUrl, {
+      wait: true,
+      timeout: 20000,
+    });
+  }
+
+  const pageUrl = await ctx.page.url();
+  assertXUrl(pageUrl || "");
+  const currentId = statusId(pageUrl);
+  const visiblePosts = await extractVisiblePosts(ctx.page, 50);
+  const post =
+    visiblePosts.find((item) => item.id && item.id === currentId) ||
+    visiblePosts[0] ||
+    null;
+  const maxArticleChars = boundedInteger(
+    args.maxArticleChars,
+    50000,
+    200000,
+    1000,
+  );
+  const article = await extractArticle(ctx.page, maxArticleChars);
+
+  if (!post && !article) {
+    throw new Error("no X post or article content found on the current page");
+  }
+  return { ...(post || { url: pageUrl }), article };
+}
+
+function assertXUrl(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`valid X URL required, got ${JSON.stringify(value)}`);
+  }
+  const hostname = url.hostname.toLowerCase();
+  const isX =
+    hostname === "x.com" ||
+    hostname.endsWith(".x.com") ||
+    hostname === "twitter.com" ||
+    hostname.endsWith(".twitter.com");
+  if (!isX || !["http:", "https:"].includes(url.protocol)) {
+    throw new Error(`valid X URL required, got ${JSON.stringify(value)}`);
+  }
+}
+
+function statusId(value) {
+  try {
+    return new URL(value).pathname.match(/\/status\/(\d+)/)?.[1] || "";
+  } catch {
+    return "";
+  }
+}

--- a/skills/ego-browser/learnings/x-com/tools/timeline.js
+++ b/skills/ego-browser/learnings/x-com/tools/timeline.js
@@ -1,32 +1,6 @@
-function boundedInteger(value, fallback, max) {
-  const number = value === undefined ? fallback : Number(value);
-  if (!Number.isFinite(number)) return fallback;
-  return Math.max(1, Math.min(max, Math.trunc(number)));
-}
+import { boundedInteger, extractVisiblePosts } from "./post-data.js";
 
 export async function getTimelinePosts(ctx, args = {}) {
   const maxPosts = boundedInteger(args.maxPosts, 50, 100);
-
-  const posts = await ctx.page
-    .locator('[data-testid="tweet"]')
-    .evaluateAll((articles, limit) => {
-      return articles.slice(0, limit).map((el) => ({
-        text:
-          el.querySelector('[data-testid="tweetText"]')?.innerText?.trim() ||
-          "",
-        author:
-          el
-            .querySelector('[data-testid="User-Name"]')
-            ?.querySelector("span")
-            ?.innerText?.trim() || "",
-        handle:
-          el
-            .querySelector('[data-testid="User-Name"]')
-            ?.querySelector("a")
-            ?.getAttribute("href") || "",
-        timestamp: el.querySelector("time")?.getAttribute("datetime") || "",
-      }));
-    }, maxPosts);
-
-  return posts;
+  return extractVisiblePosts(ctx.page, maxPosts);
 }


### PR DESCRIPTION
## Summary

- add signed-in X bookmark collection with virtual-scroll deduplication, bounded work, and login-redirect detection
- add X post and expanded article extraction with stable status matching and output limits
- improve CDP runtime behavior by detaching temporary target sessions, removing the state/runtime circular dependency, and amortizing event-buffer compaction
- add Playwright-facade integration coverage, X usage notes, and a root CHANGELOG

## Why

ego-browser can reuse a user's authenticated browser state, but the bundled X learning lacked durable bookmark and long-form reading primitives. Long-running runtime paths also retained temporary sessions and shifted the full 10k event buffer for every overflow event.

## Developer impact

The X site skill now exposes:

- `get_bookmarks`
- `get_post`
- richer `get_timeline_posts` records with ids, URLs, handles, timestamps, and links

Existing helper behavior remains compatible. Task-space hard stops still prevent follow-up cleanup commands after user takeover.

## Validation

- `npm test` — 253/253 passing
- `npm run validate:site-skills`
- TypeScript typecheck
- Prettier check
- `npm audit` — 0 vulnerabilities
- Real-browser E2E was not run because the closed-source ego lite app / `ego-browser` command is not installed in the test environment
