### PR TITLE
fix(downloads): sanitize server-supplied download filename to prevent path traversal

### DIFF
--- a/package/ego-browser/src/driver/downloads.test.mjs
+++ b/package/ego-browser/src/driver/downloads.test.mjs
@@ -1,12 +1,17 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import { resolve, sep } from "node:path";
 
 import {
   clearPreferredTarget,
   drainBrowserEvents,
   invalidateSession,
 } from "../../dist/src/browser-runtime.js";
-import { waitForEvent } from "../../dist/src/driver/downloads.js";
+import {
+  waitForEvent,
+  safeDownloadFilename,
+} from "../../dist/src/driver/downloads.js";
 
 function installAutoEgo(options = {}) {
   const calls = [];
@@ -79,6 +84,52 @@ test("waitForEvent('download') returns a Playwright-style download facade", asyn
   } finally {
     cleanup();
   }
+});
+
+test("waitForEvent('download') keeps a traversal suggestedFilename inside the download dir", async () => {
+  installAutoEgo();
+  try {
+    const promise = waitForEvent("download", { timeout: 1000 });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    // A malicious server can set this via Content-Disposition; it is untrusted.
+    fireEvent("Page.downloadWillBegin", {
+      guid: "download-1",
+      url: "https://attacker.example/report",
+      suggestedFilename: "../../../../../../../../etc/passwd",
+    });
+    fireEvent("Page.downloadProgress", {
+      guid: "download-1",
+      state: "completed",
+    });
+    const download = await promise;
+
+    const downloadedPath = resolve(await download.path());
+    const tmpRoot = resolve(tmpdir());
+    assert.ok(
+      downloadedPath.startsWith(tmpRoot + sep),
+      `download.path() escaped the temp dir: ${downloadedPath}`,
+    );
+    assert.ok(
+      !downloadedPath.includes(`${sep}..${sep}`) &&
+        !downloadedPath.endsWith(`${sep}..`),
+      `download.path() still contains a traversal segment: ${downloadedPath}`,
+    );
+    // Sanitized to the basename, so it lands inside the per-download dir.
+    assert.match(downloadedPath, /passwd$/);
+  } finally {
+    cleanup();
+  }
+});
+
+test("safeDownloadFilename strips directory components and rejects dot segments", () => {
+  assert.equal(safeDownloadFilename("../../etc/passwd"), "passwd");
+  assert.equal(safeDownloadFilename("..\\..\\Windows\\win.ini"), "win.ini");
+  assert.equal(safeDownloadFilename("/etc/shadow"), "shadow");
+  assert.equal(safeDownloadFilename("report.pdf"), "report.pdf");
+  assert.equal(safeDownloadFilename(".."), "");
+  assert.equal(safeDownloadFilename("."), "");
+  assert.equal(safeDownloadFilename(""), "");
+  assert.equal(safeDownloadFilename(undefined), "");
 });
 
 test("waitForEvent('download') rejects when the download is canceled", async () => {

--- a/package/ego-browser/src/driver/downloads.ts
+++ b/package/ego-browser/src/driver/downloads.ts
@@ -7,6 +7,25 @@ import { cdp } from "../cdp-eval.js";
 import { ensureSession, waitForBrowserEvent } from "../browser-runtime.js";
 import { state } from "../state.js";
 
+/**
+ * Reduce a server-suggested download filename to a safe basename that cannot
+ * escape the download directory. `suggestedFilename` on Page.downloadWillBegin
+ * is derived from the remote response (Content-Disposition), i.e. it is
+ * untrusted input; a value like "../../../../etc/passwd" must never be joined
+ * onto the download path as-is. Strips any directory components (both `/` and
+ * `\`) and rejects `.`/`..`/empty so the result is always a single path
+ * segment. Returns "" when nothing safe remains, so callers can fall back.
+ */
+export function safeDownloadFilename(name: string | undefined): string {
+  const base = String(name ?? "")
+    .split(/[\\/]/)
+    .pop();
+  if (!base || base === "." || base === "..") {
+    return "";
+  }
+  return base;
+}
+
 type WaitForEventOptions = {
   timeout?: number;
 };
@@ -78,7 +97,14 @@ async function waitForDownload(options: WaitForEventOptions = {}) {
   if (progress.params?.state === "canceled") {
     throw new Error(`Download canceled: ${suggestedFilename}`);
   }
-  const downloadedPath = join(downloadDir, suggestedFilename);
+  // Derive the on-disk path from a sanitized basename, never the raw
+  // server-supplied name, so a crafted Content-Disposition filename cannot
+  // make path()/saveAs() read or write outside the download directory.
+  const safeName =
+    safeDownloadFilename(willBegin.params?.suggestedFilename) ||
+    safeDownloadFilename(guid) ||
+    "download";
+  const downloadedPath = join(downloadDir, safeName);
   return {
     suggestedFilename: () => suggestedFilename,
     url: () => willBegin.params?.url || "",


### PR DESCRIPTION
## Summary

`page.waitForEvent("download")` derived the on-disk download path by joining the remote-controlled `suggestedFilename` straight onto the download directory, with no sanitization. `suggestedFilename` comes from the downloaded response (`Content-Disposition`), so it is untrusted input. A crafted value like `../../../../etc/passwd` made `download.path()` and `download.saveAs()` operate on an arbitrary absolute path outside the download directory: an arbitrary local file read driven by web content, crossing the untrusted-page to host boundary.

## Related issue

Fixes #130 (full writeup, proof, and threat model there).

## The bug

`package/ego-browser/src/driver/downloads.ts`:

```ts
const downloadedPath = join(downloadDir, suggestedFilename); // untrusted name joined as-is
```

Proven at the harness level using this repo's own mock CDP bridge: firing `Page.downloadWillBegin` with `suggestedFilename: "../../../../../../../../etc/passwd"` makes `download.path()` resolve to `/etc/passwd` (outside the per-download temp dir), and `download.saveAs(dest)` then `copyFile`s from that attacker-chosen source.

## The fix

Add `safeDownloadFilename()`: strip any directory components (both `/` and `\`), reject `.` / `..` / empty, and use that basename when building the path, falling back to the download `guid` or `"download"`. The reported `suggestedFilename()` accessor value is intentionally unchanged (Playwright parity); only the path derivation is hardened.

```ts
const safeName =
  safeDownloadFilename(willBegin.params?.suggestedFilename) ||
  safeDownloadFilename(guid) ||
  "download";
const downloadedPath = join(downloadDir, safeName);
```

This mirrors how Playwright sanitizes suggested filenames before using them as paths.

## Verification

- New regression test `waitForEvent('download') keeps a traversal suggestedFilename inside the download dir` fires the traversal filename and asserts the resolved path stays within `tmpdir()` with no `..` segment. It fails against the pre-fix source (path escapes to `/etc/passwd`) and passes with this change.
- New unit tests for `safeDownloadFilename` cover `../` chains, `..\` (backslash), absolute paths, plain names, and `.` / `..` / empty / undefined.
- Full package suite green locally: `npm test` -> 308 passing (build + typecheck + tests). `prettier --check` clean on both changed files.

## Impact

- [x] Public helper API or behavior (download path derivation is hardened; `suggestedFilename()` value unchanged)
- [x] Security fix

No migration concerns: legitimate downloads with ordinary filenames are unaffected (basename of a normal name is the name itself).