### PR TITLE
fix(ego-browser): contain fixture and subscriber failures

### DIFF
--- a/package/ego-browser/scripts/real-browser-e2e/fixture.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/fixture.mjs
@@ -19,7 +19,17 @@ export async function startFixtureServer(taskName) {
   const handleDamaiRushRoute = createDamaiRushRoutes();
   const fixtureServer = createServer(async (req, res) => {
     const url = new URL(req.url || "/", "http://127.0.0.1");
-    if (await handleDamaiRushRoute(req, res, url)) return;
+    try {
+      if (await handleDamaiRushRoute(req, res, url)) return;
+    } catch (error) {
+      if (res.headersSent) {
+        res.destroy(error);
+      } else {
+        res.writeHead(500, { "content-type": "text/plain; charset=utf-8" });
+        res.end("Internal Server Error");
+      }
+      return;
+    }
     if (url.pathname === "/healthz") {
       res.writeHead(200, {
         "content-type": "application/json",

--- a/package/ego-browser/src/browser-runtime.test.mjs
+++ b/package/ego-browser/src/browser-runtime.test.mjs
@@ -287,6 +287,47 @@ test("subscribeBrowserEvent stops delivery after unsubscribe", async () => {
   }
 });
 
+test("subscribeBrowserEvent isolates listener failures", async () => {
+  const { subscribeBrowserEvent } =
+    await import("../dist/src/browser-runtime.js");
+  installAutoEgo();
+  const originalConsoleError = console.error;
+  const errors = [];
+  console.error = (...args) => errors.push(args);
+  let unsubscribeFailing;
+  let unsubscribeHealthy;
+  try {
+    await browserCdp("Runtime.evaluate", { expression: "1" });
+    unsubscribeFailing = subscribeBrowserEvent(
+      "Page.screencastFrame",
+      "sess-video",
+      () => {
+        throw new Error("subscriber failed");
+      },
+    );
+    const received = [];
+    unsubscribeHealthy = subscribeBrowserEvent(
+      "Page.screencastFrame",
+      "sess-video",
+      (event) => received.push(event.params.data),
+    );
+
+    assert.doesNotThrow(() => {
+      fireEvent("Page.screencastFrame", { data: "frame-1" }, "sess-video");
+    });
+
+    assert.deepEqual(received, ["frame-1"]);
+    assert.equal(errors.length, 1);
+    assert.match(String(errors[0][0]), /subscriber/i);
+    assert.match(String(errors[0][1]), /subscriber failed/);
+  } finally {
+    unsubscribeFailing?.();
+    unsubscribeHealthy?.();
+    console.error = originalConsoleError;
+    cleanup();
+  }
+});
+
 test("subscribed screencast frames bypass the generic event buffer", async () => {
   const { subscribeBrowserEvent } =
     await import("../dist/src/browser-runtime.js");

--- a/package/ego-browser/src/browser-runtime.ts
+++ b/package/ego-browser/src/browser-runtime.ts
@@ -281,7 +281,11 @@ function handleMessage(message) {
       continue;
     }
     deliveredToSubscriber = true;
-    subscriber.listener(data);
+    try {
+      subscriber.listener(data);
+    } catch (error) {
+      console.error("Browser event subscriber failed:", error);
+    }
   }
   if (!(deliveredToSubscriber && data.method === "Page.screencastFrame")) {
     events.push(data);

--- a/package/ego-browser/test/fixture-server.test.js
+++ b/package/ego-browser/test/fixture-server.test.js
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  closeFixtureServer,
+  startFixtureServer,
+} from "../scripts/real-browser-e2e/fixture.mjs";
+
+test("fixture server contains route handler failures", async (t) => {
+  const fixture = await startFixtureServer("route-failure-test");
+  t.after(() => closeFixtureServer(fixture.server));
+
+  const response = await fetch(`${fixture.baseUrl}/e2e/damai-rush/api/reset`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{",
+    signal: AbortSignal.timeout(500),
+  });
+
+  assert.equal(response.status, 500);
+  assert.equal(await response.text(), "Internal Server Error");
+
+  const health = await fetch(`${fixture.baseUrl}/healthz`);
+  assert.equal(health.status, 200);
+});


### PR DESCRIPTION
## Summary

Address the two actionable review findings from #115 without changing the public helper surface.

## Changes

- Convert Damai Rush fixture route rejections into deterministic HTTP 500 responses, or destroy the response when headers were already sent.
- Isolate and report synchronous browser event subscriber failures so later subscribers and the CDP message pump keep running.
- Add regression coverage for both failure paths.

## TDD verification

Both regression tests were added first and observed failing against the previous implementation:

- `fixture server contains route handler failures`
- `subscribeBrowserEvent isolates listener failures`

After the minimal fixes:

- `npm test` — 301/301 passed
- `npm run validate:site-skills` — passed
- `npm run e2e` — 45/45 cases and 529 assertions passed
- Prettier and `git diff --check` — passed
- `npm audit --audit-level=moderate` — 0 vulnerabilities

## Related review threads

- https://github.com/citrolabs/ego-lite/pull/115#discussion_r3629324499
- https://github.com/citrolabs/ego-lite/pull/115#discussion_r3629324527