### PR TITLE
test(ego-browser): cover bare Meta input isolation

### DIFF
--- a/package/ego-browser/scripts/real-browser-e2e/cases/index.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/cases/index.mjs
@@ -12,6 +12,7 @@ import {
 } from "./pointer.mjs";
 import { keyboardCase } from "./keyboard.mjs";
 import { keyboardRegressionCase } from "./keyboard-regression.mjs";
+import { macosInputRegressionCase } from "./macos-input-regression.mjs";
 import {
   cdpJsHelpCase,
   fetchHelpersCase,
@@ -40,6 +41,10 @@ export const e2eCases = [
   },
   { name: "keyboard and file helpers", body: keyboardCase },
   { name: "keyboard regression", body: keyboardRegressionCase },
+  {
+    name: "macOS bare Meta input isolation",
+    body: macosInputRegressionCase,
+  },
   { name: "wait helpers", body: waitHelpersCase },
   { name: "fetch helpers", body: fetchHelpersCase },
   { name: "cdp js help", body: cdpJsHelpCase },

--- a/package/ego-browser/scripts/real-browser-e2e/cases/macos-input-regression.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/cases/macos-input-regression.mjs
@@ -1,0 +1,69 @@
+export function macosInputRegressionCase() {
+  return `
+    assertEqual(process.platform, "darwin", "bare Meta input isolation runs on macOS");
+
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const execFileAsync = promisify(execFile);
+
+    async function isSystemInformationRunning() {
+      const { stdout } = await execFileAsync("/usr/bin/lsappinfo", ["list"]);
+      return /bundleID="com\\.apple\\.SystemProfiler"/.test(stdout);
+    }
+
+    await taskSpaces.useOrCreate(taskName);
+    await resetHome();
+
+    const systemInformationWasRunning = await isSystemInformationRunning();
+    assertEqual(
+      systemInformationWasRunning,
+      false,
+      "System Information is closed before the bare Meta input probe"
+    );
+
+    let systemInformationLaunched = false;
+    try {
+      await cdp("Input.dispatchKeyEvent", {
+        type: "keyDown",
+        key: "Meta",
+        code: "MetaLeft",
+        windowsVirtualKeyCode: 91,
+        nativeVirtualKeyCode: 55,
+        metaKey: true,
+        modifiers: 4,
+      });
+      await cdp("Input.dispatchKeyEvent", {
+        type: "keyUp",
+        key: "Meta",
+        code: "MetaLeft",
+        windowsVirtualKeyCode: 91,
+        nativeVirtualKeyCode: 55,
+        metaKey: false,
+        modifiers: 0,
+      });
+
+      const deadline = Date.now() + 2000;
+      while (Date.now() <= deadline) {
+        systemInformationLaunched = await isSystemInformationRunning();
+        if (systemInformationLaunched) break;
+        await page.waitForTimeout(100);
+      }
+    } finally {
+      systemInformationLaunched =
+        systemInformationLaunched ||
+        (await isSystemInformationRunning().catch(() => false));
+      if (!systemInformationWasRunning && systemInformationLaunched) {
+        await execFileAsync("/usr/bin/osascript", [
+          "-e",
+          'tell application id "com.apple.SystemProfiler" to quit',
+        ]);
+      }
+    }
+
+    assertEqual(
+      systemInformationLaunched,
+      false,
+      "raw Meta CDP input does not launch macOS System Information"
+    );
+  `;
+}


### PR DESCRIPTION
## Summary

- add a macOS real-browser regression case for bare Meta CDP key events
- verify the input remains isolated and does not launch macOS System Information
- clean up a System Information instance launched by a failing regression probe
- register the case in the default real-browser E2E suite

## Why

Raw modifier input crosses the native browser boundary, so unit-level CDP parameter assertions cannot detect system-level side effects. This test exercises the installed Ego runtime with the SDK built from the checkout and observes the macOS application state directly.

## Validation

- `npm run e2e` — 34/34 cases passed, 452 assertions
- `npm test` — 250/250 tests passed
- TypeScript typecheck passed
- site-skill validation passed
- Prettier check passed
- dependency vulnerability audit reported 0 vulnerabilities