### PR TITLE
fix(ego-browser): align role locator match sets

### DIFF
--- a/package/ego-browser/scripts/real-browser-e2e/cases/helper-surface.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/cases/helper-surface.mjs
@@ -59,6 +59,21 @@ export function helperSurfaceCase() {
     assertEqual(await page.locator("#text-input").inputValue(), "from placeholder", "getByPlaceholder targets the input");
     assertEqual(await page.getByAltText("Ego fixture logo").count(), 1, "getByAltText finds the image");
     assertEqual(await page.getByTitle("Counter button").count(), 1, "getByTitle finds titled elements");
+    // Role-locator match-set consistency (the Redfin "Locator miss" regression).
+    // The listbox holds two visible "House" options plus one display:none dupe.
+    // A DOM role scan counts all three (no visibility filtering); the AX tree
+    // ignores the hidden one. count()/nth()/click() must all agree on the same
+    // AX set, otherwise "read count, act on the last index" targets past the end.
+    const houseOptions = page.getByRole("option", { name: "House" });
+    const houseCount = await houseOptions.count();
+    assertEqual(houseCount, 2, "count() reports only AX-actionable options (display:none dupe excluded)");
+    assertEqual(await houseOptions.nth(houseCount - 1).innerText(), "House", "nth reads from the same AX match set count() used");
+    await houseOptions.nth(houseCount - 1).click();
+    assertEqual(
+      await houseOptions.nth(houseCount - 1).getAttribute("aria-selected"),
+      "true",
+      "the option count() calls last is exactly the one nth()/click() targets"
+    );
     assertEqual(await page.locator("text=Download sample").count(), 1, "text= locator compatibility works"); // agent-style-ok: compatibility check
     const extracted = await page.locator(".card").first().evaluateAll((cards) =>
       cards.map((card) => ({

--- a/package/ego-browser/scripts/real-browser-e2e/fixture.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/fixture.mjs
@@ -402,6 +402,12 @@ function pageHtml(kind) {
         <button class="duplicate-action" type="button">Duplicate action</button>
         <a id="nav-link" href="/nav-target" style="margin-left:8px">Go to nav target</a>
         <a id="download-link" href="/download/sample.txt" download style="margin-left:8px">Download sample</a>
+        <div id="home-type-listbox" role="listbox" aria-label="Home type" style="display:inline-flex;gap:6px;margin-left:8px">
+          <button id="house-option-primary" type="button" role="option" aria-selected="false">House</button>
+          <button id="house-option-secondary" type="button" role="option" aria-selected="false">House</button>
+          <!-- Hidden responsive-variant dupe: visible to a naive DOM role scan, ignored by the AX tree. -->
+          <button id="house-option-hidden" type="button" role="option" aria-selected="false" style="display:none">House</button>
+        </div>
       </div>
 
       <div class="card-row">
@@ -560,6 +566,14 @@ function pageHtml(kind) {
         window.__fixtureState.doubleClicks += 1;
         window.__fixtureState.lastDoubleClickDetail = event.detail;
       });
+
+      for (const option of document.querySelectorAll("#home-type-listbox [role=option]")) {
+        option.addEventListener("click", () => {
+          for (const peer of document.querySelectorAll("#home-type-listbox [role=option]")) {
+            peer.setAttribute("aria-selected", String(peer === option));
+          }
+        });
+      }
 
       /* ---- hover zone ---- */
       for (const type of ["mousemove", "mouseover"]) {

--- a/package/ego-browser/src/driver/locator.test.mjs
+++ b/package/ego-browser/src/driver/locator.test.mjs
@@ -150,17 +150,27 @@ test("filter locators support hasText, hasNotText, has, and hasNot", async () =>
   }
 });
 
-test("role locators support regex accessible names in collection queries", async () => {
+test("role locators use AX regex accessible names in collection queries", async () => {
   const selector = `loc=role:button[name=${JSON.stringify({
     regex: "checkout",
     flags: "i",
   })}]`;
+  const calls = [];
   const restore = setOverrides({
     cdpOverride(method, params) {
-      assert.equal(method, "Runtime.evaluate");
-      assert.match(params.expression, /new RegExp\("checkout", "i"\)/);
-      assert.match(params.expression, /accessibleName\(el\)/);
-      return { result: { value: 1 } };
+      calls.push({ method, params });
+      if (method === "Accessibility.getFullAXTree") {
+        return {
+          nodes: [
+            {
+              role: { value: "button" },
+              name: { value: "Proceed to Checkout" },
+              backendDOMNodeId: 101,
+            },
+          ],
+        };
+      }
+      throw new Error(`Unexpected CDP method: ${method}`);
     },
   });
   try {
@@ -168,6 +178,86 @@ test("role locators support regex accessible names in collection queries", async
   } finally {
     restore();
   }
+  assert.deepEqual(
+    calls.map((call) => call.method),
+    ["Accessibility.getFullAXTree"],
+  );
+});
+
+test("role collections use the same AX match set as nth element operations", async () => {
+  const selector = 'loc=role:option[name="House"]';
+  const second = `internal:nth=1;${selector}`;
+  const calls = [];
+  const restore = setOverrides({
+    cdpOverride(method, params) {
+      calls.push({ method, params });
+      if (method === "Accessibility.getFullAXTree") {
+        return {
+          nodes: [
+            {
+              role: { value: "option" },
+              name: { value: "House" },
+              backendDOMNodeId: 100,
+            },
+            {
+              role: { value: "option" },
+              name: { value: "House" },
+              backendDOMNodeId: 200,
+            },
+          ],
+        };
+      }
+      if (method === "DOM.resolveNode") {
+        return { object: { objectId: `node-${params.backendNodeId}` } };
+      }
+      if (method === "Runtime.callFunctionOn") {
+        if (params.functionDeclaration.includes("innerText target")) {
+          assert.equal(params.objectId, "node-200");
+          return { result: { value: "House 2" } };
+        }
+        assert.deepEqual(
+          [
+            params.objectId,
+            ...params.arguments
+              .filter((argument) => argument.objectId)
+              .map((argument) => argument.objectId),
+          ],
+          ["node-100", "node-200"],
+        );
+        const functionSource = params.arguments.find(
+          (argument) =>
+            typeof argument.value === "string" &&
+            argument.value.includes("elements"),
+        )?.value;
+        if (functionSource?.includes("allInnerTexts targets")) {
+          return { result: { value: ["House 1", "House 2"] } };
+        }
+        return { result: { value: ["HOUSE 1", "HOUSE 2"] } };
+      }
+      if (method === "Runtime.releaseObject") {
+        return {};
+      }
+      throw new Error(`Unexpected CDP method: ${method}`);
+    },
+  });
+  try {
+    assert.equal(await count(selector), 2);
+    assert.equal(await count(second), 1);
+    assert.equal(await innerText(second), "House 2");
+    assert.deepEqual(await allInnerTexts(selector), ["House 1", "House 2"]);
+    assert.deepEqual(
+      await evaluateAll(selector, (elements) =>
+        elements.map((element) => element.textContent.toUpperCase()),
+      ),
+      ["HOUSE 1", "HOUSE 2"],
+    );
+  } finally {
+    restore();
+  }
+  assert.equal(
+    calls.some((call) => call.method === "Runtime.evaluate"),
+    false,
+  );
 });
 
 test("raw Playwright has-text selectors filter native CSS candidates", async () => {

--- a/package/ego-browser/src/driver/locator.ts
+++ b/package/ego-browser/src/driver/locator.ts
@@ -1,5 +1,8 @@
 import { cdp, runtimeValue } from "../cdp-eval.js";
-import { ElementResolutionError } from "../element-resolver.js";
+import {
+  ElementResolutionError,
+  queryRoleLocatorBackendNodeIds,
+} from "../element-resolver.js";
 import { queryAllExpression as buildQueryAllExpression } from "../locator-query.js";
 import { parseRef } from "../ref-map.js";
 import { releaseHandle, resolveAndCall, resolveHandle } from "./element-ops.js";
@@ -218,6 +221,10 @@ export async function count(selector) {
     await releaseHandle(handle.objectId, handle.sessionId);
     return 1;
   }
+  const backendNodeIds = await queryRoleBackendNodeIds(selector);
+  if (backendNodeIds !== null) {
+    return backendNodeIds.length;
+  }
   return readQueryAll(selector, "return elements.length;");
 }
 
@@ -286,6 +293,10 @@ export async function evaluateAll(selector, pageFunction, arg = undefined) {
       [functionSource, arg],
     );
   }
+  const backendNodeIds = await queryRoleBackendNodeIds(selector);
+  if (backendNodeIds !== null) {
+    return evaluateRoleBackendNodes(backendNodeIds, functionSource, arg, true);
+  }
   return evaluateQueryAll(selector, functionSource, arg);
 }
 
@@ -311,6 +322,15 @@ async function readOptionalElement(
 }
 
 async function readQueryAll(selector, body) {
+  const backendNodeIds = await queryRoleBackendNodeIds(selector);
+  if (backendNodeIds !== null) {
+    return evaluateRoleBackendNodes(
+      backendNodeIds,
+      `function(elements){${body}}`,
+      undefined,
+      false,
+    );
+  }
   const expression = `(() => {
     const elements = ${buildQueryAllExpression(selector)};
     ${body}
@@ -321,6 +341,73 @@ async function readQueryAll(selector, body) {
     awaitPromise: false,
   });
   return runtimeValue(result, expression);
+}
+
+async function evaluateRoleBackendNodes(
+  backendNodeIds,
+  functionSource,
+  arg,
+  awaitPromise,
+) {
+  if (backendNodeIds.length === 0) {
+    const expression = `(() => {
+      const pageFunction = (0, eval)(${JSON.stringify(`(${functionSource})`)});
+      return pageFunction([], ${serializedArg(arg)});
+    })()`;
+    const result = await cdp("Runtime.evaluate", {
+      expression,
+      returnByValue: true,
+      awaitPromise,
+    });
+    return runtimeValue(result, expression);
+  }
+
+  const handles = [];
+  try {
+    for (const backendNodeId of backendNodeIds) {
+      const result = await cdp("DOM.resolveNode", {
+        backendNodeId,
+        objectGroup: "ego-browser-role-collection",
+      });
+      const objectId = result.object?.objectId;
+      if (!objectId) {
+        throw new ElementResolutionError(
+          `No objectId for AX backend node ${backendNodeId}`,
+          "permanent",
+        );
+      }
+      handles.push({ objectId });
+    }
+
+    const [first, ...rest] = handles;
+    const functionDeclaration = `function(...args) {
+      const functionSource = args.at(-2);
+      const arg = args.at(-1);
+      const elements = [this, ...args.slice(0, -2)];
+      const pageFunction = (0, eval)("(" + functionSource + ")");
+      return pageFunction(elements, arg);
+    }`;
+    const result = await cdp("Runtime.callFunctionOn", {
+      functionDeclaration,
+      objectId: first.objectId,
+      arguments: [
+        ...rest.map(({ objectId }) => ({ objectId })),
+        { value: functionSource },
+        { value: arg },
+      ],
+      returnByValue: true,
+      awaitPromise,
+    });
+    return runtimeValue(result, functionDeclaration);
+  } finally {
+    for (const { objectId } of handles) {
+      await releaseHandle(objectId, undefined);
+    }
+  }
+}
+
+function queryRoleBackendNodeIds(selector) {
+  return queryRoleLocatorBackendNodeIds({ sendRaw: cdp }, undefined, selector);
 }
 
 async function evaluateQueryAll(selector, functionSource, arg) {

--- a/package/ego-browser/src/element-resolver.ts
+++ b/package/ego-browser/src/element-resolver.ts
@@ -10,6 +10,34 @@ export class ElementResolutionError extends Error {
   }
 }
 
+/**
+ * Return the ordered AX backend-node match set for a root role locator.
+ * Non-role selectors return null so callers can use their normal DOM path.
+ */
+export async function queryRoleLocatorBackendNodeIds(
+  cdp,
+  sessionId,
+  selectorOrRef,
+): Promise<number[] | null> {
+  const locator = parseLocator(selectorOrRef);
+  if (locator?.kind !== "role") {
+    return null;
+  }
+  const backendNodeIds = await findBackendNodeIdsByRoleName(
+    cdp,
+    sessionId,
+    locator.role,
+    locator.name,
+  );
+  const nth = locator.nth as number | "last" | undefined;
+  if (nth === undefined) {
+    return backendNodeIds;
+  }
+  const nthIndex = nth === "last" ? backendNodeIds.length - 1 : nth;
+  const backendNodeId = backendNodeIds[nthIndex];
+  return backendNodeId === undefined ? [] : [backendNodeId];
+}
+
 function exceptionText(result: any) {
   const d = result?.exceptionDetails;
   return d?.exception?.description || d?.text || "evaluation error";
@@ -369,6 +397,33 @@ async function findBackendNodeIdByRoleName(
   frameId = undefined,
   iframeSessions = new Map(),
 ) {
+  const matches = await findBackendNodeIdsByRoleName(
+    cdp,
+    sessionId,
+    role,
+    name,
+    frameId,
+    iframeSessions,
+  );
+  const nthIndex = nth === "last" ? matches.length - 1 : (nth ?? 0);
+  const match = matches[nthIndex];
+  if (match !== undefined) {
+    return match;
+  }
+  throw new ElementResolutionError(
+    `Could not locate element with role=${role} name=${name}`,
+    "transient",
+  );
+}
+
+async function findBackendNodeIdsByRoleName(
+  cdp,
+  sessionId,
+  role,
+  name,
+  frameId = undefined,
+  iframeSessions = new Map(),
+): Promise<number[]> {
   const [params, effectiveSessionId] = resolveAxSession(
     frameId,
     sessionId,
@@ -394,42 +449,25 @@ async function findBackendNodeIdByRoleName(
     ) {
       continue;
     }
-    matches.push(node);
-  }
-  const nthIndex = nth === "last" ? matches.length - 1 : (nth ?? 0);
-  const match = matches[nthIndex];
-  if (match) {
-    if (
-      match.backendDOMNodeId === undefined ||
-      match.backendDOMNodeId === null
-    ) {
+    const backendNodeId = node.backendDOMNodeId;
+    if (backendNodeId === undefined || backendNodeId === null) {
       throw new ElementResolutionError(
         `AX node has no backendDOMNodeId for role=${role} name=${name}`,
         "permanent",
       );
     }
-    return match.backendDOMNodeId;
+    matches.push(backendNodeId);
   }
-  throw new ElementResolutionError(
-    `Could not locate element with role=${role} name=${name}`,
-    "transient",
-  );
+  return matches;
 }
 
 async function findUniqueBackendNodeIdByRoleName(cdp, sessionId, role, name) {
-  const result = await send(cdp, "Accessibility.getFullAXTree", {}, sessionId);
-  const matches = [];
-  for (const node of result.nodes || []) {
-    if (node.ignored) {
-      continue;
-    }
-    if (
-      extractAxString(node.role) === role &&
-      (name === undefined || axNameMatches(extractAxString(node.name), name))
-    ) {
-      matches.push(node);
-    }
-  }
+  const matches = await findBackendNodeIdsByRoleName(
+    cdp,
+    sessionId,
+    role,
+    name,
+  );
   if (matches.length === 0) {
     throw new ElementResolutionError(
       `Locator role:${role}[name=${JSON.stringify(name)}] matched 0 elements`,
@@ -442,14 +480,7 @@ async function findUniqueBackendNodeIdByRoleName(cdp, sessionId, role, name) {
       "permanent",
     );
   }
-  const backendNodeId = matches[0].backendDOMNodeId;
-  if (backendNodeId === undefined || backendNodeId === null) {
-    throw new ElementResolutionError(
-      `AX node has no backendDOMNodeId for role=${role} name=${name}`,
-      "permanent",
-    );
-  }
-  return backendNodeId;
+  return matches[0];
 }
 
 function resolveAxSession(frameId, sessionId, iframeSessions) {


### PR DESCRIPTION
## Problem

`role:` locators had two independent match-set implementations that could disagree on the same selector at the same moment:

1. **Single-element ops** (click / getAttribute / waitForSelector / nth resolution) resolved through the real AX tree (`Accessibility.getFullAXTree`), which uses Chromium's computed roles/names and excludes `ignored` (hidden) nodes.
2. **Collection ops** (`count` / `allInnerTexts` / `allTextContents` / `evaluateAll`) ran an injected-JS DOM approximation (`roleElementsExpression`): literal `role` attribute + a partial implicit-role table + a hand-rolled accessible-name algorithm, with **no visibility filtering**.

The two sets diverge on visibility (DOM scan counts `display:none` nodes; AX drops them), role vocabulary (AX emits Chromium role names like `listboxoption` that a DOM attribute scan can never match), and name computation.

The common agent pattern "`count()` then act on `nth(i)`" spans both implementations: it sizes the DOM set but indexes into the AX set. Observed on Redfin's filter dialog (real-world-bench, `rwb-redfin-mortgage-01`), where the same locator returned `count 2` and then failed nth resolution with `Could not locate element with role=button name=Apply` in the same script. Snapshot-suggested `role:listboxoption[...]` locators also always returned 0 from collection queries.

## Fix

Make `findBackendNodeIdsByRoleName` the single source of truth for the ordered AX match set, and delegate everything to it:

- nth resolution (`findBackendNodeIdByRoleName`) and strict resolution (`findUniqueBackendNodeIdByRoleName`) now index into that shared set.
- New `queryRoleLocatorBackendNodeIds` routes root `role:` collection queries (`count` / `readQueryAll` / `evaluateAll`) through the same AX set instead of the DOM approximation; matched backend nodes are materialized via `DOM.resolveNode` and passed to the page function as real element handles (released in `finally`).
- nth-scoped collections keep Playwright semantics: out-of-range nth yields an empty set; empty sets still invoke the page function with `[]` without any node resolution.

Chained/filtered forms (`internal:scope:` / `internal:filter:`) intentionally keep the DOM path on both read and act sides — they remain self-consistent.

## Testing

- Unit: full suite passes (251 tests, incl. build + typecheck). New tests assert collection queries issue only `Accessibility.getFullAXTree` (no `Runtime.evaluate` DOM scan) and that `count()`/`nth()`/`evaluateAll()` enumerate exactly the same backendNodeIds as element ops.
- Real-browser e2e: new `helper surface` assertions reproduce the regression with a listbox holding two visible "House" options plus a `display:none` dupe — `count()` must report the AX-actionable set and `nth(count - 1).click()` must hit the element the count enumerated. Passes against the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)