### PR TITLE
docs(skill): document legacy-API fallback and upgrade path (#111)

### DIFF
--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -188,6 +188,22 @@ Combine the paths within the same Bash invocation whenever their next inputs are
 - Once the current browser task stops or completes (including right before/after `taskSpaces.complete`), tell the user about the update: the notice line, and the current version shown in the notice. Proactively offer to run the upgrade — mention that it updates the ego lite browser, the CLI, and the Skills together, not just the app.
 - If the user agrees, run `ego-browser upgrade` in the shell. After the upgrade finishes, re-read the `ego-browser` skill (this file) before continuing, since the upgrade may have changed its content.
 
+## Runtime compatibility
+
+The Playwright-style `page`, `browser`, and `taskSpaces` facades documented above require a recent ego lite App/CLI. Older builds (for example `ego-browser 0.4.4.x`) inject only the legacy top-level helpers instead, so a script written against the new facades fails immediately with `ReferenceError: taskSpaces is not defined` (or the same for `page` / `browser`).
+
+If a first command fails that way, the installed runtime is out of date, not the script. Run `ego-browser upgrade` (it updates the browser, CLI, and Skills together), then re-read this file and retry with the facade API. Only if the upgrade is unavailable, fall back to the legacy top-level helpers exposed by the older runtime:
+
+| Facade API (this skill) | Legacy top-level helper (older App/CLI) |
+|---|---|
+| `taskSpaces.useOrCreate(nameOrId)` | `useOrCreateTaskSpace(nameOrId)` |
+| `taskSpaces.complete(nameOrId, { keep })` | `completeTaskSpace(nameOrId, { keep })` |
+| `browser.openOrReuseTab(url, opts)` | `openOrReuseTab(url, opts)` |
+| `page.snapshot()` | `snapshotText()` |
+| `fetch.server` / `fetch.browser` | `fetch` |
+
+Probe the runtime with `typeof taskSpaces !== 'undefined' ? 'facade' : 'legacy'` when you are unsure which API a build exposes. The legacy helpers are a compatibility fallback only; prefer upgrading so the documented facade behavior, waits, and ownership semantics apply.
+
 ## Caveats
 
 - Timeouts are milliseconds in the Playwright-style `page`, locator, navigation, and browser helpers. Exceptions: `fetch.server` / `fetch.browser` timeout and `taskSpaces.waitForAgentControl` interval/timeout are seconds.


### PR DESCRIPTION
## Summary

The `ego-browser` SKILL.md documents the Playwright-style facades (`page`, `browser`, `taskSpaces`), but public App/CLI builds such as `ego-browser 0.4.4.x` inject only the **legacy top-level helpers** (`useOrCreateTaskSpace`, `openOrReuseTab`, `completeTaskSpace`, `snapshotText`, `fetch`). Agents following the current skill against those runtimes fail on the very first command with `ReferenceError: taskSpaces is not defined`.

This adds a short **Runtime compatibility** section — the smallest useful fix — implementing option 2 from #111: explain the symptom, point to `ego-browser upgrade` as the primary fix, and give a facade→legacy mapping table plus a runtime probe as a fallback.

## Related issue

Closes #111

## Changes

- Add a `## Runtime compatibility` section to `skills/ego-browser/SKILL.md`:
  - Explains that the facade API requires a recent App/CLI and that older builds expose only legacy top-level helpers, surfacing as `ReferenceError`.
  - Directs agents to run `ego-browser upgrade` first (updates browser, CLI, and Skills together), consistent with the existing "Update notices" guidance.
  - Provides a facade → legacy helper mapping table and a `typeof taskSpaces` runtime probe for the fallback path.

### Sourcing of the mapping

- `useOrCreateTaskSpace(nameOrId)`, `completeTaskSpace(nameOrId, { keep })`, and `openOrReuseTab(url, options)` are still present as top-level functions in this repo's harness source (`package/ego-browser/src/helpers.ts` and `package/ego-browser/src/driver/nav.ts`), and the documented signatures match those definitions.
- `snapshotText` and the legacy top-level `fetch` are not in this repo's source; they are the legacy helpers named in the #111 runtime probe against `ego-browser 0.4.4.17` (`typeof snapshotText === 'function'`, `typeof fetch === 'function'`, while `taskSpaces`/`browser`/`page` are `undefined`). They are mapped to their current facade equivalents (`page.snapshot()`, `fetch.server` / `fetch.browser`).

## Verification

Documentation-only change to `skills/ego-browser/SKILL.md`. No public helper surface, site learning, or `package/ego-browser` code changed, so the prettier / `validate:site-skills` / e2e hooks (scoped to `package/ego-browser/` and `skills/ego-browser/learnings/`) do not apply. Confirmed the legacy helper names and signatures against the repo source and the #111 probe output, and checked the Markdown table renders correctly.

## Impact

- [x] Documentation only
- [x] Agent skill or instructions

No compatibility or migration concerns: additive documentation only, no behavior change.

## Checklist

- [x] The PR targets the correct base branch (`dev`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained above (docs-only).
- [x] Relevant tests and validation commands pass locally (none apply to this path).
- [x] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes (no helper surface change).
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [ ] A release-note label is selected — `docs` requested; the label does not yet exist in this repo and I lack write access to create it, so a maintainer may need to add it.