### PR TITLE
ci(security): prevent shell injection via github.head_ref in Main PR Source

### DIFF
--- a/.github/workflows/main-pr-source.yml
+++ b/.github/workflows/main-pr-source.yml
@@ -10,8 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Require dev branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [ "${{ github.head_ref }}" != "dev" ]; then
+          if [ "$HEAD_REF" != "dev" ]; then
             echo "Pull requests into main must come from the dev branch."
             exit 1
           fi


### PR DESCRIPTION
## Summary

The `require-dev-source` job in `.github/workflows/main-pr-source.yml` interpolated the untrusted `${{ github.head_ref }}` value directly into a `run:` shell block. A pull request author can choose the source branch name, and valid Git refs may contain shell metacharacters. If the workflow is allowed to run, a crafted branch name can therefore be interpreted as shell code before the string comparison. This is a GitHub Actions script-injection pattern.

## Related issue

Fixes #127

## Fix

Pass the untrusted value through an intermediate environment variable and compare the quoted shell variable, so the branch name is handled as data rather than code:

```yaml
      - name: Require dev branch
        env:
          HEAD_REF: ${{ github.head_ref }}
        run: |
          if [ "$HEAD_REF" != "dev" ]; then
            echo "Pull requests into main must come from the dev branch."
            exit 1
          fi
```

This follows GitHub's recommended mitigation for untrusted values used by inline scripts. Behavior is unchanged for legitimate PRs: the job still fails any PR into `main` whose source branch is not `dev`.

## Verification

- Parsed the workflow with a YAML parser after the change: the step now has `env.HEAD_REF: ${{ github.head_ref }}`, the `run` block references `"$HEAD_REF"`, and no `github.head_ref` interpolation remains inside the `run` script.
- Verified with a valid, harmless branch payload: `$(printf${IFS}PR128_INJECTION_PROVED>&2)` passes `git check-ref-format --branch`. The original script evaluates it and prints the marker; after this change, the same value is compared as a literal string and is not executed.

## Impact

- [x] Build, CI, or release process
- [x] No externally visible impact (CI-only change; no runtime/helper/skill surface touched)

This is runner-integrity hardening, not a repository-compromise or secret-exposure fix. Recent fork-originated runs in this repository have been held for maintainer approval (`action_required`), so the vulnerable job is not automatically triggered for those contributors. Once an affected run is approved or otherwise permitted to start, however, the vulnerable interpolation is deterministic.

The job uses a GitHub-hosted `ubuntu-latest` runner, does not check out repository code or use a cache, and fork pull requests do not receive repository secrets; their `GITHUB_TOKEN` is read-only. The realistic impact is limited to code execution within that ephemeral runner job, such as compute or outbound network use.

This PR hardens the workflow only. Making `require-dev-source` a required status check is a separate enforcement concern.

## Checklist

- [x] The PR targets the correct base branch (`dev`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Relevant tests and validation commands pass locally (YAML validated; no code paths affected).
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [ ] A release-note label (`ci` requested) - I lack write access to set labels; a maintainer may need to apply it.