### PR TITLE
fix(ego-browser): select the newly opened tab in openOrReuseTab

### DIFF
--- a/package/ego-browser/src/driver/nav.test.mjs
+++ b/package/ego-browser/src/driver/nav.test.mjs
@@ -141,24 +141,46 @@ test("newTab throws when the binding returns no targetId", async () => {
   );
 });
 
-test("openOrReuseTab settles a newly opened tab in milliseconds, not seconds", async () => {
+test("openOrReuseTab selects a newly opened tab and settles it in milliseconds", async () => {
   // Regression: the new-tab branch used to sleep(settle * 1000), so settle:500
   // (documented as 500ms) blocked for 500 seconds while the reuse branch
   // already treated it as milliseconds.
   const sleeps = [];
+  const cdpCalls = [];
+  let created = false;
   await withEgo(
     {
       async listTabs() {
-        return { tabs: [] }; // no match → open a new tab
+        return {
+          tabs: created
+            ? [
+                {
+                  targetId: "target-new",
+                  active: true,
+                  title: "Fresh",
+                  url: "https://example.com/fresh",
+                },
+              ]
+            : [], // no match → open a new tab
+        };
       },
       async createTab() {
+        created = true;
         return { targetId: "target-new" };
       },
     },
     async () => {
       const restore = setOverrides({
+        sessionId: "session-old",
+        sessionTargetId: "target-old",
+        sessionAt: Date.now(),
+        preferredTargetId: null,
         sleep: async (ms) => {
           sleeps.push(ms);
+        },
+        cdpOverride(method, params) {
+          cdpCalls.push({ method, params });
+          return {};
         },
       });
       try {
@@ -168,6 +190,18 @@ test("openOrReuseTab settles a newly opened tab in milliseconds, not seconds", a
         });
         assert.equal(opened.reused, false);
         assert.equal(opened.targetId, "target-new");
+        assert.equal(opened.active, true);
+        // The opened tab is selected before returning: activated, the stale
+        // session for the previous tab is dropped, and it becomes preferred so
+        // later work (and the load wait) targets the new tab.
+        assert.deepEqual(cdpCalls, [
+          {
+            method: "Target.activateTarget",
+            params: { targetId: "target-new" },
+          },
+        ]);
+        assert.equal(state.sessionId, null);
+        assert.equal(state.preferredTargetId, "target-new");
       } finally {
         restore();
       }

--- a/package/ego-browser/src/driver/nav.ts
+++ b/package/ego-browser/src/driver/nav.ts
@@ -198,6 +198,7 @@ export async function openOrReuseTab(
     return { ...existing, active: true, reused: true };
   }
   const targetId = await newTab(url);
+  await switchTab(targetId);
   if (options.wait !== false) {
     await waitForDocumentLoad({ timeout: options.timeout ?? 20000 });
   }


### PR DESCRIPTION
## Summary

`browser.openOrReuseTab(url)` is documented as "open a URL in a new or reusable tab, then select it," and the reuse path does exactly that via `switchTab`. The new-tab path did not: it opened the tab but never selected it, so the harness session stayed attached to the previously active tab. As a result the post-open load wait targeted the wrong tab and the returned `active: true` was untruthful. This makes the new-tab path select the opened tab, matching the reuse path.

## Related issue

No existing issue. Found while auditing tab/session handling in `nav.ts`.

## Changes

- `src/driver/nav.ts`: in `openOrReuseTab`, call `await switchTab(targetId)` after opening a new tab, before waiting for load — mirroring the reuse branch.
- `src/driver/nav.test.mjs`: update the new-tab test to simulate the opened tab appearing in the tab list and assert it is activated, the stale session is invalidated, and it becomes the preferred target.

## Details

`waitForDocumentLoad()` issues `Page.getFrameTree` / `document.readyState` through `cdp()` → `browserCdp()` → `ensureSession()`. `ensureSession()` returns the cached session (2s TTL) still attached to the previously active tab. The new-tab branch called `newTab(url)` (which does not invalidate the session or set a preferred target) and then waited:

```js
const targetId = await newTab(url);
if (options.wait !== false) {
  await waitForDocumentLoad({ timeout: options.timeout ?? 20000 });
}
return { targetId, url, title: "", active: true, reused: false };
```

So `waitForDocumentLoad` polls the *old* tab's `readyState` (already `complete`) and returns immediately without waiting for the new tab, and the new tab is never selected — yet the return claims `active: true`. The reuse branch avoids this by calling `switchTab(existing.targetId)` first (which activates the target, invalidates the session, and sets it preferred). Adding the same `switchTab(targetId)` to the new-tab branch fixes the wait target, fulfills the documented "then select it," and makes `active: true` truthful.

## Verification

```text
npm test                     # 306 pass, incl. updated "openOrReuseTab selects a newly opened tab and settles it in milliseconds"
npm run validate:site-skills # ok
npm run typecheck            # clean
npx prettier --check         # clean
```

## Impact

- [x] Public helper API or behavior
- [ ] Agent skill or instructions
- [ ] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

Behavior change is a bug fix: after opening a new tab, `openOrReuseTab` now selects it (as already documented and as the reuse path already does), so the load wait and subsequent helpers act on the intended tab. No API surface change.

## Checklist

- [x] The PR targets the correct base branch (`dev`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were updated for the behavior change.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc unaffected (behavior aligns with the existing "then select it" contract).
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [x] Release-note label: `fix`.
