### PR TITLE
fix(ego-browser): stop Tab key from inserting a literal tab character

### DIFF
--- a/package/ego-browser/src/driver/keyboard.test.mjs
+++ b/package/ego-browser/src/driver/keyboard.test.mjs
@@ -194,6 +194,41 @@ test("press leaves ordinary printable keys unchanged", async () => {
   });
 });
 
+test("press sends Tab as a navigation key without inserting text", async () => {
+  const calls = [];
+  const restore = setOverrides({
+    cdpOverride(method, params, sessionId) {
+      calls.push({ method, params, sessionId });
+      return {};
+    },
+  });
+  try {
+    await press("Tab");
+  } finally {
+    restore();
+  }
+
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[0].params, {
+    type: "keyDown",
+    key: "Tab",
+    code: "Tab",
+    modifiers: 0,
+    windowsVirtualKeyCode: 9,
+    nativeVirtualKeyCode: 9,
+  });
+  assert.equal(calls[0].params.text, undefined);
+  assert.equal(calls[0].params.unmodifiedText, undefined);
+  assert.deepEqual(calls[1].params, {
+    type: "keyUp",
+    key: "Tab",
+    code: "Tab",
+    modifiers: 0,
+    windowsVirtualKeyCode: 9,
+    nativeVirtualKeyCode: 9,
+  });
+});
+
 test("press maps Backspace and Delete to editing commands", async () => {
   const calls = [];
   const restore = setOverrides({

--- a/package/ego-browser/src/driver/keyboard.ts
+++ b/package/ego-browser/src/driver/keyboard.ts
@@ -21,7 +21,7 @@ type SelectOption =
 
 const KEYS = {
   Enter: { vk: 13, key: "Enter", code: "Enter", text: "\r" },
-  Tab: { vk: 9, key: "Tab", code: "Tab", text: "\t" },
+  Tab: { vk: 9, key: "Tab", code: "Tab", text: "" },
   Backspace: { vk: 8, key: "Backspace", code: "Backspace", text: "" },
   Escape: { vk: 27, key: "Escape", code: "Escape", text: "" },
   Delete: { vk: 46, key: "Delete", code: "Delete", text: "" },


### PR DESCRIPTION
## Summary

`page.keyboard.press('Tab')` currently types a literal tab character into the focused field instead of moving focus, because the `Tab` entry in the keyboard layout carries `text: "\t"`. Dropping that text makes Tab behave as a navigation key, matching Playwright's US keyboard layout.

## Related issue

No existing issue. Found while auditing the keyboard driver for Playwright parity.

## Changes

- `src/driver/keyboard.ts`: `Tab` key definition now uses `text: ""` instead of `"\t"`.
- `src/driver/keyboard.test.mjs`: add a regression test asserting `press('Tab')` dispatches a `keyDown`/`keyUp` with **no** `text`/`unmodifiedText`.

## Details

The `KEYS` table mirrors Playwright's US keyboard layout. In that layout only character-producing keys carry `text` — `Enter` (`"\r"`) and `Space` (`" "`) — while `Tab`, `Backspace`, `Escape`, arrows, etc. have none. `press()` spreads `text`/`unmodifiedText` onto the CDP `Input.dispatchKeyEvent` only when `text` is truthy:

```js
...(text ? { text, unmodifiedText: text } : {})
```

With `Tab` set to `"\t"`, CDP receives a character-producing `keyDown`, so a focused `<input>`/`<textarea>`/contenteditable inserts a literal tab instead of Tab performing focus navigation (`Shift+Tab` is affected the same way). Every other non-text key already uses `text: ""`; `Tab` was the lone deviation.

## Verification

```text
npm test                     # 307 pass, incl. new "press sends Tab as a navigation key without inserting text"
npm run validate:site-skills # ok
npx prettier --check         # clean
```

## Impact

- [x] Public helper API or behavior
- [ ] Agent skill or instructions
- [ ] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

Behavior change is a bug fix: `Tab`/`Shift+Tab` now navigate focus (Playwright-parity) rather than inserting a tab character. No API surface change.

## Checklist

- [x] The PR targets the correct base branch (`dev`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added for the behavior change.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc unaffected (behavior aligns with existing docs).
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [x] Release-note label: `fix`.
