### PR TITLE
fix(ego-browser): support waitForSelector state hidden and detached

### DIFF
--- a/package/ego-browser/src/driver/waits.test.mjs
+++ b/package/ego-browser/src/driver/waits.test.mjs
@@ -13,6 +13,7 @@ import {
   waitForLoadState,
   waitForRequest,
   waitForResponse,
+  waitForSelector,
   waitForURL,
 } from "../../dist/src/driver/waits.js";
 
@@ -857,6 +858,110 @@ test("waitForLoadState survives a bridge that rejects Network.enable", async () 
   try {
     const result = await waitForLoadState("networkidle", { timeout: 5000 });
     assert.equal(result, true, "falls back to passive observation");
+  } finally {
+    restore();
+  }
+});
+
+function selectorHarness({ attachedAt = () => true, visible = false }) {
+  let t = 0;
+  const sleeps = [];
+  let resolveCall = 0;
+  const restore = setOverrides({
+    now: () => t,
+    sleep: async (ms) => {
+      sleeps.push(ms);
+      t += ms;
+    },
+    cdpOverride: async (method) => {
+      if (method === "Runtime.evaluate") {
+        const attached = attachedAt(resolveCall++);
+        return attached ? { result: { objectId: "obj-1" } } : { result: {} };
+      }
+      if (method === "Runtime.callFunctionOn") {
+        return { result: { value: visible } };
+      }
+      return {};
+    },
+  });
+  return { restore, sleeps };
+}
+
+test("waitForSelector state:attached resolves once the element is present", async () => {
+  const { restore, sleeps } = selectorHarness({ attachedAt: () => true });
+  try {
+    assert.equal(await waitForSelector("#ready", { timeout: 1000 }), true);
+  } finally {
+    restore();
+  }
+  assert.deepEqual(sleeps, []);
+});
+
+test("waitForSelector state:visible resolves when the element is visible", async () => {
+  const { restore } = selectorHarness({
+    attachedAt: () => true,
+    visible: true,
+  });
+  try {
+    assert.equal(
+      await waitForSelector("#ready", { state: "visible", timeout: 1000 }),
+      true,
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("waitForSelector state:hidden resolves when the element is present but not visible", async () => {
+  const { restore } = selectorHarness({
+    attachedAt: () => true,
+    visible: false,
+  });
+  try {
+    assert.equal(
+      await waitForSelector("#spinner", { state: "hidden", timeout: 1000 }),
+      true,
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("waitForSelector state:hidden resolves immediately when the element is absent", async () => {
+  const { restore, sleeps } = selectorHarness({ attachedAt: () => false });
+  try {
+    assert.equal(
+      await waitForSelector("#spinner", { state: "hidden", timeout: 1000 }),
+      true,
+    );
+  } finally {
+    restore();
+  }
+  assert.deepEqual(sleeps, []);
+});
+
+test("waitForSelector state:hidden keeps waiting while the element stays visible", async () => {
+  const { restore } = selectorHarness({
+    attachedAt: () => true,
+    visible: true,
+  });
+  try {
+    assert.equal(
+      await waitForSelector("#spinner", { state: "hidden", timeout: 900 }),
+      false,
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("waitForSelector state:detached resolves after the element leaves the DOM", async () => {
+  const { restore } = selectorHarness({ attachedAt: (call) => call === 0 });
+  try {
+    assert.equal(
+      await waitForSelector("#dialog", { state: "detached", timeout: 1000 }),
+      true,
+    );
   } finally {
     restore();
   }

--- a/package/ego-browser/src/driver/waits.ts
+++ b/package/ego-browser/src/driver/waits.ts
@@ -8,7 +8,7 @@ import { waitForBrowserEvent } from "../browser-runtime.js";
 
 type WaitForSelectorOptions = {
   timeout?: number;
-  state?: "visible" | "attached";
+  state?: "visible" | "attached" | "hidden" | "detached";
 };
 
 type WaitForFunctionOptions = {
@@ -483,17 +483,19 @@ function acquireNetworkEvents() {
 }
 
 /**
- * Wait until an element exists, optionally requiring visibility.
+ * Wait until an element reaches a DOM state: "attached" (present, the default),
+ * "visible" (present and visible), "hidden" (absent or not visible), or
+ * "detached" (absent).
  * @param {string} selector CSS selector / @ref / loc= / xpath= to poll.
- * @param {{timeout?: number, state?: "visible"|"attached"}} [options] timeout in milliseconds; state defaults to "attached".
- * @returns {Promise<boolean>} True when found before timeout.
+ * @param {{timeout?: number, state?: "visible"|"attached"|"hidden"|"detached"}} [options] timeout in milliseconds; state defaults to "attached".
+ * @returns {Promise<boolean>} True when the state is reached before timeout.
  */
 export async function waitForSelector(
   selector: string,
   options: WaitForSelectorOptions = {},
 ) {
   const timeout = options.timeout ?? state.defaultTimeout;
-  const requireVisible = options.state === "visible";
+  const wanted = options.state ?? "attached";
   const deadline = state.now() + timeout;
   const visibilityFn =
     "function(){if(typeof this.checkVisibility==='function')return this.checkVisibility({checkOpacity:true,checkVisibilityCSS:true});const s=getComputedStyle(this);return s.display!=='none'&&s.visibility!=='hidden'&&s.opacity!=='0';}";
@@ -503,26 +505,31 @@ export async function waitForSelector(
       handle = await resolveHandle(selector);
     } catch (err) {
       if (err instanceof ElementResolutionError && err.kind === "transient") {
+        if (wanted === "hidden" || wanted === "detached") return true;
         await state.sleep(300);
-        continue; // not found / not ready yet — keep polling.
+        continue;
       }
-      throw err; // permanent (bad selector / ambiguous) or unknown error — fail loud.
+      throw err;
     }
     try {
-      if (!requireVisible) return true;
-      const response = await cdp(
-        "Runtime.callFunctionOn",
-        {
-          functionDeclaration: visibilityFn,
-          objectId: handle.objectId,
-          returnByValue: true,
-          awaitPromise: false,
-        },
-        handle.sessionId,
-      );
-      if (response.result?.value) return true;
+      if (wanted === "attached") return true;
+      if (wanted !== "detached") {
+        const response = await cdp(
+          "Runtime.callFunctionOn",
+          {
+            functionDeclaration: visibilityFn,
+            objectId: handle.objectId,
+            returnByValue: true,
+            awaitPromise: false,
+          },
+          handle.sessionId,
+        );
+        const visible = Boolean(response.result?.value);
+        if (wanted === "visible" && visible) return true;
+        if (wanted === "hidden" && !visible) return true;
+      }
     } catch {
-      // visibility check failed (element raced away); treat as not-ready, keep polling.
+      /* retry */
     } finally {
       await releaseHandle(handle.objectId, handle.sessionId);
     }


### PR DESCRIPTION
## Summary

`waitForSelector` (and therefore `locator.waitFor(...)`, which forwards its options verbatim) silently treats `state: "hidden"` and `state: "detached"` as `"attached"`: it returns `true` as soon as the element is present. The canonical "wait for the spinner to disappear" pattern — `await page.getByText('Loading').waitFor({ state: 'hidden' })` — therefore resolves immediately while the element is still visible, and the script proceeds too early. This implements the two missing states.

## Related issue

No existing issue. Found while checking the wait helpers for Playwright-style parity.

## Changes

- `src/driver/waits.ts`: `waitForSelector` now handles all four states — `attached` (default), `visible`, `hidden` (absent or not visible), `detached` (absent). The option type is widened accordingly. `attached`/`visible` and the default are unchanged.
- `src/driver/waits.test.mjs`: add coverage for `attached`, `visible`, `hidden` (present-but-hidden, absent, and stays-visible→timeout), and `detached`.

## Details

Old behavior derived only a boolean `requireVisible = options.state === "visible"`; any other state (including `hidden`/`detached`) fell through to the attached branch and returned `true` on first resolve. The facade `locator.waitFor(options)` passes `options` straight to `waitForSelector`, and both the README and SKILL market Playwright-style call shapes, so agents will pass these states — and get the opposite of the intended wait.

New behavior:
- `attached` — resolves when the element is present (default; unchanged).
- `visible` — resolves when present and visible (unchanged).
- `hidden` — resolves when the element is absent, or present but not visible.
- `detached` — resolves when the element is absent.

The `attached` default is preserved (documented in the JSDoc), so existing callers are unaffected.

## Verification

```text
npm test                     # 312 pass, incl. 6 new waitForSelector state tests
npm run typecheck            # clean
npm run validate:site-skills # ok
npx prettier --check         # clean
```

## Impact

- [x] Public helper API or behavior
- [ ] Agent skill or instructions
- [ ] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

`hidden`/`detached` were previously accepted but silently behaved like `attached`; they now behave correctly. No signature change and no change to `attached`/`visible`/default behavior. `SKILL.md`/`SKILL.zh.md` do not enumerate the state values, so no doc sync is required.

## Checklist

- [x] The PR targets the correct base branch (`dev`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added for the behavior change.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc updated to describe the four states.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [x] Release-note label: `fix`.
