### PR TITLE
docs(ego-browser): document legacy runtime compatibility

### DIFF
--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -12,6 +12,12 @@ ego-browser exposes a real Chromium browser through a CLI-accessible Node.js run
 
 For setup, install, or connection problems, read `references/install.md`.
 
+The examples below require the Playwright-style runtime. If `taskSpaces`,
+`browser`, or `page` is undefined but legacy helpers such as
+`useOrCreateTaskSpace` exist, read
+[`references/legacy-runtime.md`](references/legacy-runtime.md) before
+continuing. Do not guess Playwright-style helper names against a legacy app.
+
 Run browser work with the `Bash` tool as `ego-browser nodejs <<'EOF' ... EOF`. Put the JavaScript directly in the heredoc; do not create a `.js` file, import Playwright, launch another browser, or invent helper names.
 
 **Treat the heredoc as an execution container, not a planning unit. Default to one Bash invocation for the whole browser task.** Keep every operation whose inputs can be derived inside that script: select the task space, observe state, branch with JavaScript, act, wait, extract, verify, complete the task space, and print the result. Use variables, loops, and conditionals instead of returning after each action. Start another Bash command only when continuation truly requires user input or control, visual inspection outside the script, or recovery from a command that cannot continue.

--- a/skills/ego-browser/references/install.md
+++ b/skills/ego-browser/references/install.md
@@ -45,15 +45,30 @@ export PATH="$HOME/.local/bin:$PATH"
 command -v ego-browser
 ```
 
-Once the command exists, verify the runtime with a minimal heredoc:
+Once the command exists, verify which runtime API the installed app exposes:
 
 ```bash
 ego-browser nodejs <<'EOF'
