### PR TITLE
chore(github): add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,97 @@
+name: Bug report
+description: Report a reproducible problem with ego lite or ego-browser.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us improve ego lite. Please search existing issues first and include the smallest reliable reproduction you can provide.
+
+        For security vulnerabilities, use a [private security advisory](https://github.com/CitroLabs/ego-lite/security/advisories/new) instead.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      options:
+        - ego lite browser app
+        - ego-browser runtime or CLI
+        - Agent skill or instructions
+        - Site learning
+        - Installation or update
+        - Other or unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior and why it is a problem.
+      placeholder: Tell us what went wrong. Include the exact error message when available.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal, repeatable sequence. Include a heredoc or code sample when relevant.
+      placeholder: |
+        1. Open or navigate to ...
+        2. Run ...
+        3. Observe ...
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Provide the ego lite app version and ego-browser or skill version, if known.
+      placeholder: "ego lite 1.2.5; ego-browser skill 1.2.5"
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Include your macOS version, CPU architecture, and agent or client.
+      placeholder: "macOS 15.5, Apple Silicon, Codex CLI"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste relevant logs or attach screenshots. Remove tokens, cookies, personal data, and other secrets.
+      render: shell
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other details that may help, such as frequency, workarounds, or recent changes.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the existing issues and did not find a duplicate.
+          required: true
+        - label: I removed secrets and sensitive browsing data from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and ideas
+    url: https://github.com/CitroLabs/ego-lite/discussions
+    about: Ask for help or discuss ideas that are not yet actionable issues.
+  - name: Documentation
+    url: https://lite.ego.app/document/
+    about: Check the guides and reference documentation before opening an issue.
+  - name: Community support
+    url: https://discord.gg/5eGZVvHbTq
+    about: Get setup help and talk with the ego lite community.
+  - name: Report a security vulnerability
+    url: https://github.com/CitroLabs/ego-lite/security/advisories/new
+    about: Privately report vulnerabilities. Do not disclose them in a public issue.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,51 @@
+name: Documentation issue
+description: Report missing, incorrect, or unclear documentation.
+title: "[Docs]: "
+labels:
+  - documentation
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Documentation area
+      options:
+        - Project README
+        - Contributor guide
+        - Agent skill guide
+        - ego-browser API or helper documentation
+        - Installation guide
+        - Website documentation
+        - Other or unsure
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: Link to the page or provide the repository path and section.
+      placeholder: "https://lite.ego.app/document/... or skills/ego-browser/SKILL.md#..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: What needs improvement?
+      description: Explain what is missing, incorrect, outdated, or hard to understand.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested change
+      description: Share the wording, example, or structure you think would help.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I checked the current documentation and searched for an existing issue.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,64 @@
+name: Feature request
+description: Propose an improvement to ego lite or ego-browser.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the user problem before the proposed implementation. Broader ideas and early-stage discussion are welcome in [GitHub Discussions](https://github.com/CitroLabs/ego-lite/discussions).
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - ego lite browser app
+        - ego-browser runtime or CLI
+        - Agent skill or instructions
+        - Site learning
+        - Installation or update
+        - Documentation
+        - Other or unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What workflow is difficult or impossible today, and who is affected?
+      placeholder: When I try to ..., I cannot ... because ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior you would like. Keep the proposal focused on the smallest useful outcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe current workarounds or other approaches you considered.
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: Examples or references
+      description: Add mockups, code samples, links, or examples from related tools when useful.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and discussions for a similar request.
+          required: true
+        - label: This request describes one focused problem.
+          required: true

--- a/.github/ISSUE_TEMPLATE/site_support_request.yml
+++ b/.github/ISSUE_TEMPLATE/site_support_request.yml
@@ -1,0 +1,71 @@
+name: Site support request
+description: Request reusable ego-browser support for a website or workflow.
+title: "[Site]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Site learnings should capture stable, reusable site knowledge rather than one-off task steps. Never include credentials, cookies, tokens, or other secrets.
+
+  - type: input
+    id: site
+    attributes:
+      label: Website
+      description: Provide the public site name and a stable entry URL.
+      placeholder: "Example — https://example.com/"
+    validations:
+      required: true
+
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Workflow to support
+      description: Describe the user goal and the repeatable sequence the agent should be able to complete.
+      placeholder: An agent should be able to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current limitation
+      description: Explain where generic ego-browser helpers fail, become unreliable, or require repeated discovery.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reusable_knowledge
+    attributes:
+      label: Reusable site knowledge
+      description: List stable URLs, roles, labels, selectors, or page structure that could make this workflow reliable. Do not use pixel coordinates.
+
+  - type: dropdown
+    id: authentication
+    attributes:
+      label: Authentication required?
+      options:
+        - "No"
+        - "Yes"
+        - Unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Examples or evidence
+      description: Add sanitized snapshots, logs, or screenshots that demonstrate the limitation.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and site learnings for this website or workflow.
+          required: true
+        - label: I removed all secrets and sensitive browsing data.
+          required: true
+        - label: This request relies on stable page semantics, not pixel coordinates.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+## Summary
+
+<!-- What changed, and why is this the smallest useful solution? -->
+
+## Related issue
+
+<!-- Use "Closes #123" when applicable. If there is no issue, briefly explain why. -->
+
+## Changes
+
+<!-- List the important implementation or documentation changes. -->
+
+-
+
+## Verification
+
+<!-- List the checks you ran and their results. Commands run from package/ego-browser unless noted otherwise. -->
+
+```text
+npm test
+npm run validate:site-skills
+```
+
+<!-- Add screenshots or a reproducible ego-browser heredoc for user-visible behavior. Remove this comment if not applicable. -->
+
+## Impact
+
+<!-- Check every affected area. -->
+
+- [ ] Public helper API or behavior
+- [ ] Agent skill or instructions
+- [ ] Site learning
+- [ ] Installation or update flow
+- [ ] Build, CI, or release process
+- [ ] Documentation only
+- [ ] No externally visible impact
+
+<!-- Describe compatibility, migration, or rollout concerns for any affected public surface. Remove this comment if none. -->
+
+## Checklist
+
+- [ ] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
+- [ ] The change is focused and does not include unrelated cleanup.
+- [ ] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained above.
+- [ ] Relevant tests and validation commands pass locally.
+- [ ] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes.
+- [ ] No credentials, tokens, cookies, personal data, or other secrets are included.
+- [ ] A release-note label is selected (`feat`, `fix`, `docs`, `chore`, `ci`, or `refactor`).


### PR DESCRIPTION
## Summary

Add structured GitHub issue forms and a pull request template tailored to the ego-lite contribution workflow.

## Changes

- Add forms for bug reports, feature requests, documentation issues, and site support requests.
- Route questions, documentation help, community support, and security reports to the appropriate channels.
- Add a PR template covering scope, verification, impact, branch policy, secrets, and release-note labels.

## Verification

- Parsed all Issue Form YAML files successfully.
- Validated required form fields and unique field IDs.
- Ran Prettier checks for all new YAML and Markdown files.
- Ran `git diff --check`.
- Passed the repository pre-commit hooks.

Code tests were not run because this change only adds GitHub contribution templates.

## Impact

Repository contribution workflow only. There are no runtime or public API changes.