### PR TITLE
Align Codex and Claude plugin versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,6 +13,7 @@
   "plugins": [
     {
       "name": "browser-skills",
+      "version": "1.2.5",
       "description": "Automates browser interactions for web testing, form filling, screenshots, and data extraction",
       "source": "./",
       "strict": false,

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "ego-lite",
+  "version": "1.2.5",
+  "description": "Browser automation for AI agents through ego lite.",
+  "author": {
+    "name": "CitroLabs",
+    "email": "contact@citrolabs.ai",
+    "url": "https://github.com/citrolabs"
+  },
+  "homepage": "https://lite.ego.app/document/",
+  "repository": "https://github.com/citrolabs/ego-lite",
+  "license": "MIT",
+  "keywords": ["browser-automation", "ai-agents", "ego-browser"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "ego-browser",
+    "shortDescription": "Automate authenticated browser tasks with ego lite.",
+    "longDescription": "Use Codex to navigate websites, fill forms, capture screenshots, extract structured data, and test web apps in isolated ego lite task spaces.",
+    "developerName": "CitroLabs",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Browser automation",
+      "Authenticated sessions",
+      "Parallel task spaces",
+      "Interactive confirmations"
+    ],
+    "defaultPrompt": [
+      "Open a website and complete a browser task for me.",
+      "Test this web app and report any usability issues.",
+      "Extract structured data from this page."
+    ],
+    "brandColor": "#1E90FF"
+  }
+}


### PR DESCRIPTION
## Summary

- add the Codex plugin manifest at version 1.2.5
- set the Claude browser-skills plugin version to 1.2.5
- omit the unused Codex MCP server configuration

## Validation

- Codex plugin validation
- Claude plugin validation
- npm test
- pre-commit hooks