### PR TITLE
ci: publish ego-browser skill from version tags

### DIFF
--- a/.github/workflows/publish-ego-browser-skill.yml
+++ b/.github/workflows/publish-ego-browser-skill.yml
@@ -1,0 +1,193 @@
+name: Publish ego-browser skill
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-ego-browser-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package/ego-browser/package-lock.json
+
+      - name: Validate release
+        working-directory: package/ego-browser
+        run: |
+          npm ci
+          npm test
+          npm run validate:site-skills
+
+      - name: Prepare release archive
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${GITHUB_REF_NAME}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Unsupported release tag: $VERSION" >&2
+            exit 1
+          fi
+
+          SOURCE_DIR="skills/ego-browser"
+          RELEASE_DIR="$RUNNER_TEMP/ego-browser"
+          test -f "$SOURCE_DIR/SKILL.md"
+          grep -Eq '^name: ego-browser$' "$SOURCE_DIR/SKILL.md"
+          cp -R "$SOURCE_DIR" "$RELEASE_DIR"
+
+          node - "$RELEASE_DIR/SKILL.md" "$VERSION" <<'NODE'
+          const fs = require('node:fs')
+
+          const [skillPath, version] = process.argv.slice(2)
+          const source = fs.readFileSync(skillPath, 'utf8')
+          const versionLine = /(^metadata:\r?\n(?:(?:[ \t]+.*)\r?\n)*?[ \t]+version:\s*)["']?[^"'\r\n]+["']?/m
+          if (!versionLine.test(source)) {
+            throw new Error('SKILL.md metadata.version is missing')
+          }
+          const release = source.replace(versionLine, (_, prefix) => `${prefix}"${version}"`)
+          fs.writeFileSync(skillPath, release)
+          NODE
+
+          if grep -R -E '(clh_|skh_|pt-)[A-Za-z0-9_-]{16,}' "$RELEASE_DIR"; then
+            echo "Release archive contains a token-like value." >&2
+            exit 1
+          fi
+
+          tar -C "$RUNNER_TEMP" -czf "$RUNNER_TEMP/ego-browser-skill.tgz" ego-browser
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ego-browser-skill-${{ steps.release.outputs.version }}
+          path: ${{ runner.temp }}/ego-browser-skill.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-clawhub:
+    needs: prepare
+    runs-on: ubuntu-latest
+    env:
+      CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+      VERSION: ${{ needs.prepare.outputs.version }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ego-browser-skill-${{ needs.prepare.outputs.version }}
+          path: ${{ runner.temp }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Publish to ClawHub
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$CLAWHUB_TOKEN"
+          tar -C "$RUNNER_TEMP" -xzf "$RUNNER_TEMP/ego-browser-skill.tgz"
+
+          npx -y clawhub@0.21.0 login --token "$CLAWHUB_TOKEN" --no-browser
+          if npx -y clawhub@0.21.0 inspect ego-browser --version "$VERSION" --json >/dev/null 2>&1; then
+            echo "ClawHub ego-browser@$VERSION already exists; skipping."
+            exit 0
+          fi
+
+          npx -y clawhub@0.21.0 skill publish "$RUNNER_TEMP/ego-browser" \
+            --slug ego-browser \
+            --name ego-browser \
+            --owner section9-lab \
+            --version "$VERSION" \
+            --changelog "Release $VERSION from citrolabs/ego-lite" \
+            --tags latest
+
+          npx -y clawhub@0.21.0 inspect ego-browser --version "$VERSION" --json >/dev/null
+
+  publish-skillhub:
+    needs: prepare
+    runs-on: ubuntu-latest
+    env:
+      SKILLHUB_TOKEN: ${{ secrets.SKILLHUB_TOKEN }}
+      SKILLHUB_HOST: https://api.skillhub.cn
+      SKILLHUB_SLUG: ego-browser
+      SKILLHUB_CLI_URL: https://skillhub-1388575217.cos.ap-guangzhou.myqcloud.com/install/latest.tar.gz
+      SKILLHUB_CLI_SHA256: af9e07635194fb9e80fd6bc32ef80ac88fe7277146a0cc6afbc36b95398e0b89
+      VERSION: ${{ needs.prepare.outputs.version }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ego-browser-skill-${{ needs.prepare.outputs.version }}
+          path: ${{ runner.temp }}
+
+      - name: Install SkillHub CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          cli_archive="$RUNNER_TEMP/skillhub-cli.tgz"
+          cli_dir="$RUNNER_TEMP/skillhub-cli"
+          curl -fsSL "$SKILLHUB_CLI_URL" -o "$cli_archive"
+          echo "$SKILLHUB_CLI_SHA256  $cli_archive" | sha256sum --check -
+          mkdir -p "$cli_dir"
+          tar -C "$cli_dir" -xzf "$cli_archive"
+          bash "$cli_dir/cli/install.sh" --cli-only
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Publish to SkillHub
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$SKILLHUB_TOKEN"
+          tar -C "$RUNNER_TEMP" -xzf "$RUNNER_TEMP/ego-browser-skill.tgz"
+
+          node - "$RUNNER_TEMP/ego-browser/SKILL.md" <<'NODE'
+          const fs = require('node:fs')
+
+          const skillPath = process.argv[2]
+          const source = fs.readFileSync(skillPath, 'utf8')
+          if (!/^name: ego-browser$/m.test(source)) {
+            throw new Error('ego-browser skill name is missing')
+          }
+          const release = source.replace(
+            /^name: ego-browser$/m,
+            'name: ego-browser\nslug: ego-browser\ndisplayName: ego-browser',
+          )
+          fs.writeFileSync(skillPath, release)
+          NODE
+
+          skillhub publish "$RUNNER_TEMP/ego-browser" \
+            --host "$SKILLHUB_HOST" \
+            --version "$VERSION" \
+            --dry-run
+
+          published_version="$(
+            curl -fsS "$SKILLHUB_HOST/api/v1/skills/$SKILLHUB_SLUG" \
+              | node -e 'let body=""; process.stdin.on("data", chunk => body += chunk); process.stdin.on("end", () => console.log(JSON.parse(body).latestVersion?.version || ""))'
+          )"
+          if [ "$published_version" = "$VERSION" ]; then
+            echo "SkillHub $SKILLHUB_SLUG@$VERSION already exists; skipping."
+            exit 0
+          fi
+
+          skillhub publish "$RUNNER_TEMP/ego-browser" \
+            --token "$SKILLHUB_TOKEN" \
+            --host "$SKILLHUB_HOST" \
+            --version "$VERSION" \
+            --changelog "Release $VERSION from citrolabs/ego-lite"
+
+          curl -fsS "$SKILLHUB_HOST/api/v1/skills/$SKILLHUB_SLUG" \
+            | node -e 'let body=""; process.stdin.on("data", chunk => body += chunk); process.stdin.on("end", () => { const expected = process.env.VERSION; const actual = JSON.parse(body).latestVersion?.version; if (actual !== expected) throw new Error(`Expected ${expected}, got ${actual}`) })'

--- a/.gitignore
+++ b/.gitignore
@@ -78,5 +78,7 @@ browser/
 task/
 test-e2e/
 test/
+!package/ego-browser/test/
+!package/ego-browser/test/*.test.js
 # Translated skill (local only)
 skills/ego-browser/SKILL.zh.md

--- a/package/ego-browser/test/skill-publish-workflow.test.js
+++ b/package/ego-browser/test/skill-publish-workflow.test.js
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const workflowUrl = new URL(
+  "../../../.github/workflows/publish-ego-browser-skill.yml",
+  import.meta.url,
+);
+
+test("publishes ego-browser to ClawHub and SkillHub from an exact SemVer tag", () => {
+  assert.equal(existsSync(workflowUrl), true, "publish workflow must exist");
+
+  const workflow = readFileSync(fileURLToPath(workflowUrl), "utf8");
+
+  assert.match(
+    workflow,
+    /tags:\s*\n\s*- ['"]\[0-9\]\+\.\[0-9\]\+\.\[0-9\]\+['"]/,
+  );
+  assert.match(workflow, /\^\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$/);
+  assert.match(workflow, /CLAWHUB_TOKEN:\s*\$\{\{ secrets\.CLAWHUB_TOKEN \}\}/);
+  assert.match(
+    workflow,
+    /SKILLHUB_TOKEN:\s*\$\{\{ secrets\.SKILLHUB_TOKEN \}\}/,
+  );
+  assert.match(
+    workflow,
+    /npm ci[\s\S]*npm test[\s\S]*npm run validate:site-skills/,
+  );
+  assert.match(workflow, /clawhub@0\.21\.0[\s\S]*skill publish/);
+  assert.match(workflow, /SKILLHUB_CLI_SHA256:\s*[a-f0-9]{64}/);
+  assert.match(workflow, /sha256sum --check/);
+  assert.match(workflow, /^\s+SKILLHUB_SLUG: ego-browser$/m);
+  assert.doesNotMatch(workflow, /ego-browser-user-/);
+  assert.match(workflow, /skillhub publish[\s\S]*--dry-run/);
+  assert.match(workflow, /skillhub publish[\s\S]*--version "\$VERSION"/);
+  assert.match(workflow, /skills\/ego-browser/);
+});


### PR DESCRIPTION
## Summary

- publish the canonical ego-browser skill to ClawHub and SkillHub when an exact x.y.z tag is pushed
- validate the release once, package a shared artifact, and publish idempotently to both registries
- pin the ClawHub CLI and verify the downloaded SkillHub CLI checksum
- verify each published version and add a workflow contract test

## Testing

- npm test — 299 tests passed
- npm run validate:site-skills
- npm run e2e — 45/45 cases and 529 assertions passed
- actionlint v1.7.7
- prettier --check
- pre-commit vulnerability audit — 0 vulnerabilities