-console.log('ego-browser ready')
+const runtimeApi =
+  typeof taskSpaces === 'object' &&
+  typeof browser === 'object' &&
+  typeof page === 'object'
+    ? 'playwright-style'
+    : typeof useOrCreateTaskSpace === 'function'
+      ? 'legacy'
+      : 'unknown'
+
+console.log(JSON.stringify({ runtimeApi }))
 EOF
 ```
 
-Printing `ego-browser ready` means the environment is ready.
+`{"runtimeApi":"playwright-style"}` means the environment matches the examples
+in `SKILL.md`. If the probe reports `legacy`, run `ego-browser upgrade`, restart
+ego lite, and repeat the probe. When no newer app is available, read
+[the legacy runtime guide](legacy-runtime.md) for the supported fallback helper
+names. An `unknown` result
+means the CLI and app runtime are not compatible; capture the command output and
+report it rather than guessing helper names.
 
 ## After that, return to the original task
 
@@ -65,3 +80,4 @@ Once the environment is ready, return to the user's original task and continue w
 - **Download failed**: the script retries 3 times automatically; if it still fails, it's usually a network issue — have the user check their network and retry.
 - **Gatekeeper still blocks it**: the script already tries to strip quarantine; if the first launch is still blocked, have the user allow ego lite manually under System Settings → Privacy & Security.
 - **Command still unavailable after onboarding**: confirm `~/.local/bin` is on the PATH (see above); or have the user reopen ego lite, finish onboarding, and retry.
+- **`taskSpaces`, `browser`, or `page` is undefined**: run the capability probe above. Upgrade and restart ego lite when possible; otherwise follow [the legacy runtime guide](legacy-runtime.md) for the legacy helper surface.

--- a/skills/ego-browser/references/legacy-runtime.md
+++ b/skills/ego-browser/references/legacy-runtime.md
@@ -1,0 +1,89 @@
+# Legacy ego-browser runtime compatibility
+
+Read this file only when the installed ego lite app exposes legacy top-level
+helpers instead of the Playwright-style `taskSpaces`, `browser`, and `page`
+facades documented in `SKILL.md`.
+
+## Confirm the mismatch
+
+Use capability detection because the app and skill have independent version
+numbers and may be updated on different schedules:
+
+```bash
+ego-browser nodejs <<'EOF'
+console.log(JSON.stringify({
+  taskSpaces: typeof taskSpaces,
+  browser: typeof browser,
+  page: typeof page,
+  useOrCreateTaskSpace: typeof useOrCreateTaskSpace,
+  openOrReuseTab: typeof openOrReuseTab,
+  snapshotText: typeof snapshotText,
+}, null, 2))
+EOF
+```
+
+The runtime is legacy when the three facade values are `undefined` and the
+top-level helpers are functions. Run `ego-browser upgrade`, restart ego lite,
+and repeat the probe first. Use the fallback below only when the public update
+channel does not yet provide the Playwright-style runtime.
+
+## Helper mapping
+
+| Playwright-style API | Legacy equivalent |
+| --- | --- |
+| `taskSpaces.useOrCreate(name)` | `useOrCreateTaskSpace(name)` |
+| `taskSpaces.list()` | `listTaskSpaces()` |
+| `taskSpaces.claim(id)` | `claimTaskSpace(id)` |
+| `taskSpaces.handOff(id)` | `handOffTaskSpace(id)` |
+| `taskSpaces.takeOver(id)` | `takeOverTaskSpace(id)` |
+| `taskSpaces.complete(id, { keep })` | `completeTaskSpace(id, { keep })` |
+| `browser.openOrReuseTab(url, options)` | `openOrReuseTab(url, options)` |
+| `browser.listTabs()` | `listTabs()` |
+| `browser.switchTab(targetId)` | `switchTab(targetId)` |
+| `browser.closeTab(targetId)` | `closeTab(targetId)` |
+| `page.info()` | `pageInfo()` |
+| `page.snapshot()` | `snapshotText()` |
+| `page.screenshot()` | `captureScreenshot()` |
+| `page.evaluate(expression)` | `js(expression)` |
+| `fetch.server(url, options)` | `serverFetch(url, options)` |
+| `fetch.browser(url, options)` | `browserFetch(url, options)` |
+| `console.log(value)` | `cliLog(value)` |
+
+Legacy timeouts are in seconds unless a parameter name ends in `Ms`. Do not
+copy millisecond values such as `20000` from the Playwright-style examples.
+Legacy `js()` accepts a string expression, not a function and argument pair.
+
+## Minimal legacy flow
+
+```bash
+ego-browser nodejs <<'EOF'
+const task = await useOrCreateTaskSpace('inspect example page')
+await openOrReuseTab('https://example.com', { wait: true, timeout: 20 })
+
+const snapshot = await snapshotText()
+const info = await pageInfo()
+if (!snapshot || !info.url) throw new Error('Example page was not ready')
+
+cliLog(JSON.stringify({
+  taskSpaceId: task.id,
+  title: info.title,
+  url: info.url,
+}, null, 2))
+EOF
+```
+
+Continue with the legacy helpers for the browser task. After a prior command
+has verified the final result, complete the task space in its own terminal
+command:
+
+```bash
+ego-browser nodejs <<'EOF'
+const completion = await completeTaskSpace('inspect example page', { keep: false })
+if (!completion.done) throw new Error('Task space was not completed: ' + JSON.stringify(completion))
+cliLog(JSON.stringify(completion))
+EOF
+```
+
+Keep the legacy ownership and handoff rules: never reclaim a user-controlled
+space without explicit confirmation, and check the `done` result from handoff
+and completion calls.


### PR DESCRIPTION
## Summary

Document how to detect and use the legacy ego-browser helper surface when the installed ego lite App/CLI does not yet expose the Playwright-style `taskSpaces`, `browser`, and `page` facades.

Closes #111.

## Why

The public App/CLI and the separately distributed skill can update on different schedules. Agents currently fail immediately with `ReferenceError: taskSpaces is not defined` when a newer skill is paired with a legacy runtime. Capability detection is more durable than hard-coding an App-to-skill version matrix.

## Changes

- Add a capability probe to the installation verification flow.
- Route facade-mismatch errors from `SKILL.md` to a focused compatibility guide.
- Add a legacy-to-Playwright helper mapping, timeout/evaluation differences, and a verified minimal legacy task-space flow.
- Recommend upgrading and restarting first, while retaining a fallback when the public update channel has not caught up.

## Verification

- `npm test` — 299 tests passed.
- `npm run validate:agent-style` — passed (31 files).
- `git diff --check` — passed.
- Ran the documented capability probe against ego lite App/CLI 0.4.4.17; it returned `{"runtimeApi":"legacy"}`.
- Verified all 17 documented legacy helper names exist in that runtime.
- Verified the branch merges cleanly into current `dev` with `git merge-tree --write-tree upstream/dev HEAD`.

## Impact

Documentation only. No runtime behavior or public helper surface changes.
