### PR TITLE
feat: Linux host for ego-browser (shared Chromium + task spaces)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,21 @@ jobs:
       - run: npm test
       - run: npm run validate:site-skills
 
+  test-linux-host:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: package/ego-linux-host
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package/ego-linux-host/package-lock.json
+      - run: npm ci
+      - run: npm test
+
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: test

--- a/docs/superpowers/plans/2026-07-23-ego-linux-host.md
+++ b/docs/superpowers/plans/2026-07-23-ego-linux-host.md
@@ -1,0 +1,1041 @@
+# ego Linux Host Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship an ego-shaped Linux host (`package/ego-linux-host`) so agents can run `ego-browser` heredocs against a long-lived shared Chromium on Linux/WSL, with Task Spaces (tab sets + ownership), shared logins, and the existing OSS harness/skill.
+
+**Architecture:** A long-lived `ego-linux-hostd` supervises Chromium (CDP on loopback), owns space state, and exposes RPC over a Unix socket. A short-lived `ego-browser` CLI shim ensures the daemon is up, installs a `globalThis.ego` client that speaks that RPC, and runs the existing `package/ego-browser` harness on stdin JS. No Playwright/Puppeteer.
+
+**Tech Stack:** Node.js ≥ 22, TypeScript (ESM), `node:test` + `node:assert/strict`, native `ws` via undici/WebSocket or `chrome-remote-interface`-free raw WebSocket (`ws` package only if needed — prefer Node 22 built-in WebSocket), Unix domain sockets, stock Chromium/Chrome CDP.
+
+**Spec:** `docs/superpowers/specs/2026-07-23-ego-linux-host-design.md`
+
+## Global Constraints
+
+- CDP only — no Playwright, no Puppeteer.
+- One shared Chromium `user-data-dir` for all spaces (shared cookies/logins).
+- Spaces isolate **tab sets + ownership**, not storage partitions.
+- Do not break `package/ego-browser` tests; prefer zero harness changes.
+- Headed by default; headless only via `EGO_HEADLESS=1` / config.
+- Daemon and CDP bind loopback / local socket only.
+- Node ≥ 22, ESM only, match ego-browser conventions (camelCase helpers, co-located `*.test.mjs`).
+
+---
+
+## File structure (create)
+
+```text
+package/ego-linux-host/
+  package.json
+  tsconfig.json
+  README.md
+  bin/
+    ego-browser.mjs          # CLI entry (shim)
+    ego-linux-hostd.mjs      # daemon entry
+  scripts/
+    build.mjs
+  src/
+    paths.ts                 # data dir, socket, defaults
+    config.ts                # load config + env overrides
+    errors.ts                # EgoError helpers / codes
+    chrome-supervisor.ts     # find/launch/supervise Chrome
+    cdp-bridge.ts            # WebSocket CDP client
+    space-manager.ts         # spaces, ownership, tab membership
+    snapshot-engine.ts       # AX → { content, refs }
+    ego-runtime.ts           # daemon-side ego method implementations
+    host-daemon.ts           # socket server + ensure chrome
+    rpc.ts                   # JSON-RPC encode/decode
+    ego-client.ts            # CLI-side globalThis.ego
+    cli.ts                   # ego-browser shim logic
+    index.ts                 # re-exports if needed
+    *.test.mjs               # co-located tests (built to dist)
+  dist/                      # build output (gitignored)
+
+skills/ego-browser/
+  scripts/install-linux.sh
+  references/install.md      # append Linux section
+```
+
+---
+
+### Task 0: Scaffold package
+
+**Files:**
+- Create: `package/ego-linux-host/package.json`
+- Create: `package/ego-linux-host/tsconfig.json`
+- Create: `package/ego-linux-host/scripts/build.mjs`
+- Create: `package/ego-linux-host/README.md`
+- Create: `package/ego-linux-host/src/paths.ts`
+- Create: `package/ego-linux-host/src/paths.test.mjs`
+- Create: `package/ego-linux-host/.gitignore`
+
+**Interfaces:**
+- Consumes: none
+- Produces: build that emits `dist/`; `paths` module with `defaultDataDir()`, `defaultSocketPath()`, `defaultProfileDir()`
+
+- [ ] **Step 1: Create package.json**
+
+```json
+{
+  "name": "ego-linux-host",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": { "node": ">=22" },
+  "bin": {
+    "ego-browser": "./bin/ego-browser.mjs",
+    "ego-linux-hostd": "./bin/ego-linux-hostd.mjs"
+  },
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "node scripts/build.mjs",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run build && npm run typecheck && node --test \"dist/**/*.test.js\""
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^22.15.29",
+    "esbuild": "^0.28.1",
+    "typescript": "^5.8.3"
+  }
+}
+```
+
+- [ ] **Step 2: Create tsconfig.json**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}
+```
+
+- [ ] **Step 3: Create build.mjs (esbuild transpile src → dist)**
+
+```js
+import { mkdir, rm, readdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const dist = join(root, "dist");
+await rm(dist, { recursive: true, force: true });
+await mkdir(dist, { recursive: true });
+
+async function collectTs(dir) {
+  const out = [];
+  for (const ent of await readdir(dir, { withFileTypes: true })) {
+    const p = join(dir, ent.name);
+    if (ent.isDirectory()) out.push(...(await collectTs(p)));
+    else if (ent.name.endsWith(".ts") && !ent.name.endsWith(".d.ts")) out.push(p);
+    else if (ent.name.endsWith(".test.mjs")) out.push(p);
+  }
+  return out;
+}
+
+const entries = await collectTs(join(root, "src"));
+await build({
+  entryPoints: entries,
+  outdir: dist,
+  outbase: join(root, "src"),
+  platform: "node",
+  format: "esm",
+  target: "node22",
+  bundle: false,
+  sourcemap: true,
+});
+console.log(`built ${entries.length} files → dist/`);
+```
+
+Also copy `*.test.mjs` that import from `./foo.js` paths — keep tests as `.test.mjs` next to compiled `.js` by including them in entryPoints with `loader: { '.mjs': 'copy' }` or write tests under `src/` that import `../dist/...`. **Preferred:** put tests as `src/paths.test.mjs` importing `./paths.js` and after build copy mjs into dist:
+
+After esbuild, copy test files:
+
+```js
+import { cp } from "node:fs/promises";
+// for each src/**/*.test.mjs → dist/
+```
+
+Simpler approach for MVP: tests live as `src/*.test.mjs` and run with:
+
+```json
+"test": "npm run build && node --test \"src/**/*.test.mjs\""
+```
+
+…importing from `../dist/paths.js` — messy. **Use:** tests import relative `./paths.js` and run against `dist` after build by placing compiled tests only. Easiest path that works:
+
+1. Write TypeScript tests as `src/paths.test.ts` compiled by esbuild to `dist/paths.test.js`
+2. `"test": "npm run build && node --test \"dist/**/*.test.js\""`
+
+- [ ] **Step 4: Implement paths.ts**
+
+```ts
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const APP_NAME = "ego-lite";
+
+export function defaultDataDir(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.EGO_DATA_DIR) return env.EGO_DATA_DIR;
+  const xdg = env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+  return join(xdg, APP_NAME);
+}
+
+export function defaultConfigDir(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.EGO_CONFIG_DIR) return env.EGO_CONFIG_DIR;
+  const xdg = env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  return join(xdg, APP_NAME);
+}
+
+export function defaultProfileDir(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.EGO_USER_DATA_DIR) return env.EGO_USER_DATA_DIR;
+  return join(defaultDataDir(env), "profile");
+}
+
+export function defaultSocketPath(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.EGO_HOST_SOCK) return env.EGO_HOST_SOCK;
+  return join(defaultDataDir(env), "host.sock");
+}
+
+export function defaultCdpPort(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.EGO_CDP_PORT;
+  if (raw) return Number(raw);
+  return 9222;
+}
+```
+
+- [ ] **Step 5: Write paths.test.ts**
+
+```ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { defaultDataDir, defaultSocketPath, defaultCdpPort } from "./paths.js";
+
+test("defaultDataDir uses EGO_DATA_DIR", () => {
+  assert.equal(defaultDataDir({ EGO_DATA_DIR: "/tmp/ego-x" }), "/tmp/ego-x");
+});
+
+test("defaultSocketPath nests under data dir", () => {
+  const sock = defaultSocketPath({ EGO_DATA_DIR: "/tmp/ego-x" });
+  assert.equal(sock, "/tmp/ego-x/host.sock");
+});
+
+test("defaultCdpPort parses env", () => {
+  assert.equal(defaultCdpPort({ EGO_CDP_PORT: "9333" }), 9333);
+  assert.equal(defaultCdpPort({}), 9222);
+});
+```
+
+- [ ] **Step 6: npm install, build, test**
+
+```bash
+cd package/ego-linux-host
+npm install
+npm test
+```
+
+Expected: PASS for paths tests.
+
+- [ ] **Step 7: README.md** — state this is ego-shaped Linux host, not Citro app; link design spec.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add package/ego-linux-host
+git commit -m "feat(ego-linux-host): scaffold package, build, and paths"
+```
+
+---
+
+### Task 1: Config + error helpers
+
+**Files:**
+- Create: `package/ego-linux-host/src/config.ts`
+- Create: `package/ego-linux-host/src/config.test.ts`
+- Create: `package/ego-linux-host/src/errors.ts`
+- Create: `package/ego-linux-host/src/errors.test.ts`
+
+**Interfaces:**
+- Consumes: `paths.ts`
+- Produces: `loadConfig(): HostConfig`, `egoError(code, message)`, `isUserControlCode(code)`
+
+```ts
+// config.ts shape
+export type HostConfig = {
+  chromePath: string | null;
+  userDataDir: string;
+  cdpPort: number;
+  headless: boolean;
+  hostSocket: string;
+  dataDir: string;
+  seedFromChrome: boolean;
+};
+export async function loadConfig(env?: NodeJS.ProcessEnv): Promise<HostConfig>;
+```
+
+- [ ] **Step 1: Write failing tests for loadConfig env overrides**
+
+```ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loadConfig } from "./config.js";
+
+test("loadConfig honors EGO_HEADLESS and EGO_CDP_PORT", async () => {
+  const cfg = await loadConfig({
+    EGO_DATA_DIR: "/tmp/ego-cfg-test",
+    EGO_HEADLESS: "1",
+    EGO_CDP_PORT: "9444",
+  });
+  assert.equal(cfg.headless, true);
+  assert.equal(cfg.cdpPort, 9444);
+  assert.equal(cfg.userDataDir, "/tmp/ego-cfg-test/profile");
+});
+```
+
+- [ ] **Step 2: Implement config.ts** — read optional `~/.config/ego-lite/config.json` if present; env wins over file; defaults from paths.
+
+- [ ] **Step 3: Implement errors.ts** — re-export the same code strings as `package/ego-browser/src/ego-errors.ts` (copy the const list; do not import across packages yet to avoid coupling). Provide:
+
+```ts
+export function makeEgoError(
+  code: string,
+  message: string,
+): Error & { error_code: string } {
+  const err = new Error(message) as Error & { error_code: string };
+  err.error_code = code;
+  return err;
+}
+
+export function egoResultError(code: string, message: string) {
+  return { error: message, error_code: code };
+}
+```
+
+- [ ] **Step 4: npm test && commit**
+
+```bash
+npm test
+git add package/ego-linux-host/src
+git commit -m "feat(ego-linux-host): add config loader and ego error helpers"
+```
+
+---
+
+### Task 2: Chrome supervisor
+
+**Files:**
+- Create: `package/ego-linux-host/src/chrome-supervisor.ts`
+- Create: `package/ego-linux-host/src/chrome-supervisor.test.ts`
+
+**Interfaces:**
+- Consumes: `HostConfig`
+- Produces:
+
+```ts
+export function resolveChromePath(env?: NodeJS.ProcessEnv, explicit?: string | null): string | null;
+export type ChromeHandle = {
+  pid: number;
+  cdpPort: number;
+  userDataDir: string;
+  kill(): Promise<void>;
+};
+export async function ensureChrome(config: HostConfig): Promise<ChromeHandle>;
+export async function isCdpUp(port: number): Promise<boolean>;
+```
+
+- [ ] **Step 1: Write tests for resolveChromePath**
+
+```ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveChromePath } from "./chrome-supervisor.js";
+import { writeFile, chmod, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+test("resolveChromePath prefers EGO_CHROME_PATH when executable", async () => {
+  const dir = join(tmpdir(), `ego-chrome-${process.pid}`);
+  await mkdir(dir, { recursive: true });
+  const bin = join(dir, "fake-chrome");
+  await writeFile(bin, "#!/bin/sh\nexit 0\n");
+  await chmod(bin, 0o755);
+  assert.equal(resolveChromePath({ EGO_CHROME_PATH: bin }), bin);
+});
+```
+
+- [ ] **Step 2: Implement resolveChromePath** — check explicit, env, then candidates: `google-chrome-stable`, `google-chrome`, `chromium`, `chromium-browser`, `/usr/bin/google-chrome`, `/usr/bin/chromium`. Use `fs.access` + `X_OK` or `which` via `command -v` spawn.
+
+- [ ] **Step 3: Implement isCdpUp** — `fetch(http://127.0.0.1:${port}/json/version)` success.
+
+- [ ] **Step 4: Implement ensureChrome**
+
+Logic:
+1. If `isCdpUp(config.cdpPort)` → return handle without pid (attached mode) or discover pid best-effort.
+2. Else resolve chrome path; throw `EGO_BROWSER_UNAVAILABLE` if missing.
+3. `mkdir` userDataDir.
+4. Spawn with args from design; if `!config.headless` and no `DISPLAY`/`WAYLAND_DISPLAY`, either set headless with stderr warning **or** throw with clear message — **implement throw** unless `EGO_HEADLESS=1` so headed-by-default is honest.
+5. Poll `isCdpUp` up to 15s.
+6. Return handle with `kill` using process group.
+
+- [ ] **Step 5: Unit-test isCdpUp against closed port (false)**
+
+```ts
+test("isCdpUp is false for closed port", async () => {
+  assert.equal(await isCdpUp(1), false);
+});
+```
+
+- [ ] **Step 6: npm test && commit**
+
+```bash
+npm test
+git commit -am "feat(ego-linux-host): chrome path resolution and supervisor"
+```
+
+---
+
+### Task 3: CDP bridge
+
+**Files:**
+- Create: `package/ego-linux-host/src/cdp-bridge.ts`
+- Create: `package/ego-linux-host/src/cdp-bridge.test.ts`
+
+**Interfaces:**
+
+```ts
+export type CdpBridge = {
+  send(method: string, params?: object, sessionId?: string): Promise<any>;
+  sendRaw(payload: object): void;
+  onEvent(handler: (msg: any) => void): () => void;
+  close(): Promise<void>;
+  listPageTargets(): Promise<Array<{ targetId: string; title: string; url: string; type: string }>>;
+  createTarget(url: string): Promise<string>;
+  attach(targetId: string): Promise<string>; // sessionId
+};
+export async function connectCdp(port: number): Promise<CdpBridge>;
+```
+
+- [ ] **Step 1: Write unit test with a mock WebSocket server** (or mock at a higher seam). Prefer testing message id correlation with a tiny fake:
+
+```ts
+// Test pure request/response map without real Chrome:
+// export internal createCdpClient({ send, onMessage }) for injection.
+```
+
+Expose:
+
+```ts
+export function createCdpSession(transport: {
+  send(text: string): void;
+  onMessage(cb: (text: string) => void): void;
+}): {
+  send(method: string, params?: object, sessionId?: string): Promise<any>;
+  handleIncoming(text: string): void;
+};
+```
+
+- [ ] **Step 2: Implement createCdpSession** — incrementing id, pending Map, timeout 15s, route events (no id) to listeners.
+
+- [ ] **Step 3: Implement connectCdp(port)** — GET `/json/version` → `webSocketDebuggerUrl` → `new WebSocket(url)` (Node 22 global). Wire transport.
+
+- [ ] **Step 4: Implement listPageTargets via `Target.getTargets`**, filter `type === 'page'`.
+
+- [ ] **Step 5: Implement createTarget via `Target.createTarget`**.
+
+- [ ] **Step 6: Tests for id correlation + timeout**
+
+```ts
+test("createCdpSession resolves matching id", async () => {
+  let handler;
+  const transport = {
+    send(text) {
+      const msg = JSON.parse(text);
+      handler(JSON.stringify({ id: msg.id, result: { ok: true } }));
+    },
+    onMessage(cb) {
+      handler = cb;
+    },
+  };
+  const session = createCdpSession(transport);
+  // need to connect onMessage - design createCdpSession to register itself
+  const result = await session.send("Foo.bar");
+  assert.deepEqual(result, { ok: true });
+});
+```
+
+- [ ] **Step 7: npm test && commit**
+
+```bash
+git commit -am "feat(ego-linux-host): CDP bridge with session attach helpers"
+```
+
+---
+
+### Task 4: Space manager
+
+**Files:**
+- Create: `package/ego-linux-host/src/space-manager.ts`
+- Create: `package/ego-linux-host/src/space-manager.test.ts`
+
+**Interfaces:**
+
+```ts
+export type Ownership = "agent" | "agentDelegatedToUser" | "user";
+export type Space = {
+  taskId: string;
+  id: number;
+  name: string;
+  createdBy: "agent" | "user";
+  ownership: Ownership;
+  recentTabTitles?: string[];
+  targetIds: string[];
+};
+
+export class SpaceManager {
+  constructor(persistPath?: string);
+  async load(): Promise<void>;
+  async save(): Promise<void>;
+  list(): Space[]; // public records without targetIds? include for internal; strip for ego list API
+  listPublic(): Array<Omit<Space, "targetIds"> & { recentTabTitles?: string[] }>;
+  createAgentSpace(name: string): Space;
+  use(id: number): { ok: true; space: Space } | { ok: false; error_code: string; error: string };
+  claim(id: number, name?: string): Space;
+  handOff(): void;
+  takeOver(): void;
+  completeKeep(): void;
+  closeSelected(): string[]; // returns targetIds to close in Chrome
+  selected(): Space | null;
+  assignTarget(targetId: string, spaceId?: number): void;
+  targetsForSelected(): string[];
+  spaceIdForTarget(targetId: string): number | null;
+  adoptOrphanTargets(targetIds: string[]): void; // unknowns → user
+}
+```
+
+- [ ] **Step 1: Write tests first (full ownership matrix)**
+
+```ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { SpaceManager } from "./space-manager.js";
+
+test("bootstraps user space id 1", () => {
+  const sm = new SpaceManager();
+  const user = sm.list().find((s) => s.id === 1);
+  assert.equal(user?.ownership, "user");
+  assert.equal(user?.name, "user");
+});
+
+test("createAgentSpace assigns tabs independently", () => {
+  const sm = new SpaceManager();
+  const a = sm.createAgentSpace("job-a");
+  const b = sm.createAgentSpace("job-b");
+  sm.use(a.id);
+  sm.assignTarget("t1");
+  sm.use(b.id);
+  sm.assignTarget("t2");
+  sm.use(a.id);
+  assert.deepEqual(sm.targetsForSelected(), ["t1"]);
+  sm.use(b.id);
+  assert.deepEqual(sm.targetsForSelected(), ["t2"]);
+});
+
+test("use on user space selects but marks user control for page ops", () => {
+  const sm = new SpaceManager();
+  const result = sm.use(1);
+  assert.equal(result.ok, true);
+  assert.equal(sm.selected()?.ownership, "user");
+  assert.equal(sm.isPageControlBlocked(), true);
+});
+
+test("handOff then takeOver", () => {
+  const sm = new SpaceManager();
+  const a = sm.createAgentSpace("x");
+  sm.use(a.id);
+  sm.handOff();
+  assert.equal(sm.selected()?.ownership, "agentDelegatedToUser");
+  assert.equal(sm.isPageControlBlocked(), true);
+  sm.takeOver();
+  assert.equal(sm.selected()?.ownership, "agent");
+  assert.equal(sm.isPageControlBlocked(), false);
+});
+
+test("claim moves user space to agent", () => {
+  const sm = new SpaceManager();
+  sm.claim(1);
+  assert.equal(sm.list().find((s) => s.id === 1)?.ownership, "agent");
+});
+```
+
+- [ ] **Step 2: Implement SpaceManager** until all tests pass. Persist JSON `{ nextId, selectedId, spaces: [...] }` when `persistPath` set.
+
+- [ ] **Step 3: npm test && commit**
+
+```bash
+git commit -am "feat(ego-linux-host): space manager with ownership and tab sets"
+```
+
+---
+
+### Task 5: Snapshot engine
+
+**Files:**
+- Create: `package/ego-linux-host/src/snapshot-engine.ts`
+- Create: `package/ego-linux-host/src/snapshot-engine.test.ts`
+- Create: `package/ego-linux-host/src/fixtures/ax-tree-minimal.json` (minimal AX nodes)
+
+**Interfaces:**
+
+```ts
+export type SnapshotOptions = {
+  scope?: "only_within_viewport" | "full_page";
+  includeActionMarks?: boolean;
+  includeStableLocator?: boolean;
+  maxResultLength?: number;
+};
+export type SnapshotResult = {
+  content: string;
+  refs: Array<{ id: number; backendNodeId: number; role?: string; name?: string }>;
+};
+export function axTreeToSnapshot(axNodes: any[], options?: SnapshotOptions): SnapshotResult;
+export async function snapshotPage(
+  cdp: CdpBridge,
+  sessionId: string,
+  options?: SnapshotOptions,
+): Promise<SnapshotResult>;
+```
+
+- [ ] **Step 1: Fixture-based test**
+
+```ts
+test("axTreeToSnapshot emits refs with backendNodeId", async () => {
+  const ax = JSON.parse(await readFile(new URL("./fixtures/ax-tree-minimal.json", import.meta.url), "utf8"));
+  const snap = axTreeToSnapshot(ax.nodes, { includeActionMarks: true });
+  assert.ok(snap.content.length > 0);
+  assert.ok(snap.refs.length > 0);
+  assert.equal(typeof snap.refs[0].backendNodeId, "number");
+  assert.match(snap.content, /@1/);
+});
+
+test("maxResultLength truncates content", () => {
+  const snap = axTreeToSnapshot(manyNodes, { maxResultLength: 1 });
+  assert.ok(snap.content.length <= 1);
+});
+```
+
+- [ ] **Step 2: Implement serializer** — walk AX nodes; for each interesting role (button, link, textbox, heading, StaticText, etc.) allocate sequential ref id; line format like `@1 button "Submit"`. Skip ignored/generic empty nodes.
+
+- [ ] **Step 3: snapshotPage** — `Accessibility.enable`, `Accessibility.getFullAXTree`, map nodes, return. On failure throw `EGO_SNAPSHOT_FAILED`.
+
+- [ ] **Step 4: npm test && commit**
+
+```bash
+git commit -am "feat(ego-linux-host): AX snapshot engine with ref map"
+```
+
+---
+
+### Task 6: Daemon ego runtime + RPC
+
+**Files:**
+- Create: `package/ego-linux-host/src/rpc.ts`
+- Create: `package/ego-linux-host/src/rpc.test.ts`
+- Create: `package/ego-linux-host/src/ego-runtime.ts`
+- Create: `package/ego-linux-host/src/ego-runtime.test.ts`
+- Create: `package/ego-linux-host/src/host-daemon.ts`
+- Create: `package/ego-linux-host/bin/ego-linux-hostd.mjs`
+
+**Interfaces:**
+
+```ts
+// rpc.ts — newline-delimited JSON
+export type RpcRequest = { id: number; method: string; params?: any };
+export type RpcResponse = { id: number; result?: any; error?: { code: string; message: string } };
+export type RpcEvent = { event: string; params?: any };
+
+// ego-runtime.ts — methods matching globalThis.ego, used by daemon
+export function createEgoRuntime(deps: {
+  spaceManager: SpaceManager;
+  getCdp: () => CdpBridge;
+  ensureSession: () => Promise<string>;
+}): {
+  handle(method: string, params: any): Promise<any>;
+  // also used to push CDP events to subscribers
+};
+```
+
+RPC methods (CLI → daemon):
+
+| method | params | result |
+|---|---|---|
+| `ping` | — | `{ ok: true, version }` |
+| `doctor` | — | doctor object |
+| `ego.listTaskSpaces` | — | ego return |
+| `ego.createTaskSpace` | `{ name }` | space |
+| `ego.useTaskSpace` | `{ id }` | id or error object |
+| `ego.claimTaskSpace` | `{ id, name? }` | space |
+| `ego.completeTaskSpace` | — | ok |
+| `ego.closeTaskSpace` | — | ok |
+| `ego.handOffTaskSpace` | — | ok |
+| `ego.takeOverTaskSpace` | — | ok |
+| `ego.listTabs` | — | `{ tabs }` |
+| `ego.createTab` | `{ url }` | `{ targetId }` |
+| `ego.snapshot` | options | `{ content, refs }` |
+| `ego.sendCDPMessage` | `{ payload: string }` | fire-and-forget ack; responses via events |
+| `reload` | — | ok |
+
+Events daemon → CLI: `cdp.message` with `{ payload: string }`, `cdp.sendError` with `{ message, error_code? }`.
+
+- [ ] **Step 1: rpc encode/decode tests**
+
+- [ ] **Step 2: ego-runtime unit tests with FakeCdp + SpaceManager** — listTabs filters by space; createTab assigns; snapshot blocked when `isPageControlBlocked()`.
+
+```ts
+test("snapshot rejects under user control", async () => {
+  const runtime = createEgoRuntime({ spaceManager: sm, getCdp: () => fakeCdp, ensureSession });
+  sm.use(1); // user
+  await assert.rejects(
+    () => runtime.handle("snapshot", {}),
+    (err) => err.error_code === "EGO_TASK_SPACE_USER_IN_CONTROL",
+  );
+});
+```
+
+- [ ] **Step 3: Implement listTabs filtering** — get all page targets from CDP; keep those in `spaceManager.targetsForSelected()`; if selected is agent space and empty, return `[]` (not user tabs).
+
+- [ ] **Step 4: Implement createTab** — CDP createTarget; `assignTarget`; return `{ targetId }`.
+
+- [ ] **Step 5: Implement sendCDPMessage path** — parse JSON; if page-domain and blocked, call sendError path; else forward; bridge events → RPC events.
+
+- [ ] **Step 6: host-daemon.ts** — `listen` on Unix socket (unlink stale sock); on connection, NDJSON lines; ensureChrome + connectCdp on start; write pid file.
+
+- [ ] **Step 7: bin/ego-linux-hostd.mjs**
+
+```js
+#!/usr/bin/env node
+import { startDaemon } from "../dist/host-daemon.js";
+await startDaemon();
+```
+
+- [ ] **Step 8: Integration test without Chrome** — SpaceManager + runtime only (already unit). Optional: spawn daemon with mock — skip if heavy.
+
+- [ ] **Step 9: npm test && commit**
+
+```bash
+git commit -am "feat(ego-linux-host): daemon RPC and ego runtime core"
+```
+
+---
+
+### Task 7: CLI ego client + shim
+
+**Files:**
+- Create: `package/ego-linux-host/src/ego-client.ts`
+- Create: `package/ego-linux-host/src/ego-client.test.ts`
+- Create: `package/ego-linux-host/src/cli.ts`
+- Create: `package/ego-linux-host/bin/ego-browser.mjs`
+
+**Interfaces:**
+
+```ts
+export async function connectHost(socketPath: string): Promise<HostConnection>;
+export function installEgoClient(conn: HostConnection): void; // sets globalThis.ego
+
+export async function runCli(argv: string[], opts?: {
+  stdin?: NodeJS.ReadableStream;
+  stdout?: NodeJS.WritableStream;
+  stderr?: NodeJS.WritableStream;
+  env?: NodeJS.ProcessEnv;
+  harnessPath?: string;
+}): Promise<number>;
+```
+
+- [ ] **Step 1: ego-client tests with mock HostConnection**
+
+```ts
+test("installEgoClient listTabs proxies to RPC", async () => {
+  const calls = [];
+  const conn = {
+    async request(method, params) {
+      calls.push([method, params]);
+      if (method === "ego.listTabs") return { tabs: [] };
+      return {};
+    },
+    onEvent() { return () => {}; },
+  };
+  installEgoClient(conn);
+  const result = await globalThis.ego.listTabs();
+  assert.deepEqual(result, { tabs: [] });
+  assert.deepEqual(calls[0][0], "ego.listTabs");
+});
+```
+
+- [ ] **Step 2: Implement sendCDPMessage client** — RPC `ego.sendCDPMessage`; wire `onEvent('cdp.message')` → `ego.onCDPMessage?.(payload)`.
+
+- [ ] **Step 3: ensureHost in cli.ts**
+
+```ts
+export async function ensureHost(config: HostConfig): Promise<void> {
+  if (await pingSocket(config.hostSocket)) return;
+  // spawn: node bin/ego-linux-hostd.mjs detached, stdio log file
+  // poll ping up to 15s
+}
+```
+
+- [ ] **Step 4: Resolve harness path**
+
+Order:
+1. `EGO_HARNESS_PATH`
+2. `../ego-browser/dist/out/index.js` relative to this package
+3. `../ego-browser/artifacts/ego-browser/index.js` if present
+
+If missing, run instructions: `cd package/ego-browser && npm ci && npm run build`.
+
+- [ ] **Step 5: runCli**
+
+```ts
+// pseudo
+if (argv includes --help) print help; return 0;
+if (argv includes --doctor) { ensureHost; print doctor; return 0; }
+if (argv includes --reload) { ensureHost; rpc reload; return 0; }
+// strip leading "nodejs" if present
+ensureHost(config);
+const conn = await connectHost(config.hostSocket);
+installEgoClient(conn);
+// Dynamic import harness runMain — better: spawn node harness with ego already set is hard across processes.
+// Same process:
+const harness = await import(pathToFileURL(harnessPath).href);
+// Harness isDirectCli may auto-run — use runMain export:
+return await harness.runMain({ argv: remaining, stdin, stdout, stderr });
+```
+
+**Important:** The harness `index.js` when imported as module should **not** auto-run if `isDirectCli()` is false. Confirm: `installEgoSdk` on import may expect `globalThis.ego` already present — set ego **before** import, or only import `run.js` / call `runMain` after `installEgoClient`.
+
+Preferred import:
+
+```ts
+const { runMain } = await import(pathToFileURL(join(egoBrowserRoot, "dist/src/run.js")).href);
+// and helpers path needs ego present for browser-runtime
+```
+
+Actually helpers read `globalThis.ego` at call time, not import time. So:
+
+```ts
+installEgoClient(conn);
+const { runMain } = await import(harnessRunUrl);
+return await runMain({ argv: [], stdin, stdout, stderr });
+```
+
+Also set `EGO_BROWSER_AGENT_WORKSPACE` default to repo `skills/ego-browser` if unset.
+
+- [ ] **Step 6: bin/ego-browser.mjs**
+
+```js
+#!/usr/bin/env node
+import { runCli } from "../dist/cli.js";
+const code = await runCli(process.argv.slice(2));
+process.exit(code ?? 0);
+```
+
+- [ ] **Step 7: Unit tests for argv parsing** (`nodejs` strip, help)
+
+- [ ] **Step 8: npm test && commit**
+
+```bash
+git commit -am "feat(ego-linux-host): ego-browser CLI shim and host client"
+```
+
+---
+
+### Task 8: Wire end-to-end smoke (manual + opt-in automated)
+
+**Files:**
+- Create: `package/ego-linux-host/scripts/smoke.sh`
+- Create: `package/ego-linux-host/src/e2e-smoke.test.ts` (skip if `EGO_LINUX_E2E` not set)
+
+- [ ] **Step 1: Build both packages**
+
+```bash
+cd package/ego-browser && npm ci && npm run build
+cd ../ego-linux-host && npm test
+```
+
+- [ ] **Step 2: smoke.sh**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export PATH="$ROOT/bin:$PATH"
+# ensure node resolves bin to this package
+node "$ROOT/bin/ego-browser.mjs" --doctor
+node "$ROOT/bin/ego-browser.mjs" nodejs <<'EOF'
+const task = await taskSpaces.useOrCreate('linux-smoke')
+await browser.openOrReuseTab('https://example.com', { wait: true, timeout: 20000 })
+const title = await page.title()
+const snap = await page.snapshot()
+if (!title) throw new Error('missing title')
+if (!snap || !String(snap).trim()) throw new Error('empty snapshot')
+console.log(JSON.stringify({ taskSpaceId: task.id, title, snapHead: String(snap).slice(0, 200) }, null, 2))
+EOF
+```
+
+- [ ] **Step 3: Run smoke if Chrome + display available; otherwise document skip**
+
+```bash
+chmod +x package/ego-linux-host/scripts/smoke.sh
+# EGO_LINUX_E2E=1 ./scripts/smoke.sh
+```
+
+- [ ] **Step 4: e2e test gates on env**
+
+```ts
+import test from "node:test";
+const enabled = process.env.EGO_LINUX_E2E === "1";
+test("e2e smoke example.com", { skip: !enabled }, async () => {
+  // spawn smoke or inline
+});
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "test(ego-linux-host): add smoke script and optional e2e gate"
+```
+
+---
+
+### Task 9: Install script + skill docs
+
+**Files:**
+- Create: `skills/ego-browser/scripts/install-linux.sh`
+- Modify: `skills/ego-browser/references/install.md`
+- Modify: `package/ego-linux-host/README.md` (install section)
+
+- [ ] **Step 1: install-linux.sh**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+# 1. uname Linux
+# 2. node -v major >= 22
+# 3. npm ci && build ego-browser + ego-linux-host
+# 4. mkdir -p ~/.local/bin ~/.local/share/ego-lite
+# 5. ln -sfn "$REPO_ROOT/package/ego-linux-host/bin/ego-browser.mjs" ~/.local/bin/ego-browser
+# 6. chmod +x bins
+# 7. detect chrome; warn if missing
+# 8. PATH check for ~/.local/bin
+# 9. ego-browser --doctor || true
+```
+
+- [ ] **Step 2: Update install.md** — new section **Install steps (Linux / WSL)** pointing to `install-linux.sh`, headed/WSLg notes, headless opt-in, not the Citro DMG.
+
+- [ ] **Step 3: Manual dry-run**
+
+```bash
+bash skills/ego-browser/scripts/install-linux.sh
+command -v ego-browser
+ego-browser --doctor
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/ego-browser/scripts/install-linux.sh skills/ego-browser/references/install.md package/ego-linux-host/README.md
+git commit -m "docs(ego-browser): Linux install script and install reference"
+```
+
+---
+
+### Task 10: Hardening + doctor completeness
+
+**Files:**
+- Modify: `package/ego-linux-host/src/host-daemon.ts`
+- Modify: `package/ego-linux-host/src/cli.ts`
+- Modify: `package/ego-linux-host/src/chrome-supervisor.ts`
+
+- [ ] **Step 1: doctor fields** — chromePath, chromeRunning, cdpPort, cdpUp, profileDir, socketPath, daemonPid, spaceCount, selectedSpace, headless, displayEnv, harnessPath.
+
+- [ ] **Step 2: Stale socket recovery** — if sock exists but ping fails, unlink and restart.
+
+- [ ] **Step 3: Chrome death** — next ensureChrome respawns; ego methods throw `EGO_BROWSER_UNAVAILABLE` with clear text.
+
+- [ ] **Step 4: Optional `--seed-chrome`** in install only (copy Default profile dirs when source Chrome not running) — document; feature-flag if risky.
+
+- [ ] **Step 5: Verify OSS harness tests still pass**
+
+```bash
+cd package/ego-browser && npm test
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -am "fix(ego-linux-host): doctor, stale socket recovery, chrome respawn"
+```
+
+---
+
+### Task 11: Acceptance checklist (manual)
+
+Run against the design acceptance criteria:
+
+- [ ] **Step 1:** `install-linux.sh` → `ego-browser` on PATH  
+- [ ] **Step 2:** `ego-browser --doctor` healthy  
+- [ ] **Step 3:** linux-smoke heredoc (example.com title + snapshot)  
+- [ ] **Step 4:** Manual tab in browser → not visible in agent space `listTabs`  
+- [ ] **Step 5:** `handOff` → snapshot errors with user-control → `takeOver` recovers  
+- [ ] **Step 6:** Two spaces, disjoint tabs  
+- [ ] **Step 7:** Second heredoc reuses space by name  
+- [ ] **Step 8:** `package/ego-browser` `npm test` green  
+
+- [ ] **Step 9: Final commit if docs tweaks**
+
+```bash
+git commit -am "docs(ego-linux-host): note MVP acceptance status"
+```
+
+---
+
+## Self-review (plan vs spec)
+
+| Spec section | Tasks |
+|---|---|
+| Architecture / package location | 0, 6, 7 |
+| Shared profile + tab-set spaces | 2, 4 |
+| globalThis.ego contract | 5, 6, 7 |
+| Daemon + CLI + install | 6, 7, 9, 10 |
+| Snapshot AX best-effort | 5 |
+| Acceptance + phases | 8, 11 |
+| Non-goals (no Playwright, no Citro UI) | Global constraints |
+
+**Placeholder scan:** none intentional — open items from spec (RPC = NDJSON methods table above; harness path order in Task 7; content line format in Task 5) are fixed in this plan.
+
+**Type consistency:** `Space`, `SnapshotResult`, `HostConfig` names used consistently across tasks.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-23-ego-linux-host.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, review between tasks (`superpowers:subagent-driven-development`)
+2. **Inline Execution** — this session with `superpowers:executing-plans`, batch with checkpoints
+
+Which approach?

--- a/docs/superpowers/specs/2026-07-23-ego-linux-host-design.md
+++ b/docs/superpowers/specs/2026-07-23-ego-linux-host-design.md
@@ -1,0 +1,423 @@
+# ego Linux Host (ego-shaped) — Design Spec
+
+**Date:** 2026-07-23  
+**Status:** Approved for planning  
+**Repo:** local clone of `citrolabs/ego-lite` at `/home/iago/projeto/ego-lite`  
+**Audience:** implementers building a Linux runtime that preserves the product purpose of ego lite
+
+---
+
+## 1. Problem and purpose
+
+ego lite’s purpose (from the upstream README) is:
+
+> The best browser for both you and your AI agents work in parallel.
+
+It is **not** a generic browser-automation framework. Contrasts that define success:
+
+| ego lite is | ego lite is not |
+|---|---|
+| One browser humans and agents share | A separate automation browser (browser-use, agent-browser) |
+| Agents in isolated **Spaces**; user tabs stay user | Agent and human fighting for the same tabs |
+| Agents inherit **real logins** | Clean profile with login friction every time |
+| **Code-base**: one JS heredoc with helpers | Multi-round CLI loops |
+| Semantic snapshot + external agents via `ego-browser` | Only a built-in agent, or only headless drivers |
+
+**Platform fact:** the closed-source ego lite **app** (Chromium customization, kernel-level snapshot, native UI) ships only for macOS today. This repository is the **open-source harness + skill**, not the browser binary (`AGENTS.md`, `CONTRIBUTING.md`).
+
+**Goal of this work:** implement an **ego-shaped Linux host** so that, on Linux/WSL, agents can drive a shared Chromium through the existing `ego-browser` skill and harness, preserving the product model as far as stock Chromium + CDP allow.
+
+**Non-goal:** reverse-engineering or shipping a drop-in clone of the Citro macOS app (native Spaces UI, kernel-level snapshot parity, full Chrome extension migration).
+
+---
+
+## 2. Decisions (locked)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Product shape | Shared Chromium host (human + agent), not agent-only headless driver | Matches README purpose |
+| Code location | New package `package/ego-linux-host/` in this clone | Keeps harness + skill + host together |
+| Task Space isolation | **Tab sets** in one shared profile (shared cookies/logins) | CONTRIBUTING: spaces own their tab set but **inherit user login state** |
+| Transport | CDP only — **no Playwright / Puppeteer** | CONTRIBUTING tech stack |
+| Browser process | Long-lived Chromium + long-lived host daemon | State lives browser-side, not in the Node heredoc process |
+| Default display | Headed (WSLg/DISPLAY); headless only opt-in | Human and agent share the browser |
+| Upstream app | Not required for MVP | Host fills `globalThis.ego` that the OSS harness already expects |
+
+---
+
+## 3. Architecture
+
+### 3.1 Components
+
+```text
+┌─ package/ego-linux-host (new) ──────────────────────────┐
+│  chrome-supervisor   Launch/supervise persistent Chrome │
+│  cdp-bridge          WebSocket CDP ↔ sendCDPMessage     │
+│  space-manager       Spaces, ownership, tab membership  │
+│  snapshot-engine     AX+DOM → { content, refs }         │
+│  ego-runtime         Implements globalThis.ego contract │
+│  host-daemon         Long process + local control socket│
+│  cli-shim            ego-browser → inject ego + harness │
+└──────────────────────────────▲──────────────────────────┘
+                               │ globalThis.ego
+┌──────────────────────────────┴──────────────────────────┐
+│  package/ego-browser (OSS harness — keep stable)        │
+│  skills/ego-browser (skill / install docs)              │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Runtime flow
+
+1. User or agent invokes `ego-browser` (CLI shim on `PATH`).
+2. Shim ensures `ego-linux-hostd` is running; daemon ensures Chromium is running with a fixed `user-data-dir` and loopback CDP port.
+3. Each heredoc is a **short-lived Node process** that:
+   - connects to the daemon (local socket),
+   - installs `globalThis.ego` client bindings,
+   - executes the existing OSS harness (`runMain` / built bundle) against stdin JS.
+4. **Durable state** (spaces, ownership, tab membership, profile/logins) lives in the daemon + Chromium profile — not in the heredoc process.
+
+### 3.3 What stays unchanged
+
+- Public helper surface and skill workflow (`taskSpaces`, `page`, `browser`, one-heredoc composition).
+- OSS unit tests under `package/ego-browser` must keep passing.
+- Prefer wiring via shim/env over forking harness contracts.
+
+---
+
+## 4. Task Space model
+
+### 4.1 Definition
+
+A Task Space is a **named browsing workspace** with:
+
+- numeric `id` and string `name` / `taskId`
+- `ownership`: `"agent" | "agentDelegatedToUser" | "user"`
+- `createdBy`: `"agent" | "user"`
+- ordered set of CDP page `targetId`s (its tabs)
+- optional `recentTabTitles`
+
+Isolation is of **tabs and control**, not of cookie jars. All spaces share one Chromium `user-data-dir` so logins carry.
+
+### 4.2 System spaces
+
+| Space | ownership | Role |
+|---|---|---|
+| `user` (fixed low id, e.g. `1`) | `user` | Human’s default tab set |
+| Agent-created | `agent` | Default for `useOrCreate` |
+| After handoff | `agentDelegatedToUser` | Still agent-owned for policy tables; page ops blocked until `takeOver` |
+
+Ownership **policy tables** already live in `package/ego-browser/src/helpers.ts` and `skills/ego-browser/SKILL.md`. The host enforces boundaries at the native bridge.
+
+### 4.3 Enforcement rules
+
+1. `listTabs` / `createTab` / session attach operate only on the **currently selected** space’s targets (agent view).
+2. New tabs from `createTab` join the selected space.
+3. Tabs opened by the human in the UI without space metadata join the `user` space (MVP).
+4. Agents never receive another space’s `targetId` from `listTabs` (except explicit debug flags).
+5. Parallel agent spaces = disjoint tab sets.
+6. Selecting a `user`-owned space via `useTaskSpace` is allowed for listing identity, but page-level work and `snapshot` fail with `EGO_TASK_SPACE_USER_IN_CONTROL` until `claim` (or appropriate take-over flow).
+7. `handOffTaskSpace` → ownership `agentDelegatedToUser`; page ops / snapshot reject with user-control code.
+8. `takeOverTaskSpace` → back to `agent`.
+9. `completeTaskSpace` with keep true/false follows harness semantics (`complete` vs `close` on ego bindings).
+10. MVP selection: one global selected space id in the daemon (one agent per machine). Multi-client selection is backlog.
+
+### 4.4 Space record shape (harness-compatible)
+
+```ts
+{
+  taskId: string,
+  id: number,
+  name: string,
+  createdBy: "agent" | "user",
+  ownership: "agent" | "agentDelegatedToUser" | "user",
+  recentTabTitles?: string[]
+}
+```
+
+Persistence: best-effort `spaces.json` under the data dir; live membership also in daemon memory. After crash, orphan page targets reattach to `user` unless recoverable metadata says otherwise.
+
+---
+
+## 5. `globalThis.ego` contract (host must implement)
+
+The OSS harness calls these. Signatures are behavioral contracts inferred from `helpers.ts`, `browser-runtime.ts`, `nav.ts`, `observe.ts`, and tests.
+
+### 5.1 CDP channel
+
+| API | Behavior |
+|---|---|
+| `sendCDPMessage(payloadJson: string)` | Send one CDP message (id/method/params/sessionId) |
+| `onCDPMessage` | Host invokes with JSON string responses/events |
+| `onSendCDPMessageError` | Host invokes on local send failures (incl. inactive/user-control) |
+
+### 5.2 Tabs
+
+| API | Behavior |
+|---|---|
+| `listTabs()` | `{ tabs: [{ targetId, title, url, active, index? }] }` filtered to selected space |
+| `createTab(url)` | `{ targetId }` in selected space |
+
+### 5.3 Task spaces
+
+| API | Behavior |
+|---|---|
+| `listTaskSpaces()` | `{ taskSpaces: Space[] }` |
+| `createTaskSpace(name)` | create agent-owned space + return record |
+| `useTaskSpace(id: number)` | select space; may return `{ error, error_code }` for user control |
+| `claimTaskSpace(id, name?)` | user → agent, then usable |
+| `completeTaskSpace()` | complete selected (keep path) |
+| `closeTaskSpace()` | close selected space and its tabs |
+| `handOffTaskSpace()` | agent → agentDelegatedToUser |
+| `takeOverTaskSpace()` | restore agent control |
+
+### 5.4 Snapshot
+
+| API | Behavior |
+|---|---|
+| `snapshot(options)` | `{ content: string, refs: Ref[] }` or reject |
+
+`refs` entries must include `backendNodeId` (required by `browserSnapshotRefsToRefMap` / element resolver). Options include `scope`, `includeActionMarks`, `includeStableLocator`, `maxResultLength`.
+
+Under user-control ownership, `snapshot` **must reject** with `EGO_TASK_SPACE_USER_IN_CONTROL` (used by `waitForAgentControl` probe).
+
+### 5.5 Optional (MVP may no-op)
+
+- `animationHighlightMouseToPosition?(x, y)`
+- `setAgentTaskState?(label)`
+
+### 5.6 Error codes
+
+Host should emit stable codes from `package/ego-browser/src/ego-errors.ts`, especially:
+
+- `EGO_TASK_SPACE_USER_IN_CONTROL`
+- `EGO_TASK_SPACE_NOT_SELECTED`
+- `EGO_TASK_SPACE_NOT_FOUND`
+- `EGO_TASK_SPACE_INACTIVE`
+- `EGO_BROWSER_UNAVAILABLE`
+- `EGO_CDP_CHANNEL_UNAVAILABLE`
+- `EGO_CDP_SEND_FAILED`
+- `EGO_SNAPSHOT_FAILED`
+- `EGO_OPERATION_FAILED`
+
+Shapes: thrown `Error` with `.error_code`, or resolved `{ error, error_code }`.
+
+---
+
+## 6. Daemon, Chromium, CLI, install
+
+### 6.1 Processes
+
+| Process | Lifetime | Role |
+|---|---|---|
+| `ego-linux-hostd` | Long | Spaces, CDP client, snapshot, RPC |
+| Chromium/Chrome | Long | Profile, tabs, logins |
+| `ego-browser` | Short per heredoc | Ensure host, inject ego, run harness |
+
+### 6.2 Paths
+
+```text
+~/.local/share/ego-lite/
+  profile/       # Chromium user-data-dir
+  spaces.json
+  host.pid
+  host.log
+  host.sock      # default control socket
+
+~/.config/ego-lite/
+  config.json
+
+~/.local/bin/ego-browser
+```
+
+- Control: Unix socket default; TCP `127.0.0.1` fallback if needed on WSL.
+- Chrome CDP: `127.0.0.1` only (e.g. port `9222`).
+- Directory mode `0700`.
+
+### 6.3 Chrome supervisor
+
+Resolve binary: `EGO_CHROME_PATH` → config → `google-chrome` / `chromium` on `PATH` → common paths.
+
+Flags (minimum):
+
+- `--user-data-dir=<profile>`
+- `--remote-debugging-port=<port>`
+- `--remote-debugging-address=127.0.0.1`
+- `--no-first-run`
+- `--no-default-browser-check`
+
+Do **not** disable web security. Headed default; `EGO_HEADLESS=1` opt-in. If no display on WSL, fail or headless **with an explicit message**.
+
+Respawn Chrome when dead; CLI respawns daemon when dead. Prefer reusing an already-running debug Chrome on the same profile when safe.
+
+### 6.4 CLI shim behavior
+
+```bash
+ego-browser nodejs <<'EOF'
+# skill-shaped
+EOF
+
+ego-browser <<'EOF'
+# harness-shaped
+EOF
+```
+
+- Treat `nodejs` as an optional no-op subcommand for skill compatibility.
+- Support `--doctor`, `--reload`, `-h` / `--help`.
+- `--doctor`: chrome path, daemon health, CDP port, profile, space count, selected space, headed/headless, display.
+- `--reload`: drop cached CDP sessions; reattach.
+
+### 6.5 Config and env
+
+`config.json` fields: `chromePath`, `userDataDir`, `cdpPort`, `headless`, `seedFromChrome`, `hostSocket`.
+
+Env overrides: `EGO_CHROME_PATH`, `EGO_USER_DATA_DIR`, `EGO_CDP_PORT`, `EGO_HEADLESS`, `EGO_HOST_SOCK`, `EGO_BROWSER_AGENT_WORKSPACE` (existing harness).
+
+### 6.6 Install (Linux)
+
+Add:
+
+- `package/ego-linux-host/` (implementation)
+- `skills/ego-browser/scripts/install-linux.sh`
+- Linux section in `skills/ego-browser/references/install.md`
+
+`install-linux.sh`:
+
+1. Require Linux + Node ≥ 22.
+2. Build `package/ego-browser` and `package/ego-linux-host`.
+3. Symlink `ego-browser` into `~/.local/bin`; remind about PATH.
+4. Detect Chrome; print install hints if missing (do not silent `apt install` without consent).
+5. Create data dirs.
+6. Optional `--seed-chrome` only when Chrome is closed; document risk.
+7. Smoke: `--doctor` + minimal heredoc when environment allows.
+
+macOS `install.sh` remains macOS-only (DMG). This host does not download Citro’s app.
+
+### 6.7 WSL notes
+
+- Prefer WSLg for headed.
+- MVP targets **Linux-side** Chrome/Chromium, not Windows `chrome.exe`.
+- Document Windows Chrome as out of scope for MVP.
+
+---
+
+## 7. Snapshot engine
+
+### 7.1 Pipeline (MVP)
+
+1. Resolve active page target in selected space.
+2. Fail fast with user-control code when ownership blocks agent work.
+3. `Accessibility.getFullAXTree` via CDP; keep nodes with `backendDOMNodeId`.
+4. Optionally enrich weak AX with simple DOM labels.
+5. Iframes: one level of child targets in MVP.
+6. Serialize compact text `content` (roles, names, `@N` marks when `includeActionMarks`).
+7. Build `refs[]` with real `backendNodeId` values.
+
+### 7.2 Quality bar
+
+Good enough for skill patterns: `page.snapshot()` + semantic locators + `@N` refs.  
+**Not** claimed to match Citro kernel-level snapshot quality. Document the gap in host README / install docs.
+
+---
+
+## 8. Testing strategy
+
+| Layer | Scope | Requires Chrome |
+|---|---|---|
+| Unit | space-manager, isolation, error codes | No |
+| Unit | snapshot serializer from AX fixtures | No |
+| Integration | daemon RPC + CLI `--doctor` | Optional |
+| E2E smoke | example.com title + snapshot | Yes, opt-in `EGO_LINUX_E2E=1` |
+| Regression | `package/ego-browser` `npm test` | No |
+
+---
+
+## 9. Acceptance criteria (MVP)
+
+1. `install-linux.sh` places a working `ego-browser` on `PATH` (with documented PATH fix if needed).
+2. `ego-browser --doctor` reports healthy daemon + Chrome + profile.
+3. Skill-shaped heredoc works:
+
+```bash
+ego-browser nodejs <<'EOF'
+const task = await taskSpaces.useOrCreate('linux-smoke')
+await browser.openOrReuseTab('https://example.com', { wait: true, timeout: 20000 })
+const title = await page.title()
+const snap = await page.snapshot()
+if (!title) throw new Error('missing title')
+if (!snap || !String(snap).trim()) throw new Error('empty snapshot')
+console.log(JSON.stringify({ taskSpaceId: task.id, title, snapHead: String(snap).slice(0, 200) }, null, 2))
+EOF
+```
+
+4. User-space tabs are not listed in an agent space’s `listTabs`.
+5. Snapshot/page ops under user-control fail with `EGO_TASK_SPACE_USER_IN_CONTROL`.
+6. Two agent spaces keep disjoint tab sets.
+7. A second heredoc reattaches the same space by name/id (daemon state).
+8. Handoff → blocked snapshot → `takeOver` → snapshot works.
+9. `cd package/ego-browser && npm test` remains green.
+
+---
+
+## 10. Delivery phases
+
+| Phase | Deliverable | Testable outcome |
+|---|---|---|
+| **0 — Scaffold** | Package layout, build, CLI stub, host README (limits) | `--help` |
+| **1 — Chrome + CDP** | supervisor + cdp-bridge + send/listTabs/createTab | CDP navigation works |
+| **2 — Spaces** | space-manager, ownership, tab filter, error codes | isolation + handoff |
+| **3 — Snapshot** | AX pipeline + refs | `page.snapshot()` usable |
+| **4 — Shim + install** | PATH shim, `install-linux.sh`, skill install docs | end-to-end skill smoke |
+| **5 — Hardening** | doctor details, respawn, optional seed, opt-in e2e | daily WSL stability |
+
+Order is intentional: CDP → Spaces → Snapshot → install polish.
+
+---
+
+## 11. Explicit non-goals / backlog
+
+- Native Spaces UI / agent overlay chrome like macOS app  
+- Kernel-level snapshot parity  
+- Full Chrome extension/keychain migration  
+- Multi-agent selected-space isolation by client id  
+- Windows host  
+- Driving Windows Chrome from WSL  
+- npm publish / marketplace packaging  
+- Upstream PR to Citro before local stability  
+
+---
+
+## 12. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| WSL without display | Document WSLg; explicit headless opt-in messaging |
+| Weaker snapshots than macOS | Rely on harness locators; iterate serializer with fixtures |
+| Profile singleton lock | Single daemon owns profile; doctor explains lock errors |
+| Space state loss on crash | Best-effort `spaces.json`; orphans → `user` |
+| Contract drift vs closed app | Contract tests derived from OSS FakeEgo + helpers |
+| Scope creep into “full browser product” | Non-goals section; phase gates |
+
+---
+
+## 13. Success definition (product language)
+
+On Linux/WSL, a developer can:
+
+1. Install the Linux host with one script.
+2. Keep a real Chromium window for themselves (user space).
+3. Have any agent CLI run `ego-browser` heredocs in **agent Spaces** without stealing user tabs.
+4. Benefit from **shared logins** on the persistent profile.
+5. Compose multi-step browser work in **one code heredoc** using the existing skill — the core ego lite promise, without the macOS app.
+
+---
+
+## 14. Open items deferred to implementation plan
+
+These are intentionally not blocked for design approval:
+
+- Exact RPC schema (JSON-RPC vs custom line protocol) on `host.sock`
+- Exact module file tree under `package/ego-linux-host/src/`
+- Whether the shim shells into `node artifacts/...` or `node package/ego-browser/dist/out/index.js`
+- Concrete AX serialization format details (string layout of `content`)
+
+They belong in `docs/superpowers/plans/` with bite-sized tasks.

--- a/package/ego-linux-host/.gitignore
+++ b/package/ego-linux-host/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/package/ego-linux-host/README.md
+++ b/package/ego-linux-host/README.md
@@ -1,0 +1,116 @@
+# ego-linux-host
+
+ego-shaped Linux host for ego lite: a long-lived Chromium supervisor plus CLI shim so agents can run `ego-browser` heredocs against a shared browser on Linux/WSL.
+
+This is **not** the Citro/macOS ego app. It is an OSS-friendly host that approximates the ego product model (shared profile/logins, Task Spaces as tab sets + ownership, CDP-only) on stock Chromium.
+
+**Design spec:** [`docs/superpowers/specs/2026-07-23-ego-linux-host-design.md`](../../docs/superpowers/specs/2026-07-23-ego-linux-host-design.md)
+
+## Status
+
+MVP host: daemon, CDP bridge, Task Spaces, CLI shim, doctor diagnostics, stale-socket recovery, and Chrome respawn on next ensure.
+
+**MVP acceptance (2026-07-23):** manual checklist PASS on Linux headed Chrome — `ego-browser` on PATH, `--doctor` healthy, example.com smoke (title + snapshot), user-tab isolation, two-space disjoint tabs, space reuse by name, handoff → `EGO_TASK_SPACE_USER_IN_CONTROL` → `takeOver` recovery, `package/ego-browser` and `package/ego-linux-host` unit tests green. Details: `.superpowers/sdd/task-11-report.md`.
+
+## Requirements
+
+- Linux (or WSL with Linux-side Chrome/Chromium)
+- Node.js ≥ 22
+- ESM only
+- Chrome/Chromium for a live browser (not required for unit tests)
+
+## Install (recommended)
+
+From the monorepo root, use the skill installer (builds harness + host, symlinks `ego-browser` into `~/.local/bin`, creates data dirs, detects Chrome, runs `--doctor`):
+
+```bash
+bash skills/ego-browser/scripts/install-linux.sh
+```
+
+Notes:
+
+- This is the **ego-shaped Linux host**, not the Citro/macOS ego lite DMG. Do not run `skills/ego-browser/scripts/install.sh` on Linux.
+- Ensure `~/.local/bin` is on your `PATH` (`export PATH="$HOME/.local/bin:$PATH"`).
+- Headed: prefer WSLg / native display (`DISPLAY` set). Headless: `export EGO_HEADLESS=1`.
+- Non-standard Chrome: `export EGO_CHROME_PATH=/path/to/chrome`.
+- **Profile seed** (`seedFromChrome` / future `--seed-chrome`): off by default and **risky** (can corrupt a live Chrome profile). See install docs; do not enable unless Chrome is closed and you accept the risk.
+
+Details and troubleshooting: [`skills/ego-browser/references/install.md`](../../skills/ego-browser/references/install.md) (section **Install steps (Linux / WSL)**).
+
+Manual alternative (same outcome as the installer steps):
+
+```bash
+cd package/ego-browser && npm ci && npm run build
+cd ../ego-linux-host && npm ci && npm run build
+mkdir -p ~/.local/bin ~/.local/share/ego-lite
+ln -sfn "$(pwd)/bin/ego-browser.mjs" ~/.local/bin/ego-browser
+export PATH="$HOME/.local/bin:$PATH"
+ego-browser --doctor
+```
+
+## Build and test
+
+```bash
+npm install
+npm run build     # esbuild: src/**/*.ts → dist/
+npm run typecheck
+npm test          # build + typecheck + node --test dist/**/*.test.js
+```
+
+Default `npm test` is Chrome-free. Opt-in E2E (example.com title + snapshot) is gated on `EGO_LINUX_E2E=1`.
+
+### End-to-end smoke
+
+Full smoke needs:
+
+1. Built helper harness: `cd package/ego-browser && npm ci && npm run build` (produces `dist/src/run.js`)
+2. Chrome/Chromium on `PATH`, or `EGO_CHROME_PATH`
+3. A display (`DISPLAY` set) for headed mode, or `EGO_HEADLESS=1`
+
+```bash
+# from package/ego-linux-host
+./scripts/smoke.sh
+# or
+EGO_LINUX_E2E=1 npm test
+```
+
+Without Chrome + display, skip the smoke script; unit/integration tests still pass.
+
+## Path defaults
+
+| Helper | Env override | Default |
+|--------|--------------|---------|
+| `defaultDataDir()` | `EGO_DATA_DIR` | `$XDG_DATA_HOME/ego-lite` or `~/.local/share/ego-lite` |
+| `defaultConfigDir()` | `EGO_CONFIG_DIR` | `$XDG_CONFIG_HOME/ego-lite` or `~/.config/ego-lite` |
+| `defaultProfileDir()` | `EGO_USER_DATA_DIR` | `<dataDir>/profile` |
+| `defaultSocketPath()` | `EGO_HOST_SOCK` | `<dataDir>/host.sock` |
+| `defaultCdpPort()` | `EGO_CDP_PORT` | `9222` |
+
+## Diagnostics (`ego-browser --doctor`)
+
+Reports (among others): `chromePath`, `chromeRunning`, `cdpPort`, `cdpUp`, `profileDir`, `socketPath`, `daemonPid`, `spaceCount`, `selectedSpace`, `headless`, `displayEnv`, `harnessPath`.
+
+Hardening behavior:
+
+- **Stale socket**: if `host.sock` exists but ping fails, the CLI unlinks it and restarts the daemon.
+- **Chrome death**: the next ego RPC that needs the browser re-runs `ensureChrome` (attach if CDP is back, otherwise respawn). Failures surface as `EGO_BROWSER_UNAVAILABLE` with clear text.
+
+## Source layout
+
+```text
+package/ego-linux-host/
+  package.json
+  tsconfig.json
+  scripts/build.mjs
+  bin/
+    ego-browser.mjs
+    ego-linux-hostd.mjs
+  src/
+    *.ts
+  dist/                 # build output (gitignored)
+```
+
+## Related
+
+- Helper harness: [`package/ego-browser`](../ego-browser)
+- Agent skill: [`skills/ego-browser`](../../skills/ego-browser)

--- a/package/ego-linux-host/bin/ego-browser.mjs
+++ b/package/ego-linux-host/bin/ego-browser.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import { runCli } from "../dist/cli.js";
+
+const code = await runCli(process.argv.slice(2));
+process.exit(code ?? 0);

--- a/package/ego-linux-host/bin/ego-linux-hostd.mjs
+++ b/package/ego-linux-host/bin/ego-linux-hostd.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import { startDaemon } from "../dist/host-daemon.js";
+
+const daemon = await startDaemon();
+
+const shutdown = async (signal) => {
+  try {
+    await daemon.close();
+  } catch {
+    // ignore
+  }
+  process.exit(signal === "SIGTERM" || signal === "SIGINT" ? 0 : 1);
+};
+
+process.on("SIGINT", () => void shutdown("SIGINT"));
+process.on("SIGTERM", () => void shutdown("SIGTERM"));
+
+// Keep process alive; socket server owns the event loop.

--- a/package/ego-linux-host/package-lock.json
+++ b/package/ego-linux-host/package-lock.json
@@ -1,0 +1,540 @@
+{
+  "name": "ego-linux-host",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ego-linux-host",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "ego-browser": "bin/ego-browser.mjs",
+        "ego-linux-hostd": "bin/ego-linux-hostd.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.29",
+        "esbuild": "^0.28.1",
+        "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package/ego-linux-host/package.json
+++ b/package/ego-linux-host/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "ego-linux-host",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": { "node": ">=22" },
+  "bin": {
+    "ego-browser": "./bin/ego-browser.mjs",
+    "ego-linux-hostd": "./bin/ego-linux-hostd.mjs"
+  },
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "node scripts/build.mjs",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run build && npm run typecheck && node --test \"dist/**/*.test.js\""
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^22.15.29",
+    "esbuild": "^0.28.1",
+    "typescript": "^5.8.3"
+  }
+}

--- a/package/ego-linux-host/scripts/build.mjs
+++ b/package/ego-linux-host/scripts/build.mjs
@@ -1,0 +1,46 @@
+import { mkdir, rm, readdir, copyFile } from "node:fs/promises";
+import { join, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const srcRoot = join(root, "src");
+const dist = join(root, "dist");
+await rm(dist, { recursive: true, force: true });
+await mkdir(dist, { recursive: true });
+
+async function collectByExt(dir, ext) {
+  const out = [];
+  for (const ent of await readdir(dir, { withFileTypes: true })) {
+    const p = join(dir, ent.name);
+    if (ent.isDirectory()) out.push(...(await collectByExt(p, ext)));
+    else if (ent.name.endsWith(ext) && !ent.name.endsWith(".d.ts")) out.push(p);
+  }
+  return out;
+}
+
+const entries = await collectByExt(srcRoot, ".ts");
+await build({
+  entryPoints: entries,
+  outdir: dist,
+  outbase: srcRoot,
+  platform: "node",
+  format: "esm",
+  target: "node22",
+  bundle: false,
+  sourcemap: true,
+});
+
+// Copy non-TS fixtures so tests can load them via import.meta.url
+const fixtures = await collectByExt(srcRoot, ".json");
+for (const file of fixtures) {
+  const rel = relative(srcRoot, file);
+  const dest = join(dist, rel);
+  await mkdir(dirname(dest), { recursive: true });
+  await copyFile(file, dest);
+}
+
+console.log(
+  `built ${entries.length} files → dist/` +
+    (fixtures.length ? ` (+${fixtures.length} fixtures)` : ""),
+);

--- a/package/ego-linux-host/scripts/smoke.sh
+++ b/package/ego-linux-host/scripts/smoke.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# End-to-end smoke for ego-linux-host (example.com title + snapshot).
+#
+# Prerequisites (full smoke):
+#   - Chrome/Chromium on PATH, or EGO_CHROME_PATH pointing at a binary
+#   - A display for headed mode (DISPLAY set), or EGO_HEADLESS=1
+#   - Built harness: cd package/ego-browser && npm ci && npm run build
+#     (produces dist/src/run.js used by the CLI shim)
+#   - Built host: cd package/ego-linux-host && npm run build
+#
+# Usage:
+#   ./scripts/smoke.sh
+#   EGO_LINUX_E2E=1 npm test   # opt-in automated gate in e2e-smoke.test.ts
+#
+# Without Chrome + display the script will fail at --doctor or navigation;
+# unit tests remain green when EGO_LINUX_E2E is unset.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export PATH="$ROOT/bin:$PATH"
+# ensure node resolves bin to this package
+node "$ROOT/bin/ego-browser.mjs" --doctor
+node "$ROOT/bin/ego-browser.mjs" nodejs <<'EOF'
+const task = await taskSpaces.useOrCreate('linux-smoke')
+await browser.openOrReuseTab('https://example.com', { wait: true, timeout: 20000 })
+const title = await page.title()
+const snap = await page.snapshot()
+if (!title) throw new Error('missing title')
+if (!snap || !String(snap).trim()) throw new Error('empty snapshot')
+console.log(JSON.stringify({ taskSpaceId: task.id, title, snapHead: String(snap).slice(0, 200) }, null, 2))
+EOF

--- a/package/ego-linux-host/src/cdp-bridge.test.ts
+++ b/package/ego-linux-host/src/cdp-bridge.test.ts
@@ -1,0 +1,406 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { createServer, type IncomingMessage } from "node:http";
+import type { Socket } from "node:net";
+import {
+  createCdpSession,
+  createCdpBridge,
+  connectCdp,
+} from "./cdp-bridge.js";
+
+/** Minimal injectable transport: records sends and delivers replies via onMessage. */
+function mockTransport() {
+  let handler: ((text: string) => void) | undefined;
+  const sent: string[] = [];
+  const transport = {
+    sent,
+    send(text: string) {
+      sent.push(text);
+    },
+    onMessage(cb: (text: string) => void) {
+      handler = cb;
+    },
+    deliver(obj: object) {
+      assert.ok(handler, "onMessage must be registered");
+      handler!(JSON.stringify(obj));
+    },
+    /** Auto-reply to each send with result (or custom builder). */
+    autoReply(resultOrBuilder: object | ((msg: any) => object)) {
+      const prevSend = transport.send.bind(transport);
+      transport.send = (text: string) => {
+        prevSend(text);
+        const msg = JSON.parse(text);
+        const reply =
+          typeof resultOrBuilder === "function"
+            ? resultOrBuilder(msg)
+            : { id: msg.id, result: resultOrBuilder };
+        queueMicrotask(() => transport.deliver(reply));
+      };
+    },
+  };
+  return transport;
+}
+
+/** Minimal RFC6455 text-frame WebSocket server on an HTTP server upgrade. */
+function attachMinimalWsServer(
+  httpServer: ReturnType<typeof createServer>,
+  onText: (text: string, reply: (text: string) => void) => void,
+) {
+  const onUpgrade = (
+    req: IncomingMessage,
+    socket: Socket,
+    head: Buffer,
+  ) => {
+    if (!req.url?.startsWith("/devtools/browser/")) {
+      socket.destroy();
+      return;
+    }
+    const key = req.headers["sec-websocket-key"];
+    if (!key || typeof key !== "string") {
+      socket.destroy();
+      return;
+    }
+    const accept = createHash("sha1")
+      .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+      .digest("base64");
+    socket.write(
+      "HTTP/1.1 101 Switching Protocols\r\n" +
+        "Upgrade: websocket\r\n" +
+        "Connection: Upgrade\r\n" +
+        `Sec-WebSocket-Accept: ${accept}\r\n` +
+        "\r\n",
+    );
+
+    let buf = head?.length ? Buffer.from(head) : Buffer.alloc(0);
+
+    const sendText = (text: string) => {
+      const payload = Buffer.from(text, "utf8");
+      let header: Buffer;
+      if (payload.length < 126) {
+        header = Buffer.alloc(2);
+        header[0] = 0x81;
+        header[1] = payload.length;
+      } else if (payload.length < 65536) {
+        header = Buffer.alloc(4);
+        header[0] = 0x81;
+        header[1] = 126;
+        header.writeUInt16BE(payload.length, 2);
+      } else {
+        header = Buffer.alloc(10);
+        header[0] = 0x81;
+        header[1] = 127;
+        header.writeBigUInt64BE(BigInt(payload.length), 2);
+      }
+      socket.write(Buffer.concat([header, payload]));
+    };
+
+    socket.on("data", (chunk) => {
+      buf = Buffer.concat([buf, chunk]);
+      while (buf.length >= 2) {
+        const opcode = buf[0] & 0x0f;
+        const masked = (buf[1] & 0x80) !== 0;
+        let len = buf[1] & 0x7f;
+        let off = 2;
+        if (len === 126) {
+          if (buf.length < 4) return;
+          len = buf.readUInt16BE(2);
+          off = 4;
+        } else if (len === 127) {
+          if (buf.length < 10) return;
+          len = Number(buf.readBigUInt64BE(2));
+          off = 10;
+        }
+        const maskLen = masked ? 4 : 0;
+        if (buf.length < off + maskLen + len) return;
+        let payload = buf.subarray(off + maskLen, off + maskLen + len);
+        if (masked) {
+          const mask = buf.subarray(off, off + 4);
+          payload = Buffer.from(payload);
+          for (let i = 0; i < payload.length; i++) payload[i] ^= mask[i % 4];
+        }
+        buf = buf.subarray(off + maskLen + len);
+        if (opcode === 0x8) {
+          socket.end();
+          return;
+        }
+        if (opcode === 0x1) {
+          onText(payload.toString("utf8"), sendText);
+        }
+      }
+    });
+  };
+
+  httpServer.on("upgrade", onUpgrade);
+  return () => httpServer.off("upgrade", onUpgrade);
+}
+
+test("createCdpSession resolves matching id", async () => {
+  let handler: ((text: string) => void) | undefined;
+  const transport = {
+    send(text: string) {
+      const msg = JSON.parse(text);
+      handler!(JSON.stringify({ id: msg.id, result: { ok: true } }));
+    },
+    onMessage(cb: (text: string) => void) {
+      handler = cb;
+    },
+  };
+  const session = createCdpSession(transport);
+  const result = await session.send("Foo.bar");
+  assert.deepEqual(result, { ok: true });
+});
+
+test("createCdpSession increments ids and correlates concurrent sends", async () => {
+  const t = mockTransport();
+  const session = createCdpSession(t);
+
+  const p1 = session.send("A.one");
+  const p2 = session.send("B.two");
+
+  assert.equal(t.sent.length, 2);
+  const m1 = JSON.parse(t.sent[0]);
+  const m2 = JSON.parse(t.sent[1]);
+  assert.equal(m1.id, 1);
+  assert.equal(m2.id, 2);
+  assert.equal(m1.method, "A.one");
+  assert.equal(m2.method, "B.two");
+
+  // Resolve out of order
+  t.deliver({ id: 2, result: { second: true } });
+  t.deliver({ id: 1, result: { first: true } });
+
+  assert.deepEqual(await p2, { second: true });
+  assert.deepEqual(await p1, { first: true });
+});
+
+test("createCdpSession includes params and sessionId when provided", async () => {
+  const t = mockTransport();
+  t.autoReply({});
+  const session = createCdpSession(t);
+  await session.send("Runtime.evaluate", { expression: "1" }, "sess-9");
+  const msg = JSON.parse(t.sent[0]);
+  assert.equal(msg.method, "Runtime.evaluate");
+  assert.deepEqual(msg.params, { expression: "1" });
+  assert.equal(msg.sessionId, "sess-9");
+});
+
+test("createCdpSession rejects CDP error responses", async () => {
+  const t = mockTransport();
+  t.autoReply((msg) => ({
+    id: msg.id,
+    error: { code: -32000, message: "Target closed" },
+  }));
+  const session = createCdpSession(t);
+  await assert.rejects(
+    () => session.send("Page.navigate"),
+    (err: Error & { error_code?: string }) => {
+      assert.match(err.message, /Target closed/);
+      assert.equal(err.error_code, "EGO_CDP_SEND_FAILED");
+      return true;
+    },
+  );
+});
+
+test("createCdpSession times out pending requests", async () => {
+  const t = mockTransport();
+  const session = createCdpSession(t, { timeoutMs: 30 });
+  await assert.rejects(
+    () => session.send("Slow.method"),
+    (err: Error & { error_code?: string }) => {
+      assert.match(err.message, /timeout/i);
+      assert.match(err.message, /Slow\.method/);
+      assert.equal(err.error_code, "EGO_CDP_SEND_FAILED");
+      return true;
+    },
+  );
+});
+
+test("createCdpSession routes events (no id) to onEvent listeners", async () => {
+  const t = mockTransport();
+  const session = createCdpSession(t);
+  const events: any[] = [];
+  const unsub = session.onEvent((msg) => events.push(msg));
+
+  t.deliver({ method: "Target.targetCreated", params: { targetId: "t1" } });
+  t.deliver({ method: "Page.loadEventFired", params: {}, sessionId: "s1" });
+
+  assert.equal(events.length, 2);
+  assert.equal(events[0].method, "Target.targetCreated");
+  assert.equal(events[1].sessionId, "s1");
+
+  unsub();
+  t.deliver({ method: "Inspector.detached", params: {} });
+  assert.equal(events.length, 2, "unsubscribed handler must not receive more");
+});
+
+test("createCdpSession handleIncoming is public for direct injection", async () => {
+  const t = mockTransport();
+  const session = createCdpSession(t);
+  const p = session.send("X.y");
+  const msg = JSON.parse(t.sent[0]);
+  session.handleIncoming(JSON.stringify({ id: msg.id, result: { direct: 1 } }));
+  assert.deepEqual(await p, { direct: 1 });
+});
+
+test("createCdpBridge listPageTargets filters type===page", async () => {
+  const t = mockTransport();
+  t.autoReply((msg) => {
+    assert.equal(msg.method, "Target.getTargets");
+    return {
+      id: msg.id,
+      result: {
+        targetInfos: [
+          {
+            targetId: "p1",
+            type: "page",
+            title: "Hello",
+            url: "https://example.com",
+          },
+          {
+            targetId: "s1",
+            type: "service_worker",
+            title: "",
+            url: "https://example.com/sw.js",
+          },
+          {
+            targetId: "p2",
+            type: "page",
+            title: "Other",
+            url: "about:blank",
+          },
+        ],
+      },
+    };
+  });
+  const bridge = createCdpBridge(t);
+  const pages = await bridge.listPageTargets();
+  assert.deepEqual(pages, [
+    {
+      targetId: "p1",
+      title: "Hello",
+      url: "https://example.com",
+      type: "page",
+    },
+    { targetId: "p2", title: "Other", url: "about:blank", type: "page" },
+  ]);
+});
+
+test("createCdpBridge createTarget returns targetId", async () => {
+  const t = mockTransport();
+  t.autoReply((msg) => {
+    assert.equal(msg.method, "Target.createTarget");
+    assert.deepEqual(msg.params, { url: "https://ego.test/" });
+    return { id: msg.id, result: { targetId: "new-tab-1" } };
+  });
+  const bridge = createCdpBridge(t);
+  const id = await bridge.createTarget("https://ego.test/");
+  assert.equal(id, "new-tab-1");
+});
+
+test("createCdpBridge attach returns sessionId with flatten", async () => {
+  const t = mockTransport();
+  t.autoReply((msg) => {
+    assert.equal(msg.method, "Target.attachToTarget");
+    assert.deepEqual(msg.params, { targetId: "tid-7", flatten: true });
+    return { id: msg.id, result: { sessionId: "session-abc" } };
+  });
+  const bridge = createCdpBridge(t);
+  const sessionId = await bridge.attach("tid-7");
+  assert.equal(sessionId, "session-abc");
+});
+
+test("createCdpBridge sendRaw emits JSON without waiting", () => {
+  const t = mockTransport();
+  const bridge = createCdpBridge(t);
+  bridge.sendRaw({ id: 99, method: "Foo", params: {} });
+  assert.equal(t.sent.length, 1);
+  assert.deepEqual(JSON.parse(t.sent[0]), {
+    id: 99,
+    method: "Foo",
+    params: {},
+  });
+});
+
+test("connectCdp opens WebSocket from /json/version and rounds trips", async () => {
+  const httpServer = createServer((req, res) => {
+    if (req.url === "/json/version") {
+      const host = req.headers.host || "127.0.0.1";
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          Browser: "Fake/1.0",
+          "Protocol-Version": "1.3",
+          webSocketDebuggerUrl: `ws://${host}/devtools/browser/fake`,
+        }),
+      );
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, "127.0.0.1", resolve),
+  );
+  const addr = httpServer.address();
+  assert.ok(addr && typeof addr === "object");
+  const port = addr.port;
+
+  const detach = attachMinimalWsServer(httpServer, (text, reply) => {
+    try {
+      const msg = JSON.parse(text);
+      if (msg.method === "Target.getTargets") {
+        reply(
+          JSON.stringify({
+            id: msg.id,
+            result: {
+              targetInfos: [
+                {
+                  targetId: "live-1",
+                  type: "page",
+                  title: "Live",
+                  url: "about:blank",
+                },
+              ],
+            },
+          }),
+        );
+      } else {
+        reply(JSON.stringify({ id: msg.id, result: { echo: msg.method } }));
+      }
+    } catch {
+      /* ignore non-JSON */
+    }
+  });
+
+  try {
+    const bridge = await connectCdp(port);
+    try {
+      const result = await bridge.send("Runtime.evaluate", {
+        expression: "1+1",
+      });
+      assert.deepEqual(result, { echo: "Runtime.evaluate" });
+      const pages = await bridge.listPageTargets();
+      assert.equal(pages.length, 1);
+      assert.equal(pages[0].targetId, "live-1");
+    } finally {
+      await bridge.close();
+    }
+  } finally {
+    detach();
+    await new Promise<void>((resolve, reject) =>
+      httpServer.close((err) => (err ? reject(err) : resolve())),
+    );
+  }
+});
+
+test("connectCdp throws EGO_CDP_CHANNEL_UNAVAILABLE when port closed", async () => {
+  await assert.rejects(
+    () => connectCdp(1),
+    (err: Error & { error_code?: string }) => {
+      assert.equal(err.error_code, "EGO_CDP_CHANNEL_UNAVAILABLE");
+      return true;
+    },
+  );
+});

--- a/package/ego-linux-host/src/cdp-bridge.ts
+++ b/package/ego-linux-host/src/cdp-bridge.ts
@@ -1,0 +1,406 @@
+/**
+ * Chrome DevTools Protocol bridge over WebSocket.
+ *
+ * Unit tests inject a pure text transport via createCdpSession / createCdpBridge.
+ * Production uses connectCdp(port) against Chrome's /json/version endpoint.
+ */
+
+import { makeEgoError } from "./errors.js";
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export type CdpPageTarget = {
+  targetId: string;
+  title: string;
+  url: string;
+  type: string;
+};
+
+export type CdpBridge = {
+  send(method: string, params?: object, sessionId?: string): Promise<any>;
+  sendRaw(payload: object): void;
+  onEvent(handler: (msg: any) => void): () => void;
+  /**
+   * Every successfully parsed incoming CDP message (responses + events).
+   * Used by the daemon to forward raw messages to CLI `onCDPMessage`.
+   */
+  onMessage?(handler: (msg: any) => void): () => void;
+  close(): Promise<void>;
+  listPageTargets(): Promise<CdpPageTarget[]>;
+  createTarget(url: string): Promise<string>;
+  attach(targetId: string): Promise<string>;
+};
+
+export type CdpTransport = {
+  send(text: string): void;
+  onMessage(cb: (text: string) => void): void;
+};
+
+export type CdpSessionOptions = {
+  /** Request timeout in ms (default 15_000). Injectable for unit tests. */
+  timeoutMs?: number;
+};
+
+export type CdpSession = {
+  send(method: string, params?: object, sessionId?: string): Promise<any>;
+  sendRaw(payload: object): void;
+  onEvent(handler: (msg: any) => void): () => void;
+  /** All parsed incoming messages (id responses and events). */
+  onMessage(handler: (msg: any) => void): () => void;
+  handleIncoming(text: string): void;
+  /** Reject all pending requests (e.g. on close / transport drop). */
+  dispose(reason?: Error): void;
+};
+
+type Pending = {
+  resolve: (value: any) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+  method: string;
+};
+
+/**
+ * Pure request/response CDP session over an injectable text transport.
+ * Registers itself on transport.onMessage at construction.
+ */
+export function createCdpSession(
+  transport: CdpTransport,
+  options: CdpSessionOptions = {},
+): CdpSession {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  let nextId = 1;
+  const pending = new Map<number, Pending>();
+  const eventHandlers = new Set<(msg: any) => void>();
+  const messageHandlers = new Set<(msg: any) => void>();
+  let disposed = false;
+
+  function handleIncoming(text: string): void {
+    let msg: any;
+    try {
+      msg = JSON.parse(text);
+    } catch {
+      return;
+    }
+
+    for (const handler of messageHandlers) {
+      try {
+        handler(msg);
+      } catch {
+        // Listener errors must not break the session
+      }
+    }
+
+    if (msg && msg.id != null && pending.has(msg.id)) {
+      const entry = pending.get(msg.id)!;
+      pending.delete(msg.id);
+      clearTimeout(entry.timer);
+      if (msg.error) {
+        const detail =
+          typeof msg.error === "object" && msg.error?.message
+            ? String(msg.error.message)
+            : JSON.stringify(msg.error);
+        entry.reject(
+          makeEgoError(
+            "EGO_CDP_SEND_FAILED",
+            `CDP error for ${entry.method}: ${detail}`,
+          ),
+        );
+      } else {
+        entry.resolve(msg.result);
+      }
+      return;
+    }
+
+    // Events: messages with a method and no correlated pending id
+    if (msg && typeof msg.method === "string") {
+      for (const handler of eventHandlers) {
+        try {
+          handler(msg);
+        } catch {
+          // Listener errors must not break the session
+        }
+      }
+    }
+  }
+
+  transport.onMessage(handleIncoming);
+
+  function send(
+    method: string,
+    params?: object,
+    sessionId?: string,
+  ): Promise<any> {
+    if (disposed) {
+      return Promise.reject(
+        makeEgoError(
+          "EGO_CDP_CHANNEL_UNAVAILABLE",
+          "CDP session is closed",
+        ),
+      );
+    }
+    const id = nextId++;
+    const payload: Record<string, unknown> = { id, method };
+    if (params !== undefined) payload.params = params;
+    if (sessionId !== undefined) payload.sessionId = sessionId;
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(
+          makeEgoError(
+            "EGO_CDP_SEND_FAILED",
+            `CDP timeout after ${timeoutMs}ms: ${method}`,
+          ),
+        );
+      }, timeoutMs);
+
+      pending.set(id, { resolve, reject, timer, method });
+
+      try {
+        transport.send(JSON.stringify(payload));
+      } catch (err) {
+        pending.delete(id);
+        clearTimeout(timer);
+        reject(
+          makeEgoError(
+            "EGO_CDP_SEND_FAILED",
+            `CDP send failed for ${method}: ${err instanceof Error ? err.message : String(err)}`,
+          ),
+        );
+      }
+    });
+  }
+
+  function sendRaw(payload: object): void {
+    if (disposed) {
+      throw makeEgoError(
+        "EGO_CDP_CHANNEL_UNAVAILABLE",
+        "CDP session is closed",
+      );
+    }
+    try {
+      transport.send(JSON.stringify(payload));
+    } catch (err) {
+      throw makeEgoError(
+        "EGO_CDP_SEND_FAILED",
+        `CDP sendRaw failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  function onEvent(handler: (msg: any) => void): () => void {
+    eventHandlers.add(handler);
+    return () => {
+      eventHandlers.delete(handler);
+    };
+  }
+
+  function onMessage(handler: (msg: any) => void): () => void {
+    messageHandlers.add(handler);
+    return () => {
+      messageHandlers.delete(handler);
+    };
+  }
+
+  function dispose(reason?: Error): void {
+    if (disposed) return;
+    disposed = true;
+    const err =
+      reason ??
+      makeEgoError("EGO_CDP_CHANNEL_UNAVAILABLE", "CDP session disposed");
+    for (const [, entry] of pending) {
+      clearTimeout(entry.timer);
+      entry.reject(err);
+    }
+    pending.clear();
+    eventHandlers.clear();
+    messageHandlers.clear();
+  }
+
+  return { send, sendRaw, onEvent, onMessage, handleIncoming, dispose };
+}
+
+export type CdpBridgeOptions = CdpSessionOptions & {
+  /** Called by bridge.close(); defaults to session.dispose only. */
+  onClose?: () => void | Promise<void>;
+};
+
+/**
+ * Build a full CdpBridge on top of an injectable transport (for unit tests).
+ */
+export function createCdpBridge(
+  transport: CdpTransport,
+  options: CdpBridgeOptions = {},
+): CdpBridge {
+  const session = createCdpSession(transport, options);
+  return wrapSessionAsBridge(session, options.onClose);
+}
+
+function wrapSessionAsBridge(
+  session: CdpSession,
+  onClose?: () => void | Promise<void>,
+): CdpBridge {
+  return {
+    send: (method, params, sessionId) =>
+      session.send(method, params, sessionId),
+    sendRaw: (payload) => session.sendRaw(payload),
+    onEvent: (handler) => session.onEvent(handler),
+    onMessage: (handler) => session.onMessage(handler),
+    async close() {
+      session.dispose(
+        makeEgoError("EGO_CDP_CHANNEL_UNAVAILABLE", "CDP bridge closed"),
+      );
+      if (onClose) await onClose();
+    },
+    async listPageTargets() {
+      const result = await session.send("Target.getTargets");
+      const infos = (result?.targetInfos ?? []) as Array<{
+        targetId?: string;
+        title?: string;
+        url?: string;
+        type?: string;
+      }>;
+      return infos
+        .filter((t) => t.type === "page")
+        .map((t) => ({
+          targetId: String(t.targetId ?? ""),
+          title: String(t.title ?? ""),
+          url: String(t.url ?? ""),
+          type: String(t.type ?? "page"),
+        }));
+    },
+    async createTarget(url: string) {
+      const result = await session.send("Target.createTarget", { url });
+      if (!result?.targetId) {
+        throw makeEgoError(
+          "EGO_CDP_SEND_FAILED",
+          "Target.createTarget returned no targetId",
+        );
+      }
+      return String(result.targetId);
+    },
+    async attach(targetId: string) {
+      const result = await session.send("Target.attachToTarget", {
+        targetId,
+        flatten: true,
+      });
+      if (!result?.sessionId) {
+        throw makeEgoError(
+          "EGO_CDP_SEND_FAILED",
+          "Target.attachToTarget returned no sessionId",
+        );
+      }
+      return String(result.sessionId);
+    },
+  };
+}
+
+/**
+ * Connect to Chrome CDP on loopback `port`.
+ * GET /json/version → webSocketDebuggerUrl → WebSocket (Node 22 global).
+ */
+export async function connectCdp(port: number): Promise<CdpBridge> {
+  let version: { webSocketDebuggerUrl?: string };
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/json/version`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    version = (await res.json()) as { webSocketDebuggerUrl?: string };
+  } catch (err) {
+    throw makeEgoError(
+      "EGO_CDP_CHANNEL_UNAVAILABLE",
+      `CDP HTTP endpoint unavailable on 127.0.0.1:${port}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const wsUrl = version.webSocketDebuggerUrl;
+  if (!wsUrl || typeof wsUrl !== "string") {
+    throw makeEgoError(
+      "EGO_CDP_CHANNEL_UNAVAILABLE",
+      `CDP /json/version missing webSocketDebuggerUrl on port ${port}`,
+    );
+  }
+
+  const ws = new WebSocket(wsUrl);
+
+  await new Promise<void>((resolve, reject) => {
+    const onOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = () => {
+      cleanup();
+      reject(
+        makeEgoError(
+          "EGO_CDP_CHANNEL_UNAVAILABLE",
+          `WebSocket connection failed to ${wsUrl}`,
+        ),
+      );
+    };
+    const cleanup = () => {
+      ws.removeEventListener("open", onOpen);
+      ws.removeEventListener("error", onError);
+    };
+    ws.addEventListener("open", onOpen);
+    ws.addEventListener("error", onError);
+  });
+
+  const messageHandlers = new Set<(text: string) => void>();
+  ws.addEventListener("message", (ev) => {
+    const data = ev.data;
+    const text =
+      typeof data === "string"
+        ? data
+        : data instanceof ArrayBuffer
+          ? Buffer.from(data).toString("utf8")
+          : Buffer.from(data as Buffer).toString("utf8");
+    for (const cb of messageHandlers) cb(text);
+  });
+
+  const transport: CdpTransport = {
+    send(text: string) {
+      if (ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket is not open");
+      }
+      ws.send(text);
+    },
+    onMessage(cb: (text: string) => void) {
+      messageHandlers.add(cb);
+    },
+  };
+
+  const session = createCdpSession(transport);
+
+  ws.addEventListener("close", () => {
+    session.dispose(
+      makeEgoError(
+        "EGO_CDP_CHANNEL_UNAVAILABLE",
+        "CDP WebSocket closed",
+      ),
+    );
+  });
+
+  return wrapSessionAsBridge(session, async () => {
+    messageHandlers.clear();
+    if (
+      ws.readyState === WebSocket.OPEN ||
+      ws.readyState === WebSocket.CONNECTING
+    ) {
+      await new Promise<void>((resolve) => {
+        const done = () => resolve();
+        ws.addEventListener("close", done, { once: true });
+        try {
+          ws.close();
+        } catch {
+          resolve();
+          return;
+        }
+        // Fallback if close never fires
+        setTimeout(resolve, 1000);
+      });
+    }
+  });
+}

--- a/package/ego-linux-host/src/chrome-supervisor.test.ts
+++ b/package/ego-linux-host/src/chrome-supervisor.test.ts
@@ -1,0 +1,198 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { writeFile, chmod, mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  resolveChromePath,
+  isCdpUp,
+  ensureChrome,
+} from "./chrome-supervisor.js";
+import type { HostConfig } from "./config.js";
+
+function baseConfig(overrides: Partial<HostConfig> = {}): HostConfig {
+  return {
+    chromePath: null,
+    userDataDir: join(tmpdir(), `ego-chrome-profile-${process.pid}`),
+    cdpPort: 1,
+    headless: true,
+    hostSocket: "/tmp/ego-test.sock",
+    dataDir: join(tmpdir(), `ego-chrome-data-${process.pid}`),
+    seedFromChrome: false,
+    ...overrides,
+  };
+}
+
+test("resolveChromePath prefers EGO_CHROME_PATH when executable", async () => {
+  const dir = join(tmpdir(), `ego-chrome-${process.pid}`);
+  await mkdir(dir, { recursive: true });
+  const bin = join(dir, "fake-chrome");
+  await writeFile(bin, "#!/bin/sh\nexit 0\n");
+  await chmod(bin, 0o755);
+  try {
+    assert.equal(resolveChromePath({ EGO_CHROME_PATH: bin }), bin);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveChromePath prefers explicit over env", async () => {
+  const dir = join(tmpdir(), `ego-chrome-explicit-${process.pid}`);
+  await mkdir(dir, { recursive: true });
+  const envBin = join(dir, "from-env");
+  const explicitBin = join(dir, "from-explicit");
+  await writeFile(envBin, "#!/bin/sh\nexit 0\n");
+  await writeFile(explicitBin, "#!/bin/sh\nexit 0\n");
+  await chmod(envBin, 0o755);
+  await chmod(explicitBin, 0o755);
+  try {
+    assert.equal(
+      resolveChromePath({ EGO_CHROME_PATH: envBin }, explicitBin),
+      explicitBin,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveChromePath returns null when nothing executable", () => {
+  // Empty candidates: do not probe host absolute paths (/usr/bin/google-chrome, etc.).
+  assert.equal(
+    resolveChromePath(
+      {
+        EGO_CHROME_PATH: "/nonexistent/ego-chrome-xyz",
+        PATH: "/nonexistent/empty-path-dir",
+      },
+      "/also/missing/chrome",
+      { candidates: [] },
+    ),
+    null,
+  );
+});
+
+test("isCdpUp is false for closed port", async () => {
+  assert.equal(await isCdpUp(1), false);
+});
+
+test("isCdpUp is true when /json/version responds", async () => {
+  const server = createServer((req, res) => {
+    if (req.url === "/json/version") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ Browser: "Test/1.0" }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address();
+  assert.ok(addr && typeof addr === "object");
+  try {
+    assert.equal(await isCdpUp(addr.port), true);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  }
+});
+
+test("ensureChrome attaches when CDP already up", async () => {
+  const server = createServer((req, res) => {
+    if (req.url === "/json/version") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end("{}");
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address();
+  assert.ok(addr && typeof addr === "object");
+  const userDataDir = join(tmpdir(), `ego-attach-profile-${process.pid}`);
+  try {
+    const handle = await ensureChrome(
+      baseConfig({
+        cdpPort: addr.port,
+        userDataDir,
+        chromePath: "/nonexistent/should-not-matter",
+      }),
+    );
+    assert.equal(handle.cdpPort, addr.port);
+    assert.equal(handle.userDataDir, userDataDir);
+    assert.equal(typeof handle.kill, "function");
+    await handle.kill();
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  }
+});
+
+test("ensureChrome throws EGO_BROWSER_UNAVAILABLE when chrome missing", async () => {
+  const prevPath = process.env.PATH;
+  const prevChrome = process.env.EGO_CHROME_PATH;
+  process.env.PATH = "/nonexistent/empty-path-dir";
+  process.env.EGO_CHROME_PATH = "/nonexistent/ego-chrome-xyz";
+  try {
+    await assert.rejects(
+      () =>
+        ensureChrome(
+          baseConfig({
+            chromePath: "/nonexistent/ego-chrome-xyz",
+            cdpPort: 1,
+            headless: true,
+          }),
+          // Empty candidates: isolate from host /usr/bin/google-chrome etc.
+          { candidates: [] },
+        ),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.equal(
+          (err as Error & { error_code?: string }).error_code,
+          "EGO_BROWSER_UNAVAILABLE",
+        );
+        return true;
+      },
+    );
+  } finally {
+    if (prevPath !== undefined) process.env.PATH = prevPath;
+    else delete process.env.PATH;
+    if (prevChrome !== undefined) process.env.EGO_CHROME_PATH = prevChrome;
+    else delete process.env.EGO_CHROME_PATH;
+  }
+});
+
+test("ensureChrome throws when headed without display", async () => {
+  const prevDisplay = process.env.DISPLAY;
+  const prevWayland = process.env.WAYLAND_DISPLAY;
+  delete process.env.DISPLAY;
+  delete process.env.WAYLAND_DISPLAY;
+  try {
+    await assert.rejects(
+      () =>
+        ensureChrome(
+          baseConfig({
+            chromePath: "/usr/bin/true",
+            cdpPort: 1,
+            headless: false,
+          }),
+        ),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.equal(
+          (err as Error & { error_code?: string }).error_code,
+          "EGO_BROWSER_UNAVAILABLE",
+        );
+        assert.match(err.message, /display|DISPLAY|WAYLAND|headed/i);
+        return true;
+      },
+    );
+  } finally {
+    if (prevDisplay !== undefined) process.env.DISPLAY = prevDisplay;
+    else delete process.env.DISPLAY;
+    if (prevWayland !== undefined) process.env.WAYLAND_DISPLAY = prevWayland;
+    else delete process.env.WAYLAND_DISPLAY;
+  }
+});

--- a/package/ego-linux-host/src/chrome-supervisor.ts
+++ b/package/ego-linux-host/src/chrome-supervisor.ts
@@ -1,0 +1,250 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { HostConfig } from "./config.js";
+import { makeEgoError } from "./errors.js";
+
+/** Ordered bare names and absolute fallbacks for Chrome/Chromium. */
+export const DEFAULT_CHROME_CANDIDATES = [
+  "google-chrome-stable",
+  "google-chrome",
+  "chromium",
+  "chromium-browser",
+  "/usr/bin/google-chrome",
+  "/usr/bin/chromium",
+] as const;
+
+export type ResolveChromePathOptions = {
+  /** Override candidate list (default: DEFAULT_CHROME_CANDIDATES). Empty isolates host binaries in tests. */
+  candidates?: readonly string[];
+};
+
+export type EnsureChromeOptions = {
+  /** Passed through to resolveChromePath for test isolation. */
+  candidates?: readonly string[];
+};
+
+const CDP_READY_TIMEOUT_MS = 15_000;
+const CDP_POLL_MS = 100;
+
+export type ChromeHandle = {
+  pid: number;
+  cdpPort: number;
+  userDataDir: string;
+  kill(): Promise<void>;
+};
+
+function isExecutable(filePath: string): boolean {
+  try {
+    accessSync(filePath, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveCandidate(
+  candidate: string,
+  env: NodeJS.ProcessEnv,
+): string | null {
+  if (candidate.includes("/") || candidate.startsWith(".")) {
+    return isExecutable(candidate) ? candidate : null;
+  }
+  const pathEnv = env.PATH ?? "";
+  for (const dir of pathEnv.split(":")) {
+    if (!dir) continue;
+    const full = join(dir, candidate);
+    if (isExecutable(full)) return full;
+  }
+  return null;
+}
+
+/**
+ * Resolve a Chrome/Chromium binary path.
+ * Order: explicit → EGO_CHROME_PATH → well-known candidates on PATH / absolute paths.
+ * Pass `options.candidates` (e.g. `[]`) to isolate tests from host-installed binaries.
+ */
+export function resolveChromePath(
+  env: NodeJS.ProcessEnv = process.env,
+  explicit?: string | null,
+  options?: ResolveChromePathOptions,
+): string | null {
+  if (explicit) {
+    const hit = resolveCandidate(explicit, env);
+    if (hit) return hit;
+  }
+  const fromEnv = env.EGO_CHROME_PATH;
+  if (fromEnv) {
+    const hit = resolveCandidate(fromEnv, env);
+    if (hit) return hit;
+  }
+  const candidates = options?.candidates ?? DEFAULT_CHROME_CANDIDATES;
+  for (const candidate of candidates) {
+    const hit = resolveCandidate(candidate, env);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/** True when CDP HTTP endpoint answers on 127.0.0.1:port. */
+export async function isCdpUp(port: number): Promise<boolean> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/json/version`, {
+      signal: AbortSignal.timeout(1000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function hasDisplayEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(env.DISPLAY || env.WAYLAND_DISPLAY);
+}
+
+async function killProcessGroup(pid: number): Promise<void> {
+  if (!pid || pid <= 0) return;
+
+  const signal = (sig: NodeJS.Signals) => {
+    try {
+      process.kill(-pid, sig);
+      return true;
+    } catch {
+      try {
+        process.kill(pid, sig);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  };
+
+  if (!signal("SIGTERM")) return;
+
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+      await sleep(50);
+    } catch {
+      return;
+    }
+  }
+  signal("SIGKILL");
+}
+
+function makeHandle(
+  pid: number,
+  cdpPort: number,
+  userDataDir: string,
+  child?: ChildProcess,
+): ChromeHandle {
+  let killed = false;
+  return {
+    pid,
+    cdpPort,
+    userDataDir,
+    async kill() {
+      if (killed) return;
+      killed = true;
+      if (child && child.pid) {
+        await killProcessGroup(child.pid);
+        return;
+      }
+      await killProcessGroup(pid);
+    },
+  };
+}
+
+/**
+ * Attach to an existing CDP endpoint or launch Chrome with the host profile.
+ * Headed by default; throws if headed and no DISPLAY/WAYLAND_DISPLAY.
+ * When CDP is down (Chrome died or never started), spawns a new process —
+ * call again after death to respawn. Throws EGO_BROWSER_UNAVAILABLE with
+ * clear text on missing binary, no display, spawn failure, or CDP timeout.
+ * `options.candidates` is for tests only (isolates host Chrome binaries).
+ */
+export async function ensureChrome(
+  config: HostConfig,
+  options?: EnsureChromeOptions,
+): Promise<ChromeHandle> {
+  if (await isCdpUp(config.cdpPort)) {
+    // Attached mode: we did not spawn; pid unknown (0). kill is best-effort no-op on 0.
+    return makeHandle(0, config.cdpPort, config.userDataDir);
+  }
+
+  const chromePath = resolveChromePath(process.env, config.chromePath, {
+    candidates: options?.candidates,
+  });
+  if (!chromePath) {
+    throw makeEgoError(
+      "EGO_BROWSER_UNAVAILABLE",
+      "Chrome/Chromium binary not found. Set EGO_CHROME_PATH or install google-chrome / chromium.",
+    );
+  }
+
+  if (!config.headless && !hasDisplayEnv()) {
+    throw makeEgoError(
+      "EGO_BROWSER_UNAVAILABLE",
+      "Headed Chrome requires DISPLAY or WAYLAND_DISPLAY. " +
+        "Use WSLg/X11, or set EGO_HEADLESS=1 for headless mode.",
+    );
+  }
+
+  await mkdir(config.userDataDir, { recursive: true });
+
+  const args = [
+    `--user-data-dir=${config.userDataDir}`,
+    `--remote-debugging-port=${config.cdpPort}`,
+    "--remote-debugging-address=127.0.0.1",
+    "--no-first-run",
+    "--no-default-browser-check",
+  ];
+  if (config.headless) {
+    args.push("--headless=new");
+  }
+
+  const child = spawn(chromePath, args, {
+    detached: true,
+    stdio: "ignore",
+    env: process.env,
+  });
+
+  // Own process group so kill(-pid) tears down Chrome helpers.
+  child.unref();
+
+  if (child.pid === undefined) {
+    throw makeEgoError(
+      "EGO_BROWSER_UNAVAILABLE",
+      `Failed to spawn Chrome at ${chromePath}`,
+    );
+  }
+
+  const pid = child.pid;
+  const handle = makeHandle(pid, config.cdpPort, config.userDataDir, child);
+
+  const deadline = Date.now() + CDP_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw makeEgoError(
+        "EGO_BROWSER_UNAVAILABLE",
+        `Chrome exited before CDP became ready (code=${child.exitCode}, signal=${child.signalCode})`,
+      );
+    }
+    if (await isCdpUp(config.cdpPort)) {
+      return handle;
+    }
+    await sleep(CDP_POLL_MS);
+  }
+
+  await handle.kill();
+  throw makeEgoError(
+    "EGO_BROWSER_UNAVAILABLE",
+    `Chrome CDP did not become ready on port ${config.cdpPort} within ${CDP_READY_TIMEOUT_MS}ms`,
+  );
+}

--- a/package/ego-linux-host/src/cli.ts
+++ b/package/ego-linux-host/src/cli.ts
@@ -1,0 +1,319 @@
+/**
+ * ego-browser CLI shim for Linux host.
+ *
+ * Ensures host daemon is up, installs globalThis.ego, runs ego-browser harness.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { open, mkdir, unlink } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+import { loadConfig, type HostConfig } from "./config.js";
+import { connectHost, installEgoClient, pingSocket } from "./ego-client.js";
+
+const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+export const CLI_HELP = `ego-browser (Linux host)
+
+Read the ego-browser skill for the default workflow and examples.
+
+Typical usage:
+  ego-browser <<'JS'
+  await page.waitForLoadState()
+  console.log(await page.info())
+  JS
+
+  ego-browser nodejs <<'JS'
+  // same helpers; optional "nodejs" subcommand is stripped
+  JS
+
+Commands:
+  ego-browser --help           show this help
+  ego-browser --doctor         ensure host and print diagnostics
+  ego-browser --reload         reconnect host CDP channel
+`;
+
+export type RunCliOptions = {
+  stdin?: NodeJS.ReadableStream;
+  stdout?: NodeJS.WritableStream;
+  stderr?: NodeJS.WritableStream;
+  env?: NodeJS.ProcessEnv;
+  harnessPath?: string;
+  /** Override host ensure (tests). */
+  ensureHost?: (
+    config: HostConfig,
+    options?: { env?: NodeJS.ProcessEnv; packageRoot?: string },
+  ) => Promise<void>;
+  packageRoot?: string;
+};
+
+export type CliFlags = {
+  help: boolean;
+  doctor: boolean;
+  reload: boolean;
+  remaining: string[];
+};
+
+/** Strip optional leading "nodejs" subcommand used by skill docs. */
+export function stripNodejsSubcommand(argv: string[]): string[] {
+  if (argv[0] === "nodejs") return argv.slice(1);
+  return argv.slice();
+}
+
+/**
+ * Parse argv: strip nodejs, detect --help / --doctor / --reload as first flag.
+ */
+export function parseCliFlags(argv: string[]): CliFlags {
+  const stripped = stripNodejsSubcommand(argv);
+  const head = stripped[0];
+  if (head === "--help" || head === "-h") {
+    return { help: true, doctor: false, reload: false, remaining: [] };
+  }
+  if (head === "--doctor") {
+    return { help: false, doctor: true, reload: false, remaining: [] };
+  }
+  if (head === "--reload") {
+    return { help: false, doctor: false, reload: true, remaining: [] };
+  }
+  return {
+    help: false,
+    doctor: false,
+    reload: false,
+    remaining: stripped,
+  };
+}
+
+/**
+ * Resolve harness module path that exports runMain.
+ *
+ * Order:
+ * 1. explicit harnessPath / EGO_HARNESS_PATH
+ * 2. ../ego-browser/dist/src/run.js (preferred)
+ * 3. ../ego-browser/dist/out/index.js
+ * 4. ../ego-browser/deps/ego-browser/index.js
+ */
+export function resolveHarnessPath(
+  env: NodeJS.ProcessEnv = process.env,
+  packageRoot: string = PACKAGE_ROOT,
+  explicit?: string,
+): string {
+  if (explicit) return resolve(explicit);
+  if (env.EGO_HARNESS_PATH) return resolve(env.EGO_HARNESS_PATH);
+
+  const sibling = join(packageRoot, "..", "ego-browser");
+  const candidates = [
+    join(sibling, "dist", "src", "run.js"),
+    join(sibling, "dist", "out", "index.js"),
+    join(sibling, "deps", "ego-browser", "index.js"),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  throw new Error(
+    [
+      "ego-browser harness not found. Build it first:",
+      "  cd package/ego-browser && npm ci && npm run build",
+      `Looked under: ${sibling}`,
+    ].join("\n"),
+  );
+}
+
+/** Default skills workspace relative to monorepo root. */
+export function defaultAgentWorkspace(packageRoot: string = PACKAGE_ROOT): string {
+  return join(packageRoot, "..", "..", "skills", "ego-browser");
+}
+
+/**
+ * Unlink a leftover host socket file when the daemon is not answering.
+ * Safe if the path is already gone (ENOENT).
+ */
+export async function unlinkStaleSocket(socketPath: string): Promise<boolean> {
+  if (!existsSync(socketPath)) return false;
+  try {
+    await unlink(socketPath);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT") return false;
+    // Best-effort: daemon start also unlinks before listen.
+    return false;
+  }
+}
+
+/**
+ * Ensure host daemon is listening on config.hostSocket.
+ * If the socket file exists but ping fails, unlinks the stale sock and restarts.
+ * Spawns bin/ego-linux-hostd.mjs detached if needed; polls ping up to 15s.
+ */
+export async function ensureHost(
+  config: HostConfig,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    packageRoot?: string;
+    timeoutMs?: number;
+    pollMs?: number;
+  } = {},
+): Promise<void> {
+  const env = options.env ?? process.env;
+  if (await pingSocket(config.hostSocket)) return;
+
+  // Stale socket recovery: file exists but daemon is not answering → unlink + restart.
+  await unlinkStaleSocket(config.hostSocket);
+
+  const packageRoot = options.packageRoot ?? PACKAGE_ROOT;
+  const daemonScript = join(packageRoot, "bin", "ego-linux-hostd.mjs");
+  if (!existsSync(daemonScript)) {
+    throw new Error(`daemon entry not found: ${daemonScript}`);
+  }
+
+  await mkdir(config.dataDir, { recursive: true, mode: 0o700 });
+  const logPath = join(config.dataDir, "host.log");
+  const logFh = await open(logPath, "a");
+
+  const childEnv: NodeJS.ProcessEnv = {
+    ...env,
+    EGO_HOST_SOCK: config.hostSocket,
+    EGO_DATA_DIR: config.dataDir,
+    EGO_USER_DATA_DIR: config.userDataDir,
+    EGO_CDP_PORT: String(config.cdpPort),
+  };
+  if (config.chromePath) childEnv.EGO_CHROME_PATH = config.chromePath;
+  if (config.headless) childEnv.EGO_HEADLESS = "1";
+
+  const child = spawn(process.execPath, [daemonScript], {
+    detached: true,
+    stdio: ["ignore", logFh.fd, logFh.fd],
+    env: childEnv,
+  });
+  child.unref();
+  // Parent no longer needs the fd; child has inherited it.
+  await logFh.close().catch(() => {});
+
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  const pollMs = options.pollMs ?? 200;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await pingSocket(config.hostSocket)) return;
+    await sleep(pollMs);
+  }
+  throw new Error(
+    `ego-linux-hostd did not become ready within ${timeoutMs}ms (socket ${config.hostSocket}; log ${logPath})`,
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function writeStream(
+  stream: NodeJS.WritableStream | undefined,
+  text: string,
+): void {
+  if (!stream) return;
+  stream.write(text);
+}
+
+/**
+ * CLI entry: flags, ensure host, install ego, run harness runMain.
+ */
+export async function runCli(
+  argv: string[],
+  opts: RunCliOptions = {},
+): Promise<number> {
+  const env = { ...(opts.env ?? process.env) };
+  const stdout = opts.stdout ?? process.stdout;
+  const stderr = opts.stderr ?? process.stderr;
+  const stdin = opts.stdin ?? process.stdin;
+  const packageRoot = opts.packageRoot ?? PACKAGE_ROOT;
+
+  const flags = parseCliFlags(argv);
+
+  if (flags.help) {
+    writeStream(stdout, CLI_HELP);
+    if (!CLI_HELP.endsWith("\n")) writeStream(stdout, "\n");
+    return 0;
+  }
+
+  if (!env.EGO_BROWSER_AGENT_WORKSPACE) {
+    const ws = defaultAgentWorkspace(packageRoot);
+    if (existsSync(ws)) {
+      env.EGO_BROWSER_AGENT_WORKSPACE = ws;
+      process.env.EGO_BROWSER_AGENT_WORKSPACE = ws;
+    }
+  }
+
+  const config = await loadConfig(env);
+  const ensure = opts.ensureHost ?? ensureHost;
+
+  if (flags.doctor) {
+    await ensure(config, { env, packageRoot });
+    let harnessPath: string | null = null;
+    try {
+      harnessPath = resolveHarnessPath(env, packageRoot, opts.harnessPath);
+    } catch {
+      harnessPath = null;
+    }
+    const conn = await connectHost(config.hostSocket);
+    try {
+      const doctor = (await conn.request("doctor")) as Record<string, unknown>;
+      writeStream(
+        stdout,
+        JSON.stringify({ ...doctor, harnessPath }, null, 2) + "\n",
+      );
+      return 0;
+    } finally {
+      conn.close();
+    }
+  }
+
+  if (flags.reload) {
+    await ensure(config, { env, packageRoot });
+    const conn = await connectHost(config.hostSocket);
+    try {
+      await conn.request("reload");
+      writeStream(stdout, "browser connection reset on next call\n");
+      return 0;
+    } finally {
+      conn.close();
+    }
+  }
+
+  await ensure(config, { env, packageRoot });
+  const conn = await connectHost(config.hostSocket);
+  installEgoClient(conn);
+
+  let harnessPath: string;
+  try {
+    harnessPath = resolveHarnessPath(env, packageRoot, opts.harnessPath);
+  } catch (err) {
+    conn.close();
+    writeStream(
+      stderr,
+      (err instanceof Error ? err.message : String(err)) + "\n",
+    );
+    return 1;
+  }
+
+  try {
+    const mod = await import(pathToFileURL(harnessPath).href);
+    const runMain = mod.runMain;
+    if (typeof runMain !== "function") {
+      writeStream(
+        stderr,
+        `harness at ${harnessPath} does not export runMain\n`,
+      );
+      return 1;
+    }
+    const code = await runMain({
+      argv: flags.remaining,
+      stdin,
+      stdout,
+      stderr,
+      env,
+    });
+    return typeof code === "number" ? code : 0;
+  } finally {
+    conn.close();
+  }
+}

--- a/package/ego-linux-host/src/config.test.ts
+++ b/package/ego-linux-host/src/config.test.ts
@@ -1,0 +1,99 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadConfig } from "./config.js";
+
+test("loadConfig honors EGO_HEADLESS and EGO_CDP_PORT", async () => {
+  const cfg = await loadConfig({
+    EGO_DATA_DIR: "/tmp/ego-cfg-test",
+    EGO_HEADLESS: "1",
+    EGO_CDP_PORT: "9444",
+  });
+  assert.equal(cfg.headless, true);
+  assert.equal(cfg.cdpPort, 9444);
+  assert.equal(cfg.userDataDir, "/tmp/ego-cfg-test/profile");
+});
+
+test("loadConfig defaults are headed, cdp 9222, null chromePath", async () => {
+  const cfg = await loadConfig({
+    EGO_DATA_DIR: "/tmp/ego-cfg-defaults",
+    EGO_CONFIG_DIR: "/tmp/ego-cfg-defaults-missing-config",
+  });
+  assert.equal(cfg.headless, false);
+  assert.equal(cfg.cdpPort, 9222);
+  assert.equal(cfg.chromePath, null);
+  assert.equal(cfg.dataDir, "/tmp/ego-cfg-defaults");
+  assert.equal(cfg.hostSocket, "/tmp/ego-cfg-defaults/host.sock");
+  assert.equal(cfg.seedFromChrome, false);
+});
+
+test("loadConfig env wins over config.json", async () => {
+  const base = join(tmpdir(), `ego-cfg-env-wins-${process.pid}`);
+  const configDir = join(base, "config");
+  await mkdir(configDir, { recursive: true });
+  await writeFile(
+    join(configDir, "config.json"),
+    JSON.stringify({
+      headless: false,
+      cdpPort: 1111,
+      chromePath: "/from/file",
+      seedFromChrome: true,
+      hostSocket: "/from/file.sock",
+      userDataDir: "/from/file/profile",
+    }),
+  );
+  try {
+    const cfg = await loadConfig({
+      EGO_CONFIG_DIR: configDir,
+      EGO_DATA_DIR: "/tmp/ego-cfg-env-wins-data",
+      EGO_HEADLESS: "1",
+      EGO_CDP_PORT: "9444",
+      EGO_CHROME_PATH: "/from/env",
+      EGO_HOST_SOCK: "/from/env.sock",
+      EGO_USER_DATA_DIR: "/from/env/profile",
+    });
+    assert.equal(cfg.headless, true);
+    assert.equal(cfg.cdpPort, 9444);
+    assert.equal(cfg.chromePath, "/from/env");
+    assert.equal(cfg.hostSocket, "/from/env.sock");
+    assert.equal(cfg.userDataDir, "/from/env/profile");
+    // seedFromChrome has no env override — file value kept
+    assert.equal(cfg.seedFromChrome, true);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig reads optional config.json when env absent", async () => {
+  const base = join(tmpdir(), `ego-cfg-file-${process.pid}`);
+  const configDir = join(base, "config");
+  await mkdir(configDir, { recursive: true });
+  await writeFile(
+    join(configDir, "config.json"),
+    JSON.stringify({
+      headless: true,
+      cdpPort: 9333,
+      chromePath: "/usr/bin/chromium",
+      seedFromChrome: true,
+      hostSocket: "/tmp/custom.sock",
+      userDataDir: "/tmp/custom-profile",
+    }),
+  );
+  try {
+    const cfg = await loadConfig({
+      EGO_CONFIG_DIR: configDir,
+      EGO_DATA_DIR: "/tmp/ego-cfg-file-data",
+    });
+    assert.equal(cfg.headless, true);
+    assert.equal(cfg.cdpPort, 9333);
+    assert.equal(cfg.chromePath, "/usr/bin/chromium");
+    assert.equal(cfg.seedFromChrome, true);
+    assert.equal(cfg.hostSocket, "/tmp/custom.sock");
+    assert.equal(cfg.userDataDir, "/tmp/custom-profile");
+    assert.equal(cfg.dataDir, "/tmp/ego-cfg-file-data");
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});

--- a/package/ego-linux-host/src/config.ts
+++ b/package/ego-linux-host/src/config.ts
@@ -1,0 +1,121 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  defaultCdpPort,
+  defaultConfigDir,
+  defaultDataDir,
+  defaultProfileDir,
+  defaultSocketPath,
+} from "./paths.js";
+
+export type HostConfig = {
+  chromePath: string | null;
+  userDataDir: string;
+  cdpPort: number;
+  headless: boolean;
+  hostSocket: string;
+  dataDir: string;
+  seedFromChrome: boolean;
+};
+
+/** Optional fields from ~/.config/ego-lite/config.json */
+type FileConfig = {
+  chromePath?: string | null;
+  userDataDir?: string;
+  cdpPort?: number;
+  headless?: boolean;
+  seedFromChrome?: boolean;
+  hostSocket?: string;
+};
+
+function configFilePath(env: NodeJS.ProcessEnv): string {
+  return join(defaultConfigDir(env), "config.json");
+}
+
+async function readFileConfig(env: NodeJS.ProcessEnv): Promise<FileConfig> {
+  const path = configFilePath(env);
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as FileConfig;
+    }
+    return {};
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT" || code === "ENOTDIR") return {};
+    throw err;
+  }
+}
+
+function parseTruthy(raw: string | undefined): boolean | undefined {
+  if (raw === undefined || raw === "") return undefined;
+  const v = raw.toLowerCase();
+  if (v === "1" || v === "true" || v === "yes") return true;
+  if (v === "0" || v === "false" || v === "no") return false;
+  return Boolean(raw);
+}
+
+/**
+ * Load host config: defaults from paths, optional config.json, env overrides.
+ * Precedence: env > file > path defaults.
+ */
+export async function loadConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<HostConfig> {
+  const file = await readFileConfig(env);
+
+  const dataDir = defaultDataDir(env);
+
+  let chromePath: string | null;
+  if (env.EGO_CHROME_PATH !== undefined && env.EGO_CHROME_PATH !== "") {
+    chromePath = env.EGO_CHROME_PATH;
+  } else if (file.chromePath !== undefined) {
+    chromePath = file.chromePath;
+  } else {
+    chromePath = null;
+  }
+
+  let userDataDir: string;
+  if (env.EGO_USER_DATA_DIR) {
+    userDataDir = env.EGO_USER_DATA_DIR;
+  } else if (file.userDataDir) {
+    userDataDir = file.userDataDir;
+  } else {
+    userDataDir = defaultProfileDir(env);
+  }
+
+  let cdpPort: number;
+  if (env.EGO_CDP_PORT) {
+    cdpPort = Number(env.EGO_CDP_PORT);
+  } else if (file.cdpPort !== undefined) {
+    cdpPort = Number(file.cdpPort);
+  } else {
+    cdpPort = defaultCdpPort(env);
+  }
+
+  const headlessEnv = parseTruthy(env.EGO_HEADLESS);
+  const headless =
+    headlessEnv !== undefined ? headlessEnv : (file.headless ?? false);
+
+  let hostSocket: string;
+  if (env.EGO_HOST_SOCK) {
+    hostSocket = env.EGO_HOST_SOCK;
+  } else if (file.hostSocket) {
+    hostSocket = file.hostSocket;
+  } else {
+    hostSocket = defaultSocketPath(env);
+  }
+
+  const seedFromChrome = file.seedFromChrome ?? false;
+
+  return {
+    chromePath,
+    userDataDir,
+    cdpPort,
+    headless,
+    hostSocket,
+    dataDir,
+    seedFromChrome,
+  };
+}

--- a/package/ego-linux-host/src/e2e-smoke.test.ts
+++ b/package/ego-linux-host/src/e2e-smoke.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Opt-in end-to-end smoke (example.com via scripts/smoke.sh).
+ *
+ * Skipped unless EGO_LINUX_E2E=1 so default `npm test` stays Chrome-free.
+ * Full smoke needs Chrome/Chromium + a display (or EGO_HEADLESS=1) and a
+ * built ego-browser harness at ../ego-browser/dist/src/run.js.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const enabled = process.env.EGO_LINUX_E2E === "1";
+
+/** package root: dist/e2e-smoke.test.js → ../ */
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const smokeScript = join(packageRoot, "scripts", "smoke.sh");
+
+function runSmoke(
+  script: string,
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("bash", [script], {
+      cwd: packageRoot,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += String(chunk);
+    });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test("e2e smoke example.com", { skip: !enabled }, async () => {
+  assert.ok(existsSync(smokeScript), `smoke script missing: ${smokeScript}`);
+  const result = await runSmoke(smokeScript);
+  assert.equal(
+    result.code,
+    0,
+    [
+      `smoke.sh exited ${result.code}`,
+      result.stdout ? `--- stdout ---\n${result.stdout}` : "",
+      result.stderr ? `--- stderr ---\n${result.stderr}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  );
+  assert.match(result.stdout, /title/i, "expected smoke JSON with title");
+});

--- a/package/ego-linux-host/src/ego-client.test.ts
+++ b/package/ego-linux-host/src/ego-client.test.ts
@@ -1,0 +1,327 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  connectHost,
+  installEgoClient,
+  pingSocket,
+  type HostConnection,
+} from "./ego-client.js";
+import { startDaemon } from "./host-daemon.js";
+import type { HostConfig } from "./config.js";
+import {
+  stripNodejsSubcommand,
+  resolveHarnessPath,
+  parseCliFlags,
+  CLI_HELP,
+  unlinkStaleSocket,
+  ensureHost,
+} from "./cli.js";
+
+function mockConn(handler?: {
+  request?: (method: string, params?: any) => Promise<any>;
+  events?: Array<(event: string, params?: any) => void>;
+}): HostConnection & { emit: (event: string, params?: any) => void; calls: any[] } {
+  const calls: any[] = [];
+  const listeners = new Set<(event: string, params?: any) => void>();
+  return {
+    calls,
+    async request(method, params) {
+      calls.push([method, params]);
+      if (handler?.request) return handler.request(method, params);
+      if (method === "ego.listTabs") return { tabs: [] };
+      return {};
+    },
+    onEvent(fn) {
+      listeners.add(fn);
+      return () => {
+        listeners.delete(fn);
+      };
+    },
+    close() {},
+    emit(event, params) {
+      for (const fn of listeners) fn(event, params);
+    },
+  };
+}
+
+test("installEgoClient listTabs proxies to RPC", async () => {
+  const conn = mockConn();
+  installEgoClient(conn);
+  const result = await (globalThis as any).ego.listTabs();
+  assert.deepEqual(result, { tabs: [] });
+  assert.deepEqual(conn.calls[0][0], "ego.listTabs");
+});
+
+test("installEgoClient maps createTab(url) and createTaskSpace(name)", async () => {
+  const conn = mockConn({
+    async request(method, params) {
+      if (method === "ego.createTab") return { targetId: "t1" };
+      if (method === "ego.createTaskSpace") return { id: 2, name: params?.name };
+      return {};
+    },
+  });
+  installEgoClient(conn);
+  const ego = (globalThis as any).ego;
+  assert.deepEqual(await ego.createTab("https://example.com"), {
+    targetId: "t1",
+  });
+  assert.deepEqual(conn.calls[0], [
+    "ego.createTab",
+    { url: "https://example.com" },
+  ]);
+  await ego.createTaskSpace("agent-job");
+  assert.deepEqual(conn.calls[1], [
+    "ego.createTaskSpace",
+    { name: "agent-job" },
+  ]);
+});
+
+test("installEgoClient maps useTaskSpace and claimTaskSpace args", async () => {
+  const conn = mockConn({
+    async request(method, params) {
+      return { method, params };
+    },
+  });
+  installEgoClient(conn);
+  const ego = (globalThis as any).ego;
+  await ego.useTaskSpace(3);
+  assert.deepEqual(conn.calls[0], ["ego.useTaskSpace", { id: 3 }]);
+  await ego.claimTaskSpace(4, "mine");
+  assert.deepEqual(conn.calls[1], [
+    "ego.claimTaskSpace",
+    { id: 4, name: "mine" },
+  ]);
+});
+
+test("installEgoClient sendCDPMessage proxies payload; events wire callbacks", async () => {
+  const conn = mockConn({
+    async request(method, params) {
+      if (method === "ego.sendCDPMessage") return { ok: true, params };
+      return {};
+    },
+  });
+  installEgoClient(conn);
+  const ego = (globalThis as any).ego;
+  const messages: string[] = [];
+  const errors: any[] = [];
+  ego.onCDPMessage = (payload: string) => messages.push(payload);
+  ego.onSendCDPMessageError = (message: string, code?: string) =>
+    errors.push([message, code]);
+
+  await ego.sendCDPMessage('{"id":1,"method":"Page.enable"}');
+  assert.equal(conn.calls[0][0], "ego.sendCDPMessage");
+  assert.deepEqual(conn.calls[0][1], {
+    payload: '{"id":1,"method":"Page.enable"}',
+  });
+
+  conn.emit("cdp.message", { payload: '{"id":1,"result":{}}' });
+  assert.deepEqual(messages, ['{"id":1,"result":{}}']);
+
+  conn.emit("cdp.sendError", {
+    message: "user control",
+    error_code: "EGO_TASK_SPACE_USER_IN_CONTROL",
+  });
+  assert.deepEqual(errors, [
+    ["user control", "EGO_TASK_SPACE_USER_IN_CONTROL"],
+  ]);
+});
+
+test("installEgoClient exposes no-op optional APIs", async () => {
+  const conn = mockConn();
+  installEgoClient(conn);
+  const ego = (globalThis as any).ego;
+  assert.equal(typeof ego.animationHighlightMouseToPosition, "function");
+  assert.equal(typeof ego.setAgentTaskState, "function");
+  await ego.animationHighlightMouseToPosition(1, 2);
+  await ego.setAgentTaskState("working");
+});
+
+test("installEgoClient snapshot and space lifecycle methods", async () => {
+  const conn = mockConn({
+    async request(method, params) {
+      return { method, params };
+    },
+  });
+  installEgoClient(conn);
+  const ego = (globalThis as any).ego;
+  await ego.snapshot({ maxResultLength: 1 });
+  await ego.listTaskSpaces();
+  await ego.completeTaskSpace();
+  await ego.closeTaskSpace();
+  await ego.handOffTaskSpace();
+  await ego.takeOverTaskSpace();
+  assert.deepEqual(
+    conn.calls.map((c) => c[0]),
+    [
+      "ego.snapshot",
+      "ego.listTaskSpaces",
+      "ego.completeTaskSpace",
+      "ego.closeTaskSpace",
+      "ego.handOffTaskSpace",
+      "ego.takeOverTaskSpace",
+    ],
+  );
+  assert.deepEqual(conn.calls[0][1], { maxResultLength: 1 });
+});
+
+test("stripNodejsSubcommand strips leading nodejs only", () => {
+  assert.deepEqual(stripNodejsSubcommand(["nodejs"]), []);
+  assert.deepEqual(stripNodejsSubcommand(["nodejs", "--doctor"]), ["--doctor"]);
+  assert.deepEqual(stripNodejsSubcommand(["--help"]), ["--help"]);
+  assert.deepEqual(stripNodejsSubcommand([]), []);
+});
+
+test("parseCliFlags detects help/doctor/reload", () => {
+  assert.deepEqual(parseCliFlags(["--help"]), {
+    help: true,
+    doctor: false,
+    reload: false,
+    remaining: [],
+  });
+  assert.deepEqual(parseCliFlags(["-h"]), {
+    help: true,
+    doctor: false,
+    reload: false,
+    remaining: [],
+  });
+  assert.deepEqual(parseCliFlags(["nodejs", "--doctor"]), {
+    help: false,
+    doctor: true,
+    reload: false,
+    remaining: [],
+  });
+  assert.deepEqual(parseCliFlags(["--reload"]), {
+    help: false,
+    doctor: false,
+    reload: true,
+    remaining: [],
+  });
+  assert.deepEqual(parseCliFlags(["nodejs"]), {
+    help: false,
+    doctor: false,
+    reload: false,
+    remaining: [],
+  });
+});
+
+test("CLI_HELP mentions doctor and reload", () => {
+  assert.match(CLI_HELP, /--doctor/);
+  assert.match(CLI_HELP, /--reload/);
+  assert.match(CLI_HELP, /ego-browser/);
+});
+
+test("resolveHarnessPath prefers EGO_HARNESS_PATH", () => {
+  const path = resolveHarnessPath(
+    { EGO_HARNESS_PATH: "/tmp/custom-harness.js" },
+    "/nonexistent-package-root",
+  );
+  assert.equal(path, "/tmp/custom-harness.js");
+});
+
+test("connectHost ping + installEgoClient against daemon", async () => {
+  const dir = join(
+    tmpdir(),
+    `ego-client-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  await mkdir(dir, { recursive: true });
+  try {
+    const config: HostConfig = {
+      chromePath: null,
+      userDataDir: join(dir, "profile"),
+      cdpPort: 19223,
+      headless: true,
+      hostSocket: join(dir, "host.sock"),
+      dataDir: dir,
+      seedFromChrome: false,
+    };
+    assert.equal(await pingSocket(config.hostSocket), false);
+    const daemon = await startDaemon({
+      config,
+      skipChrome: true,
+      writePid: false,
+    });
+    try {
+      assert.equal(await pingSocket(daemon.socketPath), true);
+      const conn = await connectHost(daemon.socketPath);
+      try {
+        installEgoClient(conn);
+        const spaces = await (globalThis as any).ego.listTaskSpaces();
+        assert.ok(Array.isArray(spaces.taskSpaces));
+        const created = await (globalThis as any).ego.createTaskSpace(
+          "cli-client",
+        );
+        assert.equal(created.name, "cli-client");
+      } finally {
+        conn.close();
+      }
+    } finally {
+      await daemon.close();
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("unlinkStaleSocket removes leftover socket file", async () => {
+  const dir = join(
+    tmpdir(),
+    `ego-stale-sock-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  await mkdir(dir, { recursive: true });
+  const sockPath = join(dir, "host.sock");
+  try {
+    // Leftover path after a dead daemon (plain file is enough for recovery).
+    await writeFile(sockPath, "");
+    assert.equal(existsSync(sockPath), true);
+    assert.equal(await pingSocket(sockPath), false);
+
+    assert.equal(await unlinkStaleSocket(sockPath), true);
+    assert.equal(existsSync(sockPath), false);
+    assert.equal(await unlinkStaleSocket(sockPath), false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensureHost unlinks stale socket before failing on missing daemon", async () => {
+  const dir = join(
+    tmpdir(),
+    `ego-ensure-stale-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  await mkdir(dir, { recursive: true });
+  const sockPath = join(dir, "host.sock");
+  try {
+    await writeFile(sockPath, "");
+    assert.equal(existsSync(sockPath), true);
+
+    const config: HostConfig = {
+      chromePath: null,
+      userDataDir: join(dir, "profile"),
+      cdpPort: 19224,
+      headless: true,
+      hostSocket: sockPath,
+      dataDir: dir,
+      seedFromChrome: false,
+    };
+
+    await assert.rejects(
+      () =>
+        ensureHost(config, {
+          packageRoot: join(dir, "no-such-package"),
+          timeoutMs: 200,
+        }),
+      /daemon entry not found/,
+    );
+    assert.equal(
+      existsSync(sockPath),
+      false,
+      "stale socket should be unlinked before spawn attempt",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/package/ego-linux-host/src/ego-client.ts
+++ b/package/ego-linux-host/src/ego-client.ts
@@ -1,0 +1,273 @@
+/**
+ * CLI-side host connection and globalThis.ego client.
+ *
+ * Speaks NDJSON RPC over a Unix domain socket with ego-linux-hostd.
+ */
+
+import { createConnection, type Socket } from "node:net";
+import {
+  decodeLine,
+  encodeRequest,
+  isRpcEvent,
+  isRpcResponse,
+  LineBuffer,
+} from "./rpc.js";
+import { makeEgoError } from "./errors.js";
+
+export type HostConnection = {
+  request(method: string, params?: any): Promise<any>;
+  /** Subscribe to all RPC events; returns unsubscribe. */
+  onEvent(handler: (event: string, params?: any) => void): () => void;
+  close(): void;
+};
+
+type Pending = {
+  resolve: (value: any) => void;
+  reject: (err: Error) => void;
+};
+
+/**
+ * Connect to the host daemon Unix socket and return a request/event API.
+ */
+export async function connectHost(socketPath: string): Promise<HostConnection> {
+  const socket = await openSocket(socketPath);
+  const lineBuf = new LineBuffer();
+  let nextId = 1;
+  const pending = new Map<number, Pending>();
+  const eventHandlers = new Set<(event: string, params?: any) => void>();
+  let closed = false;
+
+  function failAll(err: Error): void {
+    for (const [, p] of pending) {
+      p.reject(err);
+    }
+    pending.clear();
+  }
+
+  function onData(chunk: Buffer | string): void {
+    for (const line of lineBuf.push(chunk)) {
+      let msg: unknown;
+      try {
+        msg = decodeLine(line);
+      } catch {
+        continue;
+      }
+      if (isRpcResponse(msg)) {
+        const p = pending.get(msg.id);
+        if (!p) continue;
+        pending.delete(msg.id);
+        if (msg.error) {
+          p.reject(makeEgoError(msg.error.code, msg.error.message));
+        } else {
+          p.resolve(msg.result);
+        }
+        continue;
+      }
+      if (isRpcEvent(msg)) {
+        for (const h of eventHandlers) {
+          try {
+            h(msg.event, msg.params);
+          } catch {
+            // subscriber errors must not break the connection
+          }
+        }
+      }
+    }
+  }
+
+  socket.on("data", onData);
+  socket.on("error", (err) => {
+    if (closed) return;
+    failAll(err instanceof Error ? err : new Error(String(err)));
+  });
+  socket.on("close", () => {
+    if (closed) return;
+    closed = true;
+    failAll(
+      makeEgoError(
+        "EGO_TASK_HOST_DISCONNECTED",
+        "host daemon socket closed",
+      ),
+    );
+  });
+
+  return {
+    request(method: string, params?: any): Promise<any> {
+      if (closed || socket.destroyed) {
+        return Promise.reject(
+          makeEgoError(
+            "EGO_TASK_HOST_DISCONNECTED",
+            "host daemon socket is closed",
+          ),
+        );
+      }
+      const id = nextId++;
+      return new Promise((resolve, reject) => {
+        pending.set(id, { resolve, reject });
+        try {
+          socket.write(encodeRequest({ id, method, params }));
+        } catch (err) {
+          pending.delete(id);
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
+    },
+    onEvent(handler: (event: string, params?: any) => void): () => void {
+      eventHandlers.add(handler);
+      return () => {
+        eventHandlers.delete(handler);
+      };
+    },
+    close(): void {
+      if (closed) return;
+      closed = true;
+      pending.clear();
+      eventHandlers.clear();
+      try {
+        socket.destroy();
+      } catch {
+        // ignore
+      }
+    },
+  };
+}
+
+function openSocket(socketPath: string): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const sock = createConnection(socketPath);
+    const onError = (err: Error) => {
+      sock.removeListener("connect", onConnect);
+      reject(err);
+    };
+    const onConnect = () => {
+      sock.removeListener("error", onError);
+      resolve(sock);
+    };
+    sock.once("error", onError);
+    sock.once("connect", onConnect);
+  });
+}
+
+/**
+ * Quick liveness check: connect, send ping, expect { ok: true }.
+ */
+export async function pingSocket(
+  socketPath: string,
+  timeoutMs = 1500,
+): Promise<boolean> {
+  let conn: HostConnection | undefined;
+  try {
+    conn = await Promise.race([
+      connectHost(socketPath),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("ping connect timeout")),
+          timeoutMs,
+        ),
+      ),
+    ]);
+    const result = await Promise.race([
+      conn.request("ping"),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("ping timeout")), timeoutMs),
+      ),
+    ]);
+    return Boolean(result && result.ok === true);
+  } catch {
+    return false;
+  } finally {
+    conn?.close();
+  }
+}
+
+type EgoClient = {
+  listTabs: () => Promise<any>;
+  createTab: (url?: string) => Promise<any>;
+  listTaskSpaces: () => Promise<any>;
+  createTaskSpace: (name: string) => Promise<any>;
+  useTaskSpace: (id: number) => Promise<any>;
+  claimTaskSpace: (id: number, name?: string) => Promise<any>;
+  completeTaskSpace: () => Promise<any>;
+  closeTaskSpace: () => Promise<any>;
+  handOffTaskSpace: () => Promise<any>;
+  takeOverTaskSpace: () => Promise<any>;
+  snapshot: (options?: any) => Promise<any>;
+  sendCDPMessage: (payload: string) => void | Promise<any>;
+  onCDPMessage?: (payload: string) => void;
+  onSendCDPMessageError?: (message: string, error_code?: string) => void;
+  animationHighlightMouseToPosition?: (x: number, y: number) => Promise<void>;
+  setAgentTaskState?: (label: string) => Promise<void>;
+  [key: string]: unknown;
+};
+
+/**
+ * Install globalThis.ego that proxies to the host daemon via HostConnection.
+ * Wires cdp.message → ego.onCDPMessage and cdp.sendError → ego.onSendCDPMessageError.
+ */
+export function installEgoClient(conn: HostConnection): void {
+  const ego: EgoClient = {
+    listTabs: () => conn.request("ego.listTabs", {}),
+    createTab: (url?: string) =>
+      conn.request(
+        "ego.createTab",
+        typeof url === "string" ? { url } : ((url as any) ?? {}),
+      ),
+    listTaskSpaces: () => conn.request("ego.listTaskSpaces", {}),
+    createTaskSpace: (name: string) =>
+      conn.request("ego.createTaskSpace", { name }),
+    useTaskSpace: (id: number) => conn.request("ego.useTaskSpace", { id }),
+    claimTaskSpace: (id: number, name?: string) =>
+      conn.request("ego.claimTaskSpace", {
+        id,
+        ...(name !== undefined ? { name } : {}),
+      }),
+    completeTaskSpace: () => conn.request("ego.completeTaskSpace", {}),
+    closeTaskSpace: () => conn.request("ego.closeTaskSpace", {}),
+    handOffTaskSpace: () => conn.request("ego.handOffTaskSpace", {}),
+    takeOverTaskSpace: () => conn.request("ego.takeOverTaskSpace", {}),
+    snapshot: (options: any = {}) =>
+      conn.request("ego.snapshot", options ?? {}),
+    sendCDPMessage: (payload: string) => {
+      const p = conn.request("ego.sendCDPMessage", { payload });
+      // browser-runtime does not await; surface local failures via callback
+      if (p && typeof (p as Promise<any>).then === "function") {
+        (p as Promise<any>).catch((err: any) => {
+          if (typeof ego.onSendCDPMessageError === "function") {
+            ego.onSendCDPMessageError(
+              err?.message ?? String(err),
+              err?.error_code,
+            );
+          }
+        });
+      }
+      return p;
+    },
+    animationHighlightMouseToPosition: async () => {},
+    setAgentTaskState: async () => {},
+  };
+
+  conn.onEvent((event, params) => {
+    if (event === "cdp.message") {
+      const payload = params?.payload;
+      if (typeof payload === "string" && typeof ego.onCDPMessage === "function") {
+        try {
+          ego.onCDPMessage(payload);
+        } catch {
+          // ignore listener errors
+        }
+      }
+      return;
+    }
+    if (event === "cdp.sendError") {
+      if (typeof ego.onSendCDPMessageError === "function") {
+        try {
+          ego.onSendCDPMessageError(params?.message, params?.error_code);
+        } catch {
+          // ignore
+        }
+      }
+    }
+  });
+
+  (globalThis as any).ego = ego;
+}

--- a/package/ego-linux-host/src/ego-runtime.test.ts
+++ b/package/ego-linux-host/src/ego-runtime.test.ts
@@ -1,0 +1,325 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { CdpBridge, CdpPageTarget } from "./cdp-bridge.js";
+import { createEgoRuntime } from "./ego-runtime.js";
+import { SpaceManager } from "./space-manager.js";
+
+type FakeCdp = CdpBridge & {
+  targets: CdpPageTarget[];
+  rawSent: object[];
+  closedTargets: string[];
+  messageHandlers: Set<(msg: any) => void>;
+  eventHandlers: Set<(msg: any) => void>;
+  deliverMessage(msg: any): void;
+};
+
+function makeFakeCdp(initial: CdpPageTarget[] = []): FakeCdp {
+  let nextTarget = 1;
+  const fake: FakeCdp = {
+    targets: [...initial],
+    rawSent: [],
+    closedTargets: [],
+    messageHandlers: new Set(),
+    eventHandlers: new Set(),
+    deliverMessage(msg: any) {
+      for (const h of fake.messageHandlers) h(msg);
+      if (msg && typeof msg.method === "string") {
+        for (const h of fake.eventHandlers) h(msg);
+      }
+    },
+    async send(method: string, params?: object) {
+      if (method === "Target.closeTarget") {
+        const tid = (params as { targetId?: string })?.targetId;
+        if (tid) fake.closedTargets.push(tid);
+        return { success: true };
+      }
+      if (method === "Accessibility.enable") return {};
+      if (method === "Accessibility.getFullAXTree") {
+        return {
+          nodes: [
+            {
+              role: { value: "button" },
+              name: { value: "Go" },
+              backendDOMNodeId: 42,
+            },
+          ],
+        };
+      }
+      return {};
+    },
+    sendRaw(payload: object) {
+      fake.rawSent.push(payload);
+    },
+    onEvent(handler) {
+      fake.eventHandlers.add(handler);
+      return () => fake.eventHandlers.delete(handler);
+    },
+    onMessage(handler) {
+      fake.messageHandlers.add(handler);
+      return () => fake.messageHandlers.delete(handler);
+    },
+    async close() {},
+    async listPageTargets() {
+      return fake.targets.map((t) => ({ ...t }));
+    },
+    async createTarget(url: string) {
+      const targetId = `T${nextTarget++}`;
+      fake.targets.push({
+        targetId,
+        title: "",
+        url,
+        type: "page",
+      });
+      return targetId;
+    },
+    async attach(targetId: string) {
+      return `session-${targetId}`;
+    },
+  };
+  return fake;
+}
+
+function setup(opts?: { targets?: CdpPageTarget[] }) {
+  const sm = new SpaceManager();
+  const fakeCdp = makeFakeCdp(opts?.targets);
+  const ensureSession = async () => "sess-1";
+  const runtime = createEgoRuntime({
+    spaceManager: sm,
+    getCdp: () => fakeCdp,
+    ensureSession,
+  });
+  return { sm, fakeCdp, runtime, ensureSession };
+}
+
+test("snapshot rejects under user control", async () => {
+  const { sm, fakeCdp, runtime } = setup();
+  sm.use(1); // user
+  await assert.rejects(
+    () => runtime.handle("snapshot", {}),
+    (err: any) => err.error_code === "EGO_TASK_SPACE_USER_IN_CONTROL",
+  );
+  void fakeCdp;
+});
+
+test("snapshot rejects when no space selected", async () => {
+  const { runtime } = setup();
+  await assert.rejects(
+    () => runtime.handle("snapshot", {}),
+    (err: any) => err.error_code === "EGO_TASK_SPACE_USER_IN_CONTROL",
+  );
+});
+
+test("snapshot works for agent-owned space", async () => {
+  const { sm, runtime } = setup();
+  const space = sm.createAgentSpace("job");
+  sm.use(space.id);
+  const result = await runtime.handle("snapshot", {
+    includeActionMarks: true,
+  });
+  assert.ok(result.content.includes("button"));
+  assert.ok(Array.isArray(result.refs));
+  assert.equal(result.refs[0]?.backendNodeId, 42);
+});
+
+test("listTabs filters to selected space only", async () => {
+  const { sm, fakeCdp, runtime } = setup({
+    targets: [
+      { targetId: "user-tab", title: "User", url: "https://u.example", type: "page" },
+      { targetId: "agent-tab", title: "Agent", url: "https://a.example", type: "page" },
+    ],
+  });
+  sm.adoptOrphanTargets(["user-tab"]);
+  const agent = sm.createAgentSpace("agent-job");
+  sm.use(agent.id);
+  sm.assignTarget("agent-tab");
+
+  const result = await runtime.handle("listTabs", {});
+  assert.equal(result.tabs.length, 1);
+  assert.equal(result.tabs[0].targetId, "agent-tab");
+  assert.equal(result.tabs[0].url, "https://a.example");
+  void fakeCdp;
+});
+
+test("listTabs returns empty for agent space with no tabs (not user tabs)", async () => {
+  const { sm, runtime } = setup({
+    targets: [
+      {
+        targetId: "user-only",
+        title: "Mine",
+        url: "https://user.example",
+        type: "page",
+      },
+    ],
+  });
+  sm.adoptOrphanTargets(["user-only"]);
+  const agent = sm.createAgentSpace("empty-agent");
+  sm.use(agent.id);
+
+  const result = await runtime.handle("listTabs", {});
+  assert.deepEqual(result.tabs, []);
+});
+
+test("createTab creates target and assigns to selected space", async () => {
+  const { sm, runtime } = setup();
+  const agent = sm.createAgentSpace("tabs");
+  sm.use(agent.id);
+
+  const created = await runtime.handle("createTab", {
+    url: "https://example.com",
+  });
+  assert.ok(created.targetId);
+  assert.deepEqual(sm.targetsForSelected(), [created.targetId]);
+
+  const listed = await runtime.handle("listTabs", {});
+  assert.equal(listed.tabs.length, 1);
+  assert.equal(listed.tabs[0].targetId, created.targetId);
+  assert.equal(listed.tabs[0].url, "https://example.com");
+});
+
+test("createTab fails without selected space", async () => {
+  const { runtime } = setup();
+  await assert.rejects(
+    () => runtime.handle("createTab", { url: "https://x" }),
+    (err: any) => err.error_code === "EGO_TASK_SPACE_NOT_SELECTED",
+  );
+});
+
+test("task space create / use / claim / handOff / takeOver", async () => {
+  const { sm, runtime } = setup();
+
+  const listed0 = await runtime.handle("listTaskSpaces", {});
+  assert.ok(listed0.taskSpaces.some((s: any) => s.id === 1));
+
+  const created = await runtime.handle("createTaskSpace", { name: "work" });
+  assert.equal(created.name, "work");
+  assert.equal(created.ownership, "agent");
+  assert.equal("targetIds" in created, false);
+
+  const used = await runtime.handle("useTaskSpace", { id: created.id });
+  assert.equal(used.id, created.id);
+  assert.equal(sm.selected()?.id, created.id);
+
+  await runtime.handle("handOffTaskSpace", {});
+  assert.equal(sm.selected()?.ownership, "agentDelegatedToUser");
+  assert.equal(sm.isPageControlBlocked(), true);
+
+  await runtime.handle("takeOverTaskSpace", {});
+  assert.equal(sm.selected()?.ownership, "agent");
+  assert.equal(sm.isPageControlBlocked(), false);
+
+  sm.use(1);
+  const claimed = await runtime.handle("claimTaskSpace", {
+    id: 1,
+    name: "claimed-user",
+  });
+  assert.equal(claimed.ownership, "agent");
+  assert.equal(claimed.name, "claimed-user");
+});
+
+test("useTaskSpace missing returns error object", async () => {
+  const { runtime } = setup();
+  const result = await runtime.handle("useTaskSpace", { id: 999 });
+  assert.equal(result.error_code, "EGO_TASK_SPACE_NOT_FOUND");
+  assert.ok(result.error);
+});
+
+test("completeTaskSpace keeps tabs under user ownership", async () => {
+  const { sm, runtime } = setup();
+  const a = sm.createAgentSpace("done");
+  sm.use(a.id);
+  sm.assignTarget("t-keep");
+  await runtime.handle("completeTaskSpace", {});
+  assert.equal(sm.list().find((s) => s.id === a.id)?.ownership, "user");
+  assert.deepEqual(sm.list().find((s) => s.id === a.id)?.targetIds, ["t-keep"]);
+});
+
+test("closeTaskSpace removes agent space and closes targets", async () => {
+  const { sm, fakeCdp, runtime } = setup();
+  const a = sm.createAgentSpace("close-me");
+  sm.use(a.id);
+  sm.assignTarget("t-close");
+  await runtime.handle("closeTaskSpace", {});
+  assert.equal(
+    sm.list().find((s) => s.id === a.id),
+    undefined,
+  );
+  assert.deepEqual(fakeCdp.closedTargets, ["t-close"]);
+});
+
+test("sendCDPMessage forwards when agent controls space", async () => {
+  const { sm, fakeCdp, runtime } = setup();
+  const a = sm.createAgentSpace("cdp");
+  sm.use(a.id);
+
+  const ack = await runtime.handle("sendCDPMessage", {
+    payload: JSON.stringify({
+      id: 1,
+      method: "Runtime.evaluate",
+      params: { expression: "1" },
+      sessionId: "s1",
+    }),
+  });
+  assert.deepEqual(ack, { ok: true });
+  assert.equal(fakeCdp.rawSent.length, 1);
+  assert.equal((fakeCdp.rawSent[0] as any).method, "Runtime.evaluate");
+});
+
+test("sendCDPMessage page domain blocked under user control emits cdp.sendError", async () => {
+  const { sm, fakeCdp, runtime } = setup();
+  sm.use(1);
+
+  const events: any[] = [];
+  runtime.onEvent((ev) => events.push(ev));
+
+  const ack = await runtime.handle("sendCDPMessage", {
+    payload: JSON.stringify({
+      id: 2,
+      method: "Page.navigate",
+      params: { url: "https://evil" },
+      sessionId: "s1",
+    }),
+  });
+  assert.deepEqual(ack, { ok: true });
+  assert.equal(fakeCdp.rawSent.length, 0);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].event, "cdp.sendError");
+  assert.equal(events[0].params.error_code, "EGO_TASK_SPACE_USER_IN_CONTROL");
+});
+
+test("sendCDPMessage allows Target.* under user control", async () => {
+  const { sm, fakeCdp, runtime } = setup();
+  sm.use(1);
+
+  await runtime.handle("sendCDPMessage", {
+    payload: JSON.stringify({
+      id: 3,
+      method: "Target.getTargets",
+      params: {},
+    }),
+  });
+  assert.equal(fakeCdp.rawSent.length, 1);
+  assert.equal((fakeCdp.rawSent[0] as any).method, "Target.getTargets");
+});
+
+test("attachCdpForwarding pushes cdp.message events", async () => {
+  const { fakeCdp, runtime } = setup();
+  const events: any[] = [];
+  runtime.onEvent((ev) => events.push(ev));
+  runtime.attachCdpForwarding();
+
+  fakeCdp.deliverMessage({ id: 9, result: { value: 1 } });
+  assert.equal(events.length, 1);
+  assert.equal(events[0].event, "cdp.message");
+  assert.equal(
+    JSON.parse(events[0].params.payload).result.value,
+    1,
+  );
+});
+
+test("handle accepts ego. prefix methods", async () => {
+  const { sm, runtime } = setup();
+  const a = sm.createAgentSpace("prefixed");
+  sm.use(a.id);
+  const result = await runtime.handle("ego.listTabs", {});
+  assert.deepEqual(result.tabs, []);
+});

--- a/package/ego-linux-host/src/ego-runtime.ts
+++ b/package/ego-linux-host/src/ego-runtime.ts
@@ -1,0 +1,366 @@
+/**
+ * Daemon-side implementations of globalThis.ego methods.
+ *
+ * Enforces Task Space isolation (listTabs / createTab) and user-control
+ * blocks on snapshot / page-domain CDP.
+ */
+
+import type { CdpBridge } from "./cdp-bridge.js";
+import { makeEgoError } from "./errors.js";
+import type { RpcEvent } from "./rpc.js";
+import { snapshotPage, type SnapshotOptions } from "./snapshot-engine.js";
+import type { SpaceManager } from "./space-manager.js";
+
+/** Browser-level CDP domains that remain allowed under user control. */
+function isBrowserLevelMethod(method: string): boolean {
+  return method.startsWith("Target.") || method.startsWith("Browser.");
+}
+
+export type EgoRuntimeDeps = {
+  spaceManager: SpaceManager;
+  getCdp: () => CdpBridge;
+  ensureSession: () => Promise<string>;
+  /** Package version reported by ping when routed through runtime (optional). */
+  version?: string;
+};
+
+export type EgoRuntime = {
+  handle(method: string, params?: any): Promise<any>;
+  /** Subscribe to runtime-pushed events (cdp.message, cdp.sendError). */
+  onEvent(handler: (ev: RpcEvent) => void): () => void;
+  /**
+   * Forward all CDP messages from the current bridge to event subscribers.
+   * Call after connect / reconnect. Returns unsubscribe.
+   */
+  attachCdpForwarding(): () => void;
+};
+
+function normalizeMethod(method: string): string {
+  if (method.startsWith("ego.")) return method.slice(4);
+  return method;
+}
+
+function publicSpace(space: {
+  taskId: string;
+  id: number;
+  name: string;
+  createdBy: string;
+  ownership: string;
+  recentTabTitles?: string[];
+}) {
+  return {
+    taskId: space.taskId,
+    id: space.id,
+    name: space.name,
+    createdBy: space.createdBy,
+    ownership: space.ownership,
+    ...(space.recentTabTitles
+      ? { recentTabTitles: [...space.recentTabTitles] }
+      : {}),
+  };
+}
+
+/**
+ * Create the ego method dispatcher used by the host daemon.
+ */
+export function createEgoRuntime(deps: EgoRuntimeDeps): EgoRuntime {
+  const eventHandlers = new Set<(ev: RpcEvent) => void>();
+  let detachCdp: (() => void) | undefined;
+
+  function emit(ev: RpcEvent): void {
+    for (const h of eventHandlers) {
+      try {
+        h(ev);
+      } catch {
+        // subscriber errors must not break the runtime
+      }
+    }
+  }
+
+  function onEvent(handler: (ev: RpcEvent) => void): () => void {
+    eventHandlers.add(handler);
+    return () => {
+      eventHandlers.delete(handler);
+    };
+  }
+
+  function attachCdpForwarding(): () => void {
+    if (detachCdp) {
+      detachCdp();
+      detachCdp = undefined;
+    }
+    const cdp = deps.getCdp();
+    const handler = (msg: any) => {
+      emit({ event: "cdp.message", params: { payload: JSON.stringify(msg) } });
+    };
+    if (typeof cdp.onMessage === "function") {
+      detachCdp = cdp.onMessage(handler);
+    } else {
+      // Fallback: events only (responses with id may be missed)
+      detachCdp = cdp.onEvent(handler);
+    }
+    return () => {
+      if (detachCdp) {
+        detachCdp();
+        detachCdp = undefined;
+      }
+    };
+  }
+
+  function emitSendError(message: string, error_code?: string): void {
+    emit({
+      event: "cdp.sendError",
+      params: {
+        message,
+        ...(error_code ? { error_code } : {}),
+      },
+    });
+  }
+
+  async function listTabs(): Promise<{ tabs: any[] }> {
+    const allowed = new Set(deps.spaceManager.targetsForSelected());
+    const all = await deps.getCdp().listPageTargets();
+    const filtered = all.filter((t) => allowed.has(t.targetId));
+    const tabs = filtered.map((t, index) => ({
+      targetId: t.targetId,
+      title: t.title,
+      url: t.url,
+      active: index === filtered.length - 1,
+      index,
+    }));
+    return { tabs };
+  }
+
+  async function createTab(params: { url?: string } = {}): Promise<{
+    targetId: string;
+  }> {
+    const selected = deps.spaceManager.selected();
+    if (!selected) {
+      throw makeEgoError(
+        "EGO_TASK_SPACE_NOT_SELECTED",
+        "task space not selected",
+      );
+    }
+    const url =
+      typeof params?.url === "string" && params.url !== ""
+        ? params.url
+        : "about:blank";
+    const targetId = await deps.getCdp().createTarget(url);
+    deps.spaceManager.assignTarget(targetId);
+    return { targetId };
+  }
+
+  async function snapshot(params: SnapshotOptions = {}): Promise<{
+    content: string;
+    refs: any[];
+  }> {
+    if (deps.spaceManager.isPageControlBlocked()) {
+      throw makeEgoError(
+        "EGO_TASK_SPACE_USER_IN_CONTROL",
+        "task space is under user control; claim or takeOver before page ops",
+      );
+    }
+    const sessionId = await deps.ensureSession();
+    return snapshotPage(deps.getCdp(), sessionId, params);
+  }
+
+  async function sendCDPMessage(params: {
+    payload?: string;
+  }): Promise<{ ok: true }> {
+    const raw = params?.payload;
+    if (typeof raw !== "string" || raw === "") {
+      throw makeEgoError(
+        "EGO_INVALID_ARGUMENT",
+        "sendCDPMessage requires { payload: string }",
+      );
+    }
+
+    let msg: any;
+    try {
+      msg = JSON.parse(raw);
+    } catch (err) {
+      emitSendError(
+        `invalid CDP payload JSON: ${err instanceof Error ? err.message : String(err)}`,
+        "EGO_INVALID_ARGUMENT",
+      );
+      return { ok: true };
+    }
+
+    const method = typeof msg?.method === "string" ? msg.method : "";
+    const pageDomain = method ? !isBrowserLevelMethod(method) : true;
+
+    if (pageDomain && deps.spaceManager.isPageControlBlocked()) {
+      emitSendError(
+        "task space is under user control; claim or takeOver before page ops",
+        "EGO_TASK_SPACE_USER_IN_CONTROL",
+      );
+      return { ok: true };
+    }
+
+    try {
+      deps.getCdp().sendRaw(msg);
+    } catch (err) {
+      const code =
+        err &&
+        typeof err === "object" &&
+        typeof (err as { error_code?: string }).error_code === "string"
+          ? (err as { error_code: string }).error_code
+          : "EGO_CDP_SEND_FAILED";
+      const message =
+        err instanceof Error
+          ? err.message
+          : typeof err === "string"
+            ? err
+            : String(err);
+      emitSendError(message, code);
+    }
+    return { ok: true };
+  }
+
+  async function listTaskSpaces() {
+    return { taskSpaces: deps.spaceManager.listPublic() };
+  }
+
+  async function createTaskSpace(params: { name?: string } = {}) {
+    const name =
+      typeof params?.name === "string" && params.name !== ""
+        ? params.name
+        : "untitled";
+    const space = deps.spaceManager.createAgentSpace(name);
+    return publicSpace(space);
+  }
+
+  async function useTaskSpace(params: { id?: number } = {}) {
+    const id = Number(params?.id);
+    if (!Number.isFinite(id)) {
+      return {
+        error: "useTaskSpace requires { id: number }",
+        error_code: "EGO_INVALID_ARGUMENT",
+      };
+    }
+    const result = deps.spaceManager.use(id);
+    if (result.ok === false) {
+      return { error: result.error, error_code: result.error_code };
+    }
+    return publicSpace(result.space);
+  }
+
+  async function claimTaskSpace(params: { id?: number; name?: string } = {}) {
+    const id = Number(params?.id);
+    if (!Number.isFinite(id)) {
+      throw makeEgoError(
+        "EGO_INVALID_ARGUMENT",
+        "claimTaskSpace requires { id: number }",
+      );
+    }
+    try {
+      const space = deps.spaceManager.claim(
+        id,
+        typeof params?.name === "string" ? params.name : undefined,
+      );
+      return publicSpace(space);
+    } catch (err) {
+      if (
+        err &&
+        typeof err === "object" &&
+        (err as { error_code?: string }).error_code
+      ) {
+        throw err;
+      }
+      throw makeEgoError(
+        "EGO_OPERATION_FAILED",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  async function completeTaskSpace() {
+    if (!deps.spaceManager.selected()) {
+      throw makeEgoError(
+        "EGO_TASK_SPACE_NOT_SELECTED",
+        "task space not selected",
+      );
+    }
+    deps.spaceManager.completeKeep();
+    return { ok: true };
+  }
+
+  async function closeTaskSpace() {
+    if (!deps.spaceManager.selected()) {
+      throw makeEgoError(
+        "EGO_TASK_SPACE_NOT_SELECTED",
+        "task space not selected",
+      );
+    }
+    const targetIds = deps.spaceManager.closeSelected();
+    // Best-effort close page targets in Chrome
+    const cdp = deps.getCdp();
+    for (const targetId of targetIds) {
+      try {
+        await cdp.send("Target.closeTarget", { targetId });
+      } catch {
+        // ignore close failures
+      }
+    }
+    return { ok: true };
+  }
+
+  async function handOffTaskSpace() {
+    if (!deps.spaceManager.selected()) {
+      throw makeEgoError(
+        "EGO_TASK_SPACE_NOT_SELECTED",
+        "task space not selected",
+      );
+    }
+    deps.spaceManager.handOff();
+    return { ok: true };
+  }
+
+  async function takeOverTaskSpace() {
+    if (!deps.spaceManager.selected()) {
+      throw makeEgoError(
+        "EGO_TASK_SPACE_NOT_SELECTED",
+        "task space not selected",
+      );
+    }
+    deps.spaceManager.takeOver();
+    return { ok: true };
+  }
+
+  async function handle(method: string, params: any = {}): Promise<any> {
+    const name = normalizeMethod(method);
+    switch (name) {
+      case "listTaskSpaces":
+        return listTaskSpaces();
+      case "createTaskSpace":
+        return createTaskSpace(params);
+      case "useTaskSpace":
+        return useTaskSpace(params);
+      case "claimTaskSpace":
+        return claimTaskSpace(params);
+      case "completeTaskSpace":
+        return completeTaskSpace();
+      case "closeTaskSpace":
+        return closeTaskSpace();
+      case "handOffTaskSpace":
+        return handOffTaskSpace();
+      case "takeOverTaskSpace":
+        return takeOverTaskSpace();
+      case "listTabs":
+        return listTabs();
+      case "createTab":
+        return createTab(params);
+      case "snapshot":
+        return snapshot(params);
+      case "sendCDPMessage":
+        return sendCDPMessage(params);
+      default:
+        throw makeEgoError(
+          "EGO_INVALID_ARGUMENT",
+          `unknown ego method: ${method}`,
+        );
+    }
+  }
+
+  return { handle, onEvent, attachCdpForwarding };
+}

--- a/package/ego-linux-host/src/errors.test.ts
+++ b/package/ego-linux-host/src/errors.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  EGO_ERROR_CODES,
+  makeEgoError,
+  egoError,
+  egoResultError,
+  isUserControlCode,
+  isEgoErrorCode,
+} from "./errors.js";
+
+test("EGO_ERROR_CODES includes stable known codes", () => {
+  assert.ok(EGO_ERROR_CODES.includes("EGO_BROWSER_UNAVAILABLE"));
+  assert.ok(EGO_ERROR_CODES.includes("EGO_TASK_SPACE_USER_IN_CONTROL"));
+  assert.ok(EGO_ERROR_CODES.includes("EGO_TASK_SPACE_INACTIVE"));
+  assert.equal(EGO_ERROR_CODES.length, 15);
+});
+
+test("isEgoErrorCode narrows known codes", () => {
+  assert.equal(isEgoErrorCode("EGO_SNAPSHOT_FAILED"), true);
+  assert.equal(isEgoErrorCode("EGO_FUTURE_CODE"), false);
+  assert.equal(isEgoErrorCode(undefined), false);
+});
+
+test("makeEgoError attaches error_code", () => {
+  const err = makeEgoError("EGO_BROWSER_UNAVAILABLE", "chrome missing");
+  assert.equal(err.message, "chrome missing");
+  assert.equal(err.error_code, "EGO_BROWSER_UNAVAILABLE");
+  assert.ok(err instanceof Error);
+});
+
+test("egoError is an alias of makeEgoError", () => {
+  const err = egoError("EGO_OPERATION_FAILED", "nope");
+  assert.equal(err.error_code, "EGO_OPERATION_FAILED");
+  assert.equal(err.message, "nope");
+});
+
+test("egoResultError returns resolved error shape", () => {
+  assert.deepEqual(egoResultError("EGO_SNAPSHOT_FAILED", "boom"), {
+    error: "boom",
+    error_code: "EGO_SNAPSHOT_FAILED",
+  });
+});
+
+test("isUserControlCode keys on USER_IN_CONTROL", () => {
+  assert.equal(isUserControlCode("EGO_TASK_SPACE_USER_IN_CONTROL"), true);
+  assert.equal(isUserControlCode("EGO_TASK_SPACE_INACTIVE"), false);
+  assert.equal(isUserControlCode("EGO_SNAPSHOT_FAILED"), false);
+});

--- a/package/ego-linux-host/src/errors.ts
+++ b/package/ego-linux-host/src/errors.ts
@@ -1,0 +1,64 @@
+/**
+ * Stable ego error codes and helpers for the Linux host.
+ *
+ * Code list mirrors package/ego-browser/src/ego-errors.ts (copied, not imported,
+ * to avoid cross-package coupling until a shared module exists).
+ */
+
+/** Stable error codes emitted by ego bindings / host. */
+export const EGO_ERROR_CODES = [
+  "EGO_BROWSER_UNAVAILABLE",
+  "EGO_CDP_CHANNEL_UNAVAILABLE",
+  "EGO_CDP_SEND_FAILED",
+  "EGO_INVALID_ARGUMENT",
+  "EGO_INVALID_RESULT_PAYLOAD",
+  "EGO_OPERATION_FAILED",
+  "EGO_RESULT_CONVERSION_FAILED",
+  "EGO_SNAPSHOT_FAILED",
+  "EGO_TASK_HOST_DISCONNECTED",
+  "EGO_TASK_SPACE_INACTIVE",
+  "EGO_TASK_SPACE_NOT_FOUND",
+  "EGO_TASK_SPACE_NOT_SELECTED",
+  "EGO_TASK_SPACE_UNAVAILABLE",
+  "EGO_TASK_SPACE_USER_IN_CONTROL",
+  "EGO_WEB_CONTENTS_UNAVAILABLE",
+] as const;
+
+export type EgoErrorCode = (typeof EGO_ERROR_CODES)[number];
+
+/** Type guard for codes this build knows about. */
+export function isEgoErrorCode(value: unknown): value is EgoErrorCode {
+  return (
+    typeof value === "string" &&
+    (EGO_ERROR_CODES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Build a thrown Error carrying a stable `error_code`.
+ * Alias: `egoError` (interface name from the plan).
+ */
+export function makeEgoError(
+  code: string,
+  message: string,
+): Error & { error_code: string } {
+  const err = new Error(message) as Error & { error_code: string };
+  err.error_code = code;
+  return err;
+}
+
+/** Plan interface name — same as makeEgoError. */
+export const egoError = makeEgoError;
+
+/** Resolved-result error shape `{ error, error_code }` (not thrown). */
+export function egoResultError(code: string, message: string) {
+  return { error: message, error_code: code };
+}
+
+/**
+ * Whether a code means the user currently controls the task space
+ * (agent must not drive page ops until takeOver/claim).
+ */
+export function isUserControlCode(code: string): boolean {
+  return code === "EGO_TASK_SPACE_USER_IN_CONTROL";
+}

--- a/package/ego-linux-host/src/fixtures/ax-tree-minimal.json
+++ b/package/ego-linux-host/src/fixtures/ax-tree-minimal.json
@@ -1,0 +1,68 @@
+{
+  "nodes": [
+    {
+      "nodeId": "1",
+      "ignored": false,
+      "role": { "type": "role", "value": "RootWebArea" },
+      "name": { "type": "computedString", "value": "Example" },
+      "childIds": ["2", "3", "4", "5"],
+      "backendDOMNodeId": 1
+    },
+    {
+      "nodeId": "2",
+      "ignored": false,
+      "role": { "type": "role", "value": "heading" },
+      "name": { "type": "computedString", "value": "Welcome" },
+      "childIds": [],
+      "backendDOMNodeId": 10
+    },
+    {
+      "nodeId": "3",
+      "ignored": false,
+      "role": { "type": "role", "value": "button" },
+      "name": { "type": "computedString", "value": "Submit" },
+      "childIds": [],
+      "backendDOMNodeId": 20
+    },
+    {
+      "nodeId": "4",
+      "ignored": false,
+      "role": { "type": "role", "value": "link" },
+      "name": { "type": "computedString", "value": "Home" },
+      "childIds": [],
+      "backendDOMNodeId": 30
+    },
+    {
+      "nodeId": "5",
+      "ignored": false,
+      "role": { "type": "role", "value": "textbox" },
+      "name": { "type": "computedString", "value": "Email" },
+      "childIds": [],
+      "backendDOMNodeId": 40
+    },
+    {
+      "nodeId": "6",
+      "ignored": true,
+      "role": { "type": "role", "value": "generic" },
+      "name": { "type": "computedString", "value": "" },
+      "childIds": [],
+      "backendDOMNodeId": 50
+    },
+    {
+      "nodeId": "7",
+      "ignored": false,
+      "role": { "type": "role", "value": "generic" },
+      "name": { "type": "computedString", "value": "" },
+      "childIds": [],
+      "backendDOMNodeId": 60
+    },
+    {
+      "nodeId": "8",
+      "ignored": false,
+      "role": { "type": "role", "value": "StaticText" },
+      "name": { "type": "computedString", "value": "Hello world" },
+      "childIds": [],
+      "backendDOMNodeId": 70
+    }
+  ]
+}

--- a/package/ego-linux-host/src/host-daemon.test.ts
+++ b/package/ego-linux-host/src/host-daemon.test.ts
@@ -1,0 +1,289 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createConnection } from "node:net";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { startDaemon, HOST_VERSION } from "./host-daemon.js";
+import {
+  decodeLine,
+  encodeRequest,
+  isRpcResponse,
+  LineBuffer,
+} from "./rpc.js";
+import type { HostConfig } from "./config.js";
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = join(
+    tmpdir(),
+    `ego-host-daemon-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  await mkdir(dir, { recursive: true });
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function rpcCall(
+  socketPath: string,
+  method: string,
+  params?: object,
+  id = 1,
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const sock = createConnection(socketPath);
+    const buf = new LineBuffer();
+    const timer = setTimeout(() => {
+      sock.destroy();
+      reject(new Error(`RPC timeout: ${method}`));
+    }, 5000);
+
+    sock.on("connect", () => {
+      sock.write(encodeRequest({ id, method, params }));
+    });
+    sock.on("data", (chunk) => {
+      for (const line of buf.push(chunk)) {
+        try {
+          const msg = decodeLine(line);
+          if (isRpcResponse(msg) && msg.id === id) {
+            clearTimeout(timer);
+            sock.end();
+            if (msg.error) {
+              reject(
+                Object.assign(new Error(msg.error.message), {
+                  error_code: msg.error.code,
+                }),
+              );
+            } else {
+              resolve(msg.result);
+            }
+          }
+        } catch (err) {
+          clearTimeout(timer);
+          sock.destroy();
+          reject(err);
+        }
+      }
+    });
+    sock.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+function testConfig(dir: string): HostConfig {
+  return {
+    chromePath: null,
+    userDataDir: join(dir, "profile"),
+    cdpPort: 19222,
+    headless: true,
+    hostSocket: join(dir, "host.sock"),
+    dataDir: dir,
+    seedFromChrome: false,
+  };
+}
+
+test("daemon listens and answers ping without Chrome", async () => {
+  await withTempDir(async (dir) => {
+    const daemon = await startDaemon({
+      config: testConfig(dir),
+      skipChrome: true,
+      writePid: true,
+    });
+    try {
+      const result = await rpcCall(daemon.socketPath, "ping");
+      assert.deepEqual(result, { ok: true, version: HOST_VERSION });
+    } finally {
+      await daemon.close();
+    }
+  });
+});
+
+test("daemon doctor and ego.listTaskSpaces without Chrome", async () => {
+  await withTempDir(async (dir) => {
+    const config = testConfig(dir);
+    const daemon = await startDaemon({
+      config,
+      skipChrome: true,
+    });
+    try {
+      const doctor = await rpcCall(daemon.socketPath, "doctor");
+      assert.equal(doctor.ok, true);
+      assert.equal(doctor.version, HOST_VERSION);
+      assert.equal(doctor.chromePath, config.chromePath);
+      assert.equal(typeof doctor.chromeRunning, "boolean");
+      assert.equal(doctor.cdpPort, config.cdpPort);
+      assert.equal(doctor.cdpUp, false);
+      assert.equal(doctor.profileDir, config.userDataDir);
+      assert.equal(doctor.socketPath, daemon.socketPath);
+      assert.equal(typeof doctor.daemonPid, "number");
+      assert.ok(doctor.daemonPid > 0);
+      assert.ok(doctor.spaceCount >= 1);
+      assert.ok(
+        doctor.selectedSpace === null ||
+          (typeof doctor.selectedSpace === "object" &&
+            doctor.selectedSpace !== null),
+      );
+      assert.equal(doctor.headless, config.headless);
+      assert.equal(typeof doctor.displayEnv, "boolean");
+      // Daemon leaves harnessPath null; CLI merges the resolved path.
+      assert.equal(doctor.harnessPath, null);
+
+      const spaces = await rpcCall(daemon.socketPath, "ego.listTaskSpaces");
+      assert.ok(Array.isArray(spaces.taskSpaces));
+      assert.ok(spaces.taskSpaces.some((s: any) => s.id === 1));
+
+      const created = await rpcCall(daemon.socketPath, "ego.createTaskSpace", {
+        name: "from-rpc",
+      });
+      assert.equal(created.name, "from-rpc");
+      assert.equal(created.ownership, "agent");
+    } finally {
+      await daemon.close();
+    }
+  });
+});
+
+test("daemon rejects unknown methods", async () => {
+  await withTempDir(async (dir) => {
+    const daemon = await startDaemon({
+      config: testConfig(dir),
+      skipChrome: true,
+    });
+    try {
+      await assert.rejects(
+        () => rpcCall(daemon.socketPath, "nope.method"),
+        (err: any) => err.error_code === "EGO_INVALID_ARGUMENT",
+      );
+    } finally {
+      await daemon.close();
+    }
+  });
+});
+
+test("daemon respawns Chrome via ensureChrome when CDP is down on ego method", async () => {
+  await withTempDir(async (dir) => {
+    let ensureCount = 0;
+    const pages = [
+      {
+        targetId: "t1",
+        title: "blank",
+        url: "about:blank",
+        type: "page",
+      },
+    ];
+    const config = testConfig(dir);
+    // Port with nothing listening → isCdpUp false → ensureBrowserReady re-calls ensureChrome.
+    config.cdpPort = 1;
+
+    const daemon = await startDaemon({
+      config,
+      ensureChrome: async () => {
+        ensureCount++;
+        return {
+          pid: 42,
+          cdpPort: config.cdpPort,
+          userDataDir: config.userDataDir,
+          async kill() {},
+        };
+      },
+      connectCdp: async () => ({
+        async send() {
+          return {};
+        },
+        sendRaw() {},
+        onEvent() {
+          return () => {};
+        },
+        onMessage() {
+          return () => {};
+        },
+        async close() {},
+        async listPageTargets() {
+          return pages;
+        },
+        async createTarget(url: string) {
+          return `new-${url}`;
+        },
+        async attach() {
+          return "session-1";
+        },
+      }),
+    });
+    try {
+      assert.equal(ensureCount, 1, "start ensures Chrome once");
+      const tabs = await rpcCall(daemon.socketPath, "ego.listTabs");
+      assert.ok(Array.isArray(tabs.tabs));
+      assert.ok(
+        ensureCount >= 2,
+        `expected respawn ensureChrome after CDP down, got ${ensureCount}`,
+      );
+    } finally {
+      await daemon.close();
+    }
+  });
+});
+
+test("daemon throws EGO_BROWSER_UNAVAILABLE when ensureChrome fails on ego method", async () => {
+  await withTempDir(async (dir) => {
+    let ensureCount = 0;
+    const config = testConfig(dir);
+    config.cdpPort = 1;
+
+    const daemon = await startDaemon({
+      config,
+      ensureChrome: async () => {
+        ensureCount++;
+        if (ensureCount === 1) {
+          return {
+            pid: 0,
+            cdpPort: config.cdpPort,
+            userDataDir: config.userDataDir,
+            async kill() {},
+          };
+        }
+        const err = Object.assign(new Error("Chrome binary not found"), {
+          error_code: "EGO_BROWSER_UNAVAILABLE",
+        });
+        throw err;
+      },
+      connectCdp: async () => ({
+        async send() {
+          return {};
+        },
+        sendRaw() {},
+        onEvent() {
+          return () => {};
+        },
+        onMessage() {
+          return () => {};
+        },
+        async close() {},
+        async listPageTargets() {
+          return [];
+        },
+        async createTarget() {
+          return "t";
+        },
+        async attach() {
+          return "s";
+        },
+      }),
+    });
+    try {
+      await assert.rejects(
+        () => rpcCall(daemon.socketPath, "ego.listTabs"),
+        (err: any) => {
+          assert.equal(err.error_code, "EGO_BROWSER_UNAVAILABLE");
+          assert.match(String(err.message), /Chrome|unavailable|binary/i);
+          return true;
+        },
+      );
+    } finally {
+      await daemon.close();
+    }
+  });
+});

--- a/package/ego-linux-host/src/host-daemon.ts
+++ b/package/ego-linux-host/src/host-daemon.ts
@@ -1,0 +1,490 @@
+/**
+ * Long-lived ego Linux host daemon.
+ *
+ * - Ensures Chrome + CDP on start
+ * - Owns SpaceManager + EgoRuntime
+ * - Serves NDJSON RPC on a Unix domain socket
+ */
+
+import { createServer, type Server, type Socket } from "node:net";
+import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { connectCdp, type CdpBridge } from "./cdp-bridge.js";
+import {
+  ensureChrome,
+  isCdpUp,
+  type ChromeHandle,
+} from "./chrome-supervisor.js";
+import { loadConfig, type HostConfig } from "./config.js";
+import { createEgoRuntime, type EgoRuntime } from "./ego-runtime.js";
+import { makeEgoError } from "./errors.js";
+import {
+  decodeLine,
+  encodeEvent,
+  encodeResponse,
+  isRpcRequest,
+  LineBuffer,
+  type RpcEvent,
+  type RpcResponse,
+} from "./rpc.js";
+import { SpaceManager } from "./space-manager.js";
+
+export const HOST_VERSION = "0.1.0";
+
+export type HostDaemonOptions = {
+  config?: HostConfig;
+  env?: NodeJS.ProcessEnv;
+  /** Skip real Chrome/CDP (unit/integration tests). */
+  skipChrome?: boolean;
+  /** Inject CDP bridge factory (defaults to connectCdp). */
+  connectCdp?: (port: number) => Promise<CdpBridge>;
+  /** Inject Chrome ensure (defaults to ensureChrome). */
+  ensureChrome?: (config: HostConfig) => Promise<ChromeHandle>;
+  /** Override spaces.json path. */
+  spacesPath?: string;
+  /** Override pid file path. */
+  pidPath?: string;
+  /** Listen without writing pid (tests). */
+  writePid?: boolean;
+};
+
+export type HostDaemon = {
+  socketPath: string;
+  config: HostConfig;
+  spaceManager: SpaceManager;
+  runtime: EgoRuntime;
+  close(): Promise<void>;
+};
+
+function errorToRpc(
+  id: number,
+  err: unknown,
+): RpcResponse {
+  const code =
+    err &&
+    typeof err === "object" &&
+    typeof (err as { error_code?: string }).error_code === "string"
+      ? (err as { error_code: string }).error_code
+      : "EGO_OPERATION_FAILED";
+  const message =
+    err instanceof Error
+      ? err.message
+      : typeof err === "string"
+        ? err
+        : String(err);
+  return { id, error: { code, message } };
+}
+
+async function safeUnlink(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== "ENOENT") throw err;
+  }
+}
+
+/**
+ * Start the host daemon: config → chrome → CDP → spaces → Unix socket.
+ */
+export async function startDaemon(
+  options: HostDaemonOptions = {},
+): Promise<HostDaemon> {
+  const env = options.env ?? process.env;
+  const config = options.config ?? (await loadConfig(env));
+  const dataDir = config.dataDir;
+  await mkdir(dataDir, { recursive: true, mode: 0o700 });
+
+  const spacesPath =
+    options.spacesPath ?? join(dataDir, "spaces.json");
+  const pidPath = options.pidPath ?? join(dataDir, "host.pid");
+  const socketPath = config.hostSocket;
+
+  const spaceManager = new SpaceManager(spacesPath);
+  await spaceManager.load();
+
+  const ensureChromeFn = options.ensureChrome ?? ensureChrome;
+  const connectCdpFn = options.connectCdp ?? connectCdp;
+
+  let chrome: ChromeHandle | null = null;
+  let cdp: CdpBridge | null = null;
+
+  if (!options.skipChrome) {
+    chrome = await ensureChromeFn(config);
+    cdp = await connectCdpFn(config.cdpPort);
+    // Adopt orphan page targets into user space
+    try {
+      const pages = await cdp.listPageTargets();
+      spaceManager.adoptOrphanTargets(pages.map((p) => p.targetId));
+      await spaceManager.save();
+    } catch {
+      // non-fatal on startup
+    }
+  } else {
+    // Minimal stub so getCdp never throws before a real inject
+    cdp = {
+      async send() {
+        throw makeEgoError(
+          "EGO_CDP_CHANNEL_UNAVAILABLE",
+          "CDP not connected (skipChrome)",
+        );
+      },
+      sendRaw() {
+        throw makeEgoError(
+          "EGO_CDP_CHANNEL_UNAVAILABLE",
+          "CDP not connected (skipChrome)",
+        );
+      },
+      onEvent() {
+        return () => {};
+      },
+      onMessage() {
+        return () => {};
+      },
+      async close() {},
+      async listPageTargets() {
+        return [];
+      },
+      async createTarget() {
+        throw makeEgoError(
+          "EGO_CDP_CHANNEL_UNAVAILABLE",
+          "CDP not connected (skipChrome)",
+        );
+      },
+      async attach() {
+        throw makeEgoError(
+          "EGO_CDP_CHANNEL_UNAVAILABLE",
+          "CDP not connected (skipChrome)",
+        );
+      },
+    };
+  }
+
+  const getCdp = () => {
+    if (!cdp) {
+      throw makeEgoError(
+        "EGO_CDP_CHANNEL_UNAVAILABLE",
+        "CDP bridge not available",
+      );
+    }
+    return cdp;
+  };
+
+  const ensureSession = async (): Promise<string> => {
+    const bridge = getCdp();
+    const allowed = new Set(spaceManager.targetsForSelected());
+    const pages = await bridge.listPageTargets();
+    const inSpace = pages.filter((p) => allowed.has(p.targetId));
+    const active = inSpace[inSpace.length - 1];
+    if (!active) {
+      throw makeEgoError(
+        "EGO_WEB_CONTENTS_UNAVAILABLE",
+        "no tab in selected task space to attach",
+      );
+    }
+    return bridge.attach(active.targetId);
+  };
+
+  const runtime = createEgoRuntime({
+    spaceManager,
+    getCdp,
+    ensureSession,
+    version: HOST_VERSION,
+  });
+
+  let detachForward: (() => void) | undefined;
+  if (!options.skipChrome) {
+    detachForward = runtime.attachCdpForwarding();
+  }
+
+  /**
+   * If Chrome/CDP died, respawn via ensureChrome and reconnect the bridge.
+   * Ego methods call this so a dead browser surfaces as a clear
+   * EGO_BROWSER_UNAVAILABLE (or recovers when spawn succeeds).
+   */
+  async function ensureBrowserReady(): Promise<void> {
+    if (options.skipChrome) return;
+
+    if (cdp && (await isCdpUp(config.cdpPort))) {
+      return;
+    }
+
+    if (detachForward) {
+      detachForward();
+      detachForward = undefined;
+    }
+    if (cdp) {
+      try {
+        await cdp.close();
+      } catch {
+        // ignore
+      }
+      cdp = null;
+    }
+
+    try {
+      // ensureChrome attaches if CDP is already back, otherwise respawns Chrome.
+      chrome = await ensureChromeFn(config);
+      cdp = await connectCdpFn(config.cdpPort);
+      detachForward = runtime.attachCdpForwarding();
+    } catch (err) {
+      const code =
+        err &&
+        typeof err === "object" &&
+        typeof (err as { error_code?: string }).error_code === "string"
+          ? (err as { error_code: string }).error_code
+          : undefined;
+      if (code === "EGO_BROWSER_UNAVAILABLE") throw err;
+      const message =
+        err instanceof Error
+          ? err.message
+          : typeof err === "string"
+            ? err
+            : String(err);
+      throw makeEgoError(
+        "EGO_BROWSER_UNAVAILABLE",
+        `Browser/CDP unavailable: ${message}. Chrome may have exited; the host will try to respawn on the next request.`,
+      );
+    }
+  }
+
+  const clients = new Set<Socket>();
+
+  async function handleRequest(
+    method: string,
+    params: any,
+  ): Promise<any> {
+    if (method === "ping") {
+      return { ok: true, version: HOST_VERSION };
+    }
+    if (method === "doctor") {
+      return buildDoctor(config, chrome, spaceManager, socketPath);
+    }
+    if (method === "reload") {
+      // Drop CDP and reconnect; respawn Chrome if CDP is down.
+      if (detachForward) {
+        detachForward();
+        detachForward = undefined;
+      }
+      if (cdp) {
+        try {
+          await cdp.close();
+        } catch {
+          // ignore
+        }
+        cdp = null;
+      }
+      if (!options.skipChrome) {
+        try {
+          if (!(await isCdpUp(config.cdpPort))) {
+            chrome = await ensureChromeFn(config);
+          }
+          cdp = await connectCdpFn(config.cdpPort);
+          detachForward = runtime.attachCdpForwarding();
+        } catch (err) {
+          const code =
+            err &&
+            typeof err === "object" &&
+            typeof (err as { error_code?: string }).error_code === "string"
+              ? (err as { error_code: string }).error_code
+              : undefined;
+          if (code === "EGO_BROWSER_UNAVAILABLE") throw err;
+          const message =
+            err instanceof Error
+              ? err.message
+              : typeof err === "string"
+                ? err
+                : String(err);
+          throw makeEgoError(
+            "EGO_BROWSER_UNAVAILABLE",
+            `Browser/CDP unavailable after reload: ${message}`,
+          );
+        }
+      }
+      return { ok: true };
+    }
+    if (method.startsWith("ego.")) {
+      await ensureBrowserReady();
+      const result = await runtime.handle(method, params ?? {});
+      // Persist space mutations (best-effort)
+      try {
+        await spaceManager.save();
+      } catch {
+        // ignore
+      }
+      return result;
+    }
+    throw makeEgoError(
+      "EGO_INVALID_ARGUMENT",
+      `unknown RPC method: ${method}`,
+    );
+  }
+
+  function writeToClient(socket: Socket, text: string): void {
+    if (socket.destroyed) return;
+    try {
+      socket.write(text);
+    } catch {
+      // ignore write failures on dead sockets
+    }
+  }
+
+  function broadcastEvent(ev: RpcEvent): void {
+    const line = encodeEvent(ev);
+    for (const socket of clients) {
+      writeToClient(socket, line);
+    }
+  }
+
+  runtime.onEvent(broadcastEvent);
+
+  await mkdir(dirname(socketPath), { recursive: true, mode: 0o700 });
+  await safeUnlink(socketPath);
+
+  const server: Server = createServer((socket) => {
+    clients.add(socket);
+    const lineBuf = new LineBuffer();
+
+    socket.on("data", (chunk) => {
+      const lines = lineBuf.push(chunk);
+      for (const line of lines) {
+        void (async () => {
+          let id = -1;
+          try {
+            const msg = decodeLine(line);
+            if (!isRpcRequest(msg)) {
+              // ignore non-requests from client
+              return;
+            }
+            id = msg.id;
+            const result = await handleRequest(msg.method, msg.params);
+            writeToClient(socket, encodeResponse({ id, result }));
+          } catch (err) {
+            if (id >= 0) {
+              writeToClient(socket, encodeResponse(errorToRpc(id, err)));
+            }
+          }
+        })();
+      }
+    });
+
+    socket.on("close", () => {
+      clients.delete(socket);
+    });
+    socket.on("error", () => {
+      clients.delete(socket);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+
+  if (options.writePid !== false) {
+    await writeFile(pidPath, String(process.pid), "utf8");
+  }
+
+  let closed = false;
+  async function close(): Promise<void> {
+    if (closed) return;
+    closed = true;
+    if (detachForward) {
+      detachForward();
+      detachForward = undefined;
+    }
+    for (const s of clients) {
+      try {
+        s.destroy();
+      } catch {
+        // ignore
+      }
+    }
+    clients.clear();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+    await safeUnlink(socketPath);
+    if (options.writePid !== false) {
+      await safeUnlink(pidPath);
+    }
+    if (cdp) {
+      try {
+        await cdp.close();
+      } catch {
+        // ignore
+      }
+      cdp = null;
+    }
+    // Do not kill chrome on daemon stop by default — profile may stay warm.
+    // Callers that own chrome (tests) can kill via returned handle if needed.
+    try {
+      await spaceManager.save();
+    } catch {
+      // ignore
+    }
+  }
+
+  return {
+    socketPath,
+    config,
+    spaceManager,
+    runtime,
+    close,
+  };
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!pid || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Diagnostic payload for RPC `doctor` / CLI `--doctor`.
+ * CLI merges `harnessPath` (resolved on the client) into this object.
+ */
+async function buildDoctor(
+  config: HostConfig,
+  chrome: ChromeHandle | null,
+  spaceManager: SpaceManager,
+  socketPath: string,
+): Promise<Record<string, unknown>> {
+  const cdpUp = await isCdpUp(config.cdpPort);
+  const chromePid = chrome?.pid ?? null;
+  const chromeRunning =
+    cdpUp || (chromePid != null && isProcessAlive(chromePid));
+  const selected = spaceManager.selected();
+  return {
+    ok: true,
+    version: HOST_VERSION,
+    chromePath: config.chromePath,
+    chromeRunning,
+    chromePid,
+    cdpPort: config.cdpPort,
+    cdpUp,
+    profileDir: config.userDataDir,
+    dataDir: config.dataDir,
+    socketPath,
+    daemonPid: process.pid,
+    spaceCount: spaceManager.list().length,
+    selectedSpace: selected
+      ? {
+          id: selected.id,
+          name: selected.name,
+          ownership: selected.ownership,
+        }
+      : null,
+    headless: config.headless,
+    displayEnv: Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY),
+    // Resolved by the CLI shim (daemon does not know the harness layout).
+    harnessPath: null,
+  };
+}

--- a/package/ego-linux-host/src/paths.test.ts
+++ b/package/ego-linux-host/src/paths.test.ts
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { defaultDataDir, defaultSocketPath, defaultCdpPort } from "./paths.js";
+
+test("defaultDataDir uses EGO_DATA_DIR", () => {
+  assert.equal(defaultDataDir({ EGO_DATA_DIR: "/tmp/ego-x" }), "/tmp/ego-x");
+});
+
+test("defaultSocketPath nests under data dir", () => {
+  const sock = defaultSocketPath({ EGO_DATA_DIR: "/tmp/ego-x" });
+  assert.equal(sock, "/tmp/ego-x/host.sock");
+});
+
+test("defaultCdpPort parses env", () => {
+  assert.equal(defaultCdpPort({ EGO_CDP_PORT: "9333" }), 9333);
+  assert.equal(defaultCdpPort({}), 9222);
+});

--- a/package/ego-linux-host/src/paths.ts
+++ b/package/ego-linux-host/src/paths.ts
@@ -1,0 +1,32 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const APP_NAME = "ego-lite";
+
+export function defaultDataDir(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.EGO_DATA_DIR) return env.EGO_DATA_DIR;
+  const xdg = env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+  return join(xdg, APP_NAME);
+}
+
+export function defaultConfigDir(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.EGO_CONFIG_DIR) return env.EGO_CONFIG_DIR;
+  const xdg = env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  return join(xdg, APP_NAME);
+}
+
+export function defaultProfileDir(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.EGO_USER_DATA_DIR) return env.EGO_USER_DATA_DIR;
+  return join(defaultDataDir(env), "profile");
+}
+
+export function defaultSocketPath(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.EGO_HOST_SOCK) return env.EGO_HOST_SOCK;
+  return join(defaultDataDir(env), "host.sock");
+}
+
+export function defaultCdpPort(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.EGO_CDP_PORT;
+  if (raw) return Number(raw);
+  return 9222;
+}

--- a/package/ego-linux-host/src/rpc.test.ts
+++ b/package/ego-linux-host/src/rpc.test.ts
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  encodeLine,
+  encodeRequest,
+  encodeResponse,
+  encodeEvent,
+  decodeLine,
+  isRpcRequest,
+  isRpcResponse,
+  isRpcEvent,
+  LineBuffer,
+  type RpcRequest,
+  type RpcResponse,
+  type RpcEvent,
+} from "./rpc.js";
+
+test("encodeRequest emits NDJSON with trailing newline", () => {
+  const line = encodeRequest({ id: 1, method: "ping" });
+  assert.equal(line.endsWith("\n"), true);
+  assert.equal(line, '{"id":1,"method":"ping"}\n');
+});
+
+test("encodeResponse and encodeEvent round-trip via decodeLine", () => {
+  const res: RpcResponse = { id: 2, result: { ok: true } };
+  const decodedRes = decodeLine(encodeResponse(res).trimEnd());
+  assert.deepEqual(decodedRes, res);
+  assert.equal(isRpcResponse(decodedRes), true);
+
+  const ev: RpcEvent = {
+    event: "cdp.message",
+    params: { payload: '{"id":1}' },
+  };
+  const decodedEv = decodeLine(encodeEvent(ev).trimEnd());
+  assert.deepEqual(decodedEv, ev);
+  assert.equal(isRpcEvent(decodedEv), true);
+});
+
+test("decodeLine classifies request with method and id", () => {
+  const req: RpcRequest = {
+    id: 7,
+    method: "ego.listTabs",
+    params: {},
+  };
+  const msg = decodeLine(JSON.stringify(req));
+  assert.equal(isRpcRequest(msg), true);
+  if (isRpcRequest(msg)) {
+    assert.equal(msg.method, "ego.listTabs");
+    assert.equal(msg.id, 7);
+  }
+});
+
+test("decodeLine classifies error response", () => {
+  const line = JSON.stringify({
+    id: 3,
+    error: { code: "EGO_OPERATION_FAILED", message: "nope" },
+  });
+  const msg = decodeLine(line);
+  assert.equal(isRpcResponse(msg), true);
+  if (isRpcResponse(msg)) {
+    assert.equal(msg.error?.code, "EGO_OPERATION_FAILED");
+  }
+});
+
+test("decodeLine rejects empty and invalid JSON", () => {
+  assert.throws(() => decodeLine(""), /empty/);
+  assert.throws(() => decodeLine("not-json"), /invalid RPC JSON/);
+  assert.throws(() => decodeLine("[]"), /JSON object/);
+});
+
+test("encodeLine is shared by helpers", () => {
+  assert.equal(encodeLine({ a: 1 }), '{"a":1}\n');
+});
+
+test("LineBuffer splits chunks across boundaries", () => {
+  const buf = new LineBuffer();
+  assert.deepEqual(buf.push('{"id":1,"method":"ping"}'), []);
+  assert.deepEqual(buf.push("\n{\"id\":2,"), ['{"id":1,"method":"ping"}']);
+  assert.deepEqual(buf.push('"method":"doctor"}\n'), [
+    '{"id":2,"method":"doctor"}',
+  ]);
+  assert.equal(buf.pending(), "");
+});
+
+test("LineBuffer skips empty lines and accepts CRLF", () => {
+  const buf = new LineBuffer();
+  const lines = buf.push('{"id":1,"method":"ping"}\r\n\n{"event":"x"}\n');
+  assert.deepEqual(lines, ['{"id":1,"method":"ping"}', '{"event":"x"}']);
+});
+
+test("type guards reject wrong shapes", () => {
+  assert.equal(isRpcRequest({ event: "x" }), false);
+  assert.equal(isRpcEvent({ id: 1, method: "ping" }), false);
+  assert.equal(isRpcResponse({ id: 1, method: "ping" }), false);
+  assert.equal(isRpcResponse({ id: 1, result: true }), true);
+});

--- a/package/ego-linux-host/src/rpc.ts
+++ b/package/ego-linux-host/src/rpc.ts
@@ -1,0 +1,127 @@
+/**
+ * Newline-delimited JSON (NDJSON) RPC for ego-linux-hostd ↔ CLI.
+ *
+ * Requests:  { id, method, params? }
+ * Responses: { id, result? } | { id, error: { code, message } }
+ * Events:    { event, params? }
+ */
+
+export type RpcRequest = { id: number; method: string; params?: any };
+export type RpcResponse = {
+  id: number;
+  result?: any;
+  error?: { code: string; message: string };
+};
+export type RpcEvent = { event: string; params?: any };
+export type RpcMessage = RpcRequest | RpcResponse | RpcEvent;
+
+/** Encode a message as one NDJSON line (includes trailing newline). */
+export function encodeLine(msg: object): string {
+  return JSON.stringify(msg) + "\n";
+}
+
+export function encodeRequest(req: RpcRequest): string {
+  return encodeLine(req);
+}
+
+export function encodeResponse(res: RpcResponse): string {
+  return encodeLine(res);
+}
+
+export function encodeEvent(ev: RpcEvent): string {
+  return encodeLine(ev);
+}
+
+export function isRpcRequest(msg: unknown): msg is RpcRequest {
+  if (!msg || typeof msg !== "object") return false;
+  const m = msg as Record<string, unknown>;
+  return (
+    typeof m.id === "number" &&
+    typeof m.method === "string" &&
+    !("event" in m)
+  );
+}
+
+export function isRpcResponse(msg: unknown): msg is RpcResponse {
+  if (!msg || typeof msg !== "object") return false;
+  const m = msg as Record<string, unknown>;
+  return (
+    typeof m.id === "number" &&
+    !("method" in m) &&
+    !("event" in m) &&
+    ("result" in m || "error" in m)
+  );
+}
+
+export function isRpcEvent(msg: unknown): msg is RpcEvent {
+  if (!msg || typeof msg !== "object") return false;
+  const m = msg as Record<string, unknown>;
+  return typeof m.event === "string" && !("method" in m);
+}
+
+/**
+ * Parse one NDJSON line (without trailing newline).
+ * Throws on empty/invalid JSON.
+ */
+export function decodeLine(line: string): RpcMessage {
+  const trimmed = line.replace(/\r$/, "");
+  if (!trimmed) {
+    throw new Error("empty RPC line");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (err) {
+    throw new Error(
+      `invalid RPC JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("RPC message must be a JSON object");
+  }
+  if (isRpcRequest(parsed)) return parsed;
+  if (isRpcEvent(parsed)) return parsed;
+  if (isRpcResponse(parsed)) return parsed;
+  // Best-effort: treat id+method as request even if shape is odd
+  const m = parsed as Record<string, unknown>;
+  if (typeof m.id === "number" && typeof m.method === "string") {
+    return parsed as RpcRequest;
+  }
+  if (typeof m.event === "string") {
+    return parsed as RpcEvent;
+  }
+  if (typeof m.id === "number") {
+    return parsed as RpcResponse;
+  }
+  throw new Error("unrecognized RPC message shape");
+}
+
+/**
+ * Incremental buffer that splits socket chunks into complete lines.
+ * Empty lines are skipped.
+ */
+export class LineBuffer {
+  private buffer = "";
+
+  push(data: string | Buffer): string[] {
+    this.buffer += typeof data === "string" ? data : data.toString("utf8");
+    const lines: string[] = [];
+    let idx: number;
+    while ((idx = this.buffer.indexOf("\n")) !== -1) {
+      let line = this.buffer.slice(0, idx);
+      this.buffer = this.buffer.slice(idx + 1);
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+      if (line.length > 0) lines.push(line);
+    }
+    return lines;
+  }
+
+  /** Leftover bytes without a trailing newline (for diagnostics). */
+  pending(): string {
+    return this.buffer;
+  }
+
+  clear(): void {
+    this.buffer = "";
+  }
+}

--- a/package/ego-linux-host/src/snapshot-engine.test.ts
+++ b/package/ego-linux-host/src/snapshot-engine.test.ts
@@ -1,0 +1,170 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { createCdpBridge } from "./cdp-bridge.js";
+import { axTreeToSnapshot, snapshotPage } from "./snapshot-engine.js";
+
+/** Minimal injectable transport: records sends and auto-replies. */
+function mockTransport() {
+  let handler: ((text: string) => void) | undefined;
+  const sent: string[] = [];
+  const transport = {
+    sent,
+    send(text: string) {
+      sent.push(text);
+    },
+    onMessage(cb: (text: string) => void) {
+      handler = cb;
+    },
+    deliver(obj: object) {
+      assert.ok(handler, "onMessage must be registered");
+      handler!(JSON.stringify(obj));
+    },
+    autoReply(resultOrBuilder: object | ((msg: any) => object)) {
+      const prevSend = transport.send.bind(transport);
+      transport.send = (text: string) => {
+        prevSend(text);
+        const msg = JSON.parse(text);
+        const reply =
+          typeof resultOrBuilder === "function"
+            ? resultOrBuilder(msg)
+            : { id: msg.id, result: resultOrBuilder };
+        queueMicrotask(() => transport.deliver(reply));
+      };
+    },
+  };
+  return transport;
+}
+
+function manyAxNodes(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    nodeId: String(i + 1),
+    ignored: false,
+    role: { value: "button" },
+    name: { value: `Btn${i}` },
+    backendDOMNodeId: 1000 + i,
+  }));
+}
+
+test("axTreeToSnapshot emits refs with backendNodeId", async () => {
+  const ax = JSON.parse(
+    await readFile(
+      new URL("./fixtures/ax-tree-minimal.json", import.meta.url),
+      "utf8",
+    ),
+  );
+  const snap = axTreeToSnapshot(ax.nodes, { includeActionMarks: true });
+  assert.ok(snap.content.length > 0);
+  assert.ok(snap.refs.length > 0);
+  assert.equal(typeof snap.refs[0].backendNodeId, "number");
+  assert.match(snap.content, /@1/);
+});
+
+test("maxResultLength truncates content", () => {
+  const snap = axTreeToSnapshot(manyAxNodes(20), { maxResultLength: 1 });
+  assert.ok(snap.content.length <= 1);
+});
+
+test("axTreeToSnapshot skips ignored and empty generic nodes", async () => {
+  const ax = JSON.parse(
+    await readFile(
+      new URL("./fixtures/ax-tree-minimal.json", import.meta.url),
+      "utf8",
+    ),
+  );
+  const snap = axTreeToSnapshot(ax.nodes, { includeActionMarks: true });
+  const backendIds = snap.refs.map((r) => r.backendNodeId);
+  assert.ok(!backendIds.includes(50), "ignored node skipped");
+  assert.ok(!backendIds.includes(60), "empty generic skipped");
+  assert.ok(backendIds.includes(20), "button kept");
+  assert.ok(backendIds.includes(70), "StaticText kept");
+});
+
+test("includeActionMarks false omits @N marks but still returns refs", async () => {
+  const ax = JSON.parse(
+    await readFile(
+      new URL("./fixtures/ax-tree-minimal.json", import.meta.url),
+      "utf8",
+    ),
+  );
+  const snap = axTreeToSnapshot(ax.nodes, { includeActionMarks: false });
+  assert.ok(snap.refs.length > 0);
+  assert.doesNotMatch(snap.content, /@\d+/);
+  assert.match(snap.content, /button/);
+});
+
+test("content line format includes role and quoted name", async () => {
+  const ax = JSON.parse(
+    await readFile(
+      new URL("./fixtures/ax-tree-minimal.json", import.meta.url),
+      "utf8",
+    ),
+  );
+  const snap = axTreeToSnapshot(ax.nodes, { includeActionMarks: true });
+  assert.match(snap.content, /@\d+ button "Submit"/);
+  assert.match(snap.content, /@\d+ link "Home"/);
+  assert.match(snap.content, /@\d+ textbox "Email"/);
+});
+
+test("refs allocate sequential ids starting at 1", async () => {
+  const ax = JSON.parse(
+    await readFile(
+      new URL("./fixtures/ax-tree-minimal.json", import.meta.url),
+      "utf8",
+    ),
+  );
+  const snap = axTreeToSnapshot(ax.nodes, { includeActionMarks: true });
+  assert.equal(snap.refs[0].id, 1);
+  for (let i = 0; i < snap.refs.length; i++) {
+    assert.equal(snap.refs[i].id, i + 1);
+    assert.equal(typeof snap.refs[i].backendNodeId, "number");
+    assert.ok(snap.refs[i].role);
+  }
+});
+
+test("snapshotPage enables AX, fetches tree, returns snapshot", async () => {
+  const ax = JSON.parse(
+    await readFile(
+      new URL("./fixtures/ax-tree-minimal.json", import.meta.url),
+      "utf8",
+    ),
+  );
+  const transport = mockTransport();
+  transport.autoReply((msg) => {
+    if (msg.method === "Accessibility.enable") {
+      return { id: msg.id, result: {} };
+    }
+    if (msg.method === "Accessibility.getFullAXTree") {
+      return { id: msg.id, result: { nodes: ax.nodes } };
+    }
+    return { id: msg.id, result: {} };
+  });
+  const cdp = createCdpBridge(transport);
+  const snap = await snapshotPage(cdp, "sess-1", { includeActionMarks: true });
+  assert.ok(snap.refs.length > 0);
+  assert.match(snap.content, /@1/);
+  const methods = transport.sent.map((t) => JSON.parse(t).method);
+  assert.ok(methods.includes("Accessibility.enable"));
+  assert.ok(methods.includes("Accessibility.getFullAXTree"));
+  const treeCall = transport.sent
+    .map((t) => JSON.parse(t))
+    .find((m) => m.method === "Accessibility.getFullAXTree");
+  assert.equal(treeCall.sessionId, "sess-1");
+});
+
+test("snapshotPage throws EGO_SNAPSHOT_FAILED on CDP failure", async () => {
+  const transport = mockTransport();
+  transport.autoReply((msg) => ({
+    id: msg.id,
+    error: { code: -32000, message: "AX boom" },
+  }));
+  const cdp = createCdpBridge(transport);
+  await assert.rejects(
+    () => snapshotPage(cdp, "sess-x"),
+    (err: any) => {
+      assert.equal(err.error_code, "EGO_SNAPSHOT_FAILED");
+      assert.match(String(err.message), /AX boom|snapshot|Accessibility/i);
+      return true;
+    },
+  );
+});

--- a/package/ego-linux-host/src/snapshot-engine.ts
+++ b/package/ego-linux-host/src/snapshot-engine.ts
@@ -1,0 +1,250 @@
+/**
+ * AX tree → compact snapshot text + ref map for ego Linux host.
+ *
+ * Pure serializer (`axTreeToSnapshot`) for fixtures/unit tests.
+ * `snapshotPage` loads Accessibility.getFullAXTree via CdpBridge.
+ */
+
+import type { CdpBridge } from "./cdp-bridge.js";
+import { makeEgoError } from "./errors.js";
+
+export type SnapshotOptions = {
+  scope?: "only_within_viewport" | "full_page";
+  includeActionMarks?: boolean;
+  includeStableLocator?: boolean;
+  maxResultLength?: number;
+};
+
+export type SnapshotRef = {
+  id: number;
+  backendNodeId: number;
+  role?: string;
+  name?: string;
+};
+
+export type SnapshotResult = {
+  content: string;
+  refs: SnapshotRef[];
+};
+
+/** Roles worth exposing as actionable / readable snapshot lines. */
+const INTERESTING_ROLES = new Set([
+  "button",
+  "link",
+  "textbox",
+  "searchbox",
+  "combobox",
+  "listbox",
+  "option",
+  "checkbox",
+  "radio",
+  "switch",
+  "slider",
+  "spinbutton",
+  "heading",
+  "StaticText",
+  "image",
+  "img",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "tab",
+  "treeitem",
+  "cell",
+  "gridcell",
+  "columnheader",
+  "rowheader",
+  "Row",
+  "table",
+  "listitem",
+  "ListItem",
+  "article",
+  "navigation",
+  "main",
+  "banner",
+  "contentinfo",
+  "form",
+  "dialog",
+  "alertdialog",
+  "alert",
+  "status",
+  "progressbar",
+  "meter",
+  "RootWebArea",
+]);
+
+/** Structural roles we only keep when they carry a non-empty name. */
+const STRUCTURAL_IF_NAMED = new Set([
+  "generic",
+  "group",
+  "none",
+  "InlineTextBox",
+  "LineBreak",
+  "paragraph",
+  "LabelText",
+  "LegacyLayout",
+]);
+
+function extractAxString(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (typeof value === "object") {
+    const raw = (value as { value?: unknown }).value;
+    if (typeof raw === "string") return raw;
+    if (typeof raw === "number" || typeof raw === "boolean") return String(raw);
+  }
+  return "";
+}
+
+function nodeRole(node: any): string {
+  return extractAxString(node?.role);
+}
+
+function nodeName(node: any): string {
+  return extractAxString(node?.name);
+}
+
+function nodeBackendId(node: any): number | undefined {
+  const id = node?.backendDOMNodeId ?? node?.backendNodeId;
+  if (id === undefined || id === null) return undefined;
+  const n = Number(id);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function isInteresting(node: any): boolean {
+  if (!node || typeof node !== "object") return false;
+  if (node.ignored) return false;
+
+  const backendNodeId = nodeBackendId(node);
+  if (backendNodeId === undefined) return false;
+
+  const role = nodeRole(node);
+  const name = nodeName(node).trim();
+
+  if (INTERESTING_ROLES.has(role)) {
+    // RootWebArea always kept (page chrome); StaticText needs name
+    if (role === "StaticText" || role === "InlineTextBox") {
+      return name.length > 0;
+    }
+    return true;
+  }
+
+  if (STRUCTURAL_IF_NAMED.has(role)) {
+    return name.length > 0;
+  }
+
+  // Unknown role with a name is still useful context
+  return name.length > 0;
+}
+
+function formatLine(
+  refId: number,
+  role: string,
+  name: string,
+  includeActionMarks: boolean,
+  includeStableLocator: boolean,
+): string {
+  const quoted = JSON.stringify(name);
+  let line = includeActionMarks
+    ? `@${refId} ${role} ${quoted}`
+    : `${role} ${quoted}`;
+  if (includeStableLocator && role && name) {
+    const loc = `loc=role:${role}[name=${JSON.stringify(name)}]`;
+    line += ` ${loc}`;
+  }
+  return line;
+}
+
+/**
+ * Walk AX nodes; emit compact snapshot lines + sequential refs with backendNodeId.
+ */
+export function axTreeToSnapshot(
+  axNodes: any[],
+  options: SnapshotOptions = {},
+): SnapshotResult {
+  const includeActionMarks = options.includeActionMarks === true;
+  const includeStableLocator = options.includeStableLocator === true;
+  const maxResultLength = options.maxResultLength;
+
+  const nodes = Array.isArray(axNodes) ? axNodes : [];
+  const lines: string[] = [];
+  const refs: SnapshotRef[] = [];
+  let nextId = 1;
+
+  for (const node of nodes) {
+    if (!isInteresting(node)) continue;
+
+    const role = nodeRole(node) || "unknown";
+    const name = nodeName(node);
+    const backendNodeId = nodeBackendId(node)!;
+    const id = nextId++;
+
+    refs.push({ id, backendNodeId, role, name });
+    lines.push(
+      formatLine(id, role, name, includeActionMarks, includeStableLocator),
+    );
+  }
+
+  let content = lines.join("\n");
+  if (
+    typeof maxResultLength === "number" &&
+    Number.isFinite(maxResultLength) &&
+    maxResultLength >= 0 &&
+    content.length > maxResultLength
+  ) {
+    content = content.slice(0, maxResultLength);
+  }
+
+  return { content, refs };
+}
+
+/**
+ * Fetch full AX tree via CDP and serialize.
+ * On any failure throws EGO_SNAPSHOT_FAILED.
+ */
+export async function snapshotPage(
+  cdp: CdpBridge,
+  sessionId: string,
+  options?: SnapshotOptions,
+): Promise<SnapshotResult> {
+  try {
+    await cdp.send("Accessibility.enable", {}, sessionId);
+    const params: Record<string, unknown> = {};
+    // scope is reserved for future viewport filtering; full tree for MVP
+    void options?.scope;
+    const result = await cdp.send(
+      "Accessibility.getFullAXTree",
+      params,
+      sessionId,
+    );
+    const nodes = result?.nodes;
+    if (!Array.isArray(nodes)) {
+      throw makeEgoError(
+        "EGO_SNAPSHOT_FAILED",
+        "Accessibility.getFullAXTree returned no nodes array",
+      );
+    }
+    return axTreeToSnapshot(nodes, options);
+  } catch (err) {
+    if (
+      err &&
+      typeof err === "object" &&
+      (err as { error_code?: string }).error_code === "EGO_SNAPSHOT_FAILED"
+    ) {
+      throw err;
+    }
+    const detail =
+      err instanceof Error
+        ? err.message
+        : typeof err === "string"
+          ? err
+          : String(err);
+    throw makeEgoError(
+      "EGO_SNAPSHOT_FAILED",
+      `Snapshot failed: ${detail}`,
+    );
+  }
+}

--- a/package/ego-linux-host/src/space-manager.test.ts
+++ b/package/ego-linux-host/src/space-manager.test.ts
@@ -1,0 +1,188 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { SpaceManager } from "./space-manager.js";
+
+test("bootstraps user space id 1", () => {
+  const sm = new SpaceManager();
+  const user = sm.list().find((s) => s.id === 1);
+  assert.equal(user?.ownership, "user");
+  assert.equal(user?.name, "user");
+});
+
+test("createAgentSpace assigns tabs independently", () => {
+  const sm = new SpaceManager();
+  const a = sm.createAgentSpace("job-a");
+  const b = sm.createAgentSpace("job-b");
+  sm.use(a.id);
+  sm.assignTarget("t1");
+  sm.use(b.id);
+  sm.assignTarget("t2");
+  sm.use(a.id);
+  assert.deepEqual(sm.targetsForSelected(), ["t1"]);
+  sm.use(b.id);
+  assert.deepEqual(sm.targetsForSelected(), ["t2"]);
+});
+
+test("use on user space selects but marks user control for page ops", () => {
+  const sm = new SpaceManager();
+  const result = sm.use(1);
+  assert.equal(result.ok, true);
+  assert.equal(sm.selected()?.ownership, "user");
+  assert.equal(sm.isPageControlBlocked(), true);
+});
+
+test("handOff then takeOver", () => {
+  const sm = new SpaceManager();
+  const a = sm.createAgentSpace("x");
+  sm.use(a.id);
+  sm.handOff();
+  assert.equal(sm.selected()?.ownership, "agentDelegatedToUser");
+  assert.equal(sm.isPageControlBlocked(), true);
+  sm.takeOver();
+  assert.equal(sm.selected()?.ownership, "agent");
+  assert.equal(sm.isPageControlBlocked(), false);
+});
+
+test("claim moves user space to agent", () => {
+  const sm = new SpaceManager();
+  sm.claim(1);
+  assert.equal(sm.list().find((s) => s.id === 1)?.ownership, "agent");
+});
+
+test("use missing space returns not found", () => {
+  const sm = new SpaceManager();
+  const result = sm.use(999);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.error_code, "EGO_TASK_SPACE_NOT_FOUND");
+  }
+});
+
+test("isPageControlBlocked false only for agent ownership", () => {
+  const sm = new SpaceManager();
+  const a = sm.createAgentSpace("agent-job");
+  sm.use(a.id);
+  assert.equal(sm.selected()?.ownership, "agent");
+  assert.equal(sm.isPageControlBlocked(), false);
+});
+
+test("listPublic strips targetIds", () => {
+  const sm = new SpaceManager();
+  const a = sm.createAgentSpace("pub");
+  sm.use(a.id);
+  sm.assignTarget("t-pub");
+  const pub = sm.listPublic().find((s) => s.id === a.id);
+  assert.ok(pub);
+  assert.equal("targetIds" in (pub as object), false);
+  assert.equal(pub?.name, "pub");
+  const internal = sm.list().find((s) => s.id === a.id);
+  assert.deepEqual(internal?.targetIds, ["t-pub"]);
+});
+
+test("assignTarget moves tab between spaces", () => {
+  const sm = new SpaceManager();
+  const a = sm.createAgentSpace("a");
+  const b = sm.createAgentSpace("b");
+  sm.assignTarget("shared", a.id);
+  assert.equal(sm.spaceIdForTarget("shared"), a.id);
+  sm.assignTarget("shared", b.id);
+  assert.equal(sm.spaceIdForTarget("shared"), b.id);
+  assert.equal(sm.list().find((s) => s.id === a.id)?.targetIds.includes("shared"), false);
+});
+
+test("adoptOrphanTargets puts unknowns on user space", () => {
+  const sm = new SpaceManager();
+  const a = sm.createAgentSpace("known");
+  sm.assignTarget("known-t", a.id);
+  sm.adoptOrphanTargets(["known-t", "orphan-1", "orphan-2"]);
+  assert.equal(sm.spaceIdForTarget("known-t"), a.id);
+  assert.equal(sm.spaceIdForTarget("orphan-1"), 1);
+  assert.equal(sm.spaceIdForTarget("orphan-2"), 1);
+});
+
+test("closeSelected returns targetIds and removes agent space", () => {
+  const sm = new SpaceManager();
+  const a = sm.createAgentSpace("to-close");
+  sm.use(a.id);
+  sm.assignTarget("c1");
+  sm.assignTarget("c2");
+  const closed = sm.closeSelected();
+  assert.deepEqual(closed.sort(), ["c1", "c2"]);
+  assert.equal(sm.list().find((s) => s.id === a.id), undefined);
+  assert.equal(sm.selected(), null);
+});
+
+test("completeKeep transfers selected agent space to user ownership", () => {
+  const sm = new SpaceManager();
+  const a = sm.createAgentSpace("done-keep");
+  sm.use(a.id);
+  sm.assignTarget("keep-tab");
+  sm.completeKeep();
+  const space = sm.list().find((s) => s.id === a.id);
+  assert.equal(space?.ownership, "user");
+  assert.deepEqual(space?.targetIds, ["keep-tab"]);
+});
+
+test("claim selects space and can rename", () => {
+  const sm = new SpaceManager();
+  const claimed = sm.claim(1, "claimed-user");
+  assert.equal(claimed.ownership, "agent");
+  assert.equal(claimed.name, "claimed-user");
+  assert.equal(sm.selected()?.id, 1);
+  assert.equal(sm.isPageControlBlocked(), false);
+});
+
+test("persist save/load round-trips spaces and selection", async () => {
+  const dir = join(tmpdir(), `ego-space-mgr-${process.pid}-${Date.now()}`);
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, "spaces.json");
+  try {
+    const sm = new SpaceManager(path);
+    const a = sm.createAgentSpace("persisted");
+    sm.use(a.id);
+    sm.assignTarget("pt1");
+    sm.handOff();
+    await sm.save();
+
+    const raw = JSON.parse(await readFile(path, "utf8"));
+    assert.equal(typeof raw.nextId, "number");
+    assert.equal(raw.selectedId, a.id);
+    assert.ok(Array.isArray(raw.spaces));
+
+    const sm2 = new SpaceManager(path);
+    await sm2.load();
+    assert.equal(sm2.selected()?.id, a.id);
+    assert.equal(sm2.selected()?.ownership, "agentDelegatedToUser");
+    assert.deepEqual(sm2.targetsForSelected(), ["pt1"]);
+    assert.ok(sm2.list().find((s) => s.id === 1));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("load missing file keeps bootstrap user space", async () => {
+  const path = join(
+    tmpdir(),
+    `ego-space-missing-${process.pid}-${Date.now()}.json`,
+  );
+  const sm = new SpaceManager(path);
+  await sm.load();
+  assert.equal(sm.list().find((s) => s.id === 1)?.name, "user");
+});
+
+test("load recovers corrupt file to bootstrap", async () => {
+  const dir = join(tmpdir(), `ego-space-bad-${process.pid}-${Date.now()}`);
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, "spaces.json");
+  try {
+    await writeFile(path, "not-json{{{", "utf8");
+    const sm = new SpaceManager(path);
+    await sm.load();
+    assert.equal(sm.list().find((s) => s.id === 1)?.ownership, "user");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/package/ego-linux-host/src/space-manager.ts
+++ b/package/ego-linux-host/src/space-manager.ts
@@ -1,0 +1,348 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export type Ownership = "agent" | "agentDelegatedToUser" | "user";
+
+export type Space = {
+  taskId: string;
+  id: number;
+  name: string;
+  createdBy: "agent" | "user";
+  ownership: Ownership;
+  recentTabTitles?: string[];
+  targetIds: string[];
+};
+
+export type UseResult =
+  | { ok: true; space: Space }
+  | { ok: false; error_code: string; error: string };
+
+type PersistShape = {
+  nextId: number;
+  selectedId: number | null;
+  spaces: Space[];
+};
+
+const USER_SPACE_ID = 1;
+
+function bootstrapUserSpace(): Space {
+  return {
+    taskId: "user",
+    id: USER_SPACE_ID,
+    name: "user",
+    createdBy: "user",
+    ownership: "user",
+    targetIds: [],
+  };
+}
+
+function cloneSpace(space: Space): Space {
+  return {
+    ...space,
+    targetIds: [...space.targetIds],
+    ...(space.recentTabTitles
+      ? { recentTabTitles: [...space.recentTabTitles] }
+      : {}),
+  };
+}
+
+/**
+ * Task Spaces = named tab sets + ownership in one shared Chromium profile.
+ * Isolation is tabs/control, not cookies.
+ */
+export class SpaceManager {
+  private readonly persistPath: string | undefined;
+  private nextId = USER_SPACE_ID + 1;
+  private selectedId: number | null = null;
+  private spaces: Space[] = [bootstrapUserSpace()];
+
+  constructor(persistPath?: string) {
+    this.persistPath = persistPath;
+  }
+
+  async load(): Promise<void> {
+    if (!this.persistPath) return;
+    try {
+      const raw = await readFile(this.persistPath, "utf8");
+      const parsed = JSON.parse(raw) as PersistShape;
+      if (
+        !parsed ||
+        typeof parsed !== "object" ||
+        !Array.isArray(parsed.spaces)
+      ) {
+        this.resetBootstrap();
+        return;
+      }
+      const spaces: Space[] = [];
+      for (const entry of parsed.spaces) {
+        if (!entry || typeof entry !== "object") continue;
+        if (typeof entry.id !== "number" || typeof entry.name !== "string") {
+          continue;
+        }
+        const ownership = entry.ownership;
+        if (
+          ownership !== "agent" &&
+          ownership !== "agentDelegatedToUser" &&
+          ownership !== "user"
+        ) {
+          continue;
+        }
+        const createdBy =
+          entry.createdBy === "agent" || entry.createdBy === "user"
+            ? entry.createdBy
+            : ownership === "user"
+              ? "user"
+              : "agent";
+        spaces.push({
+          taskId:
+            typeof entry.taskId === "string" ? entry.taskId : String(entry.id),
+          id: entry.id,
+          name: entry.name,
+          createdBy,
+          ownership,
+          targetIds: Array.isArray(entry.targetIds)
+            ? entry.targetIds.filter((t): t is string => typeof t === "string")
+            : [],
+          ...(Array.isArray(entry.recentTabTitles)
+            ? {
+                recentTabTitles: entry.recentTabTitles.filter(
+                  (t): t is string => typeof t === "string",
+                ),
+              }
+            : {}),
+        });
+      }
+      if (!spaces.some((s) => s.id === USER_SPACE_ID)) {
+        spaces.unshift(bootstrapUserSpace());
+      }
+      this.spaces = spaces;
+      this.nextId =
+        typeof parsed.nextId === "number" && parsed.nextId > USER_SPACE_ID
+          ? parsed.nextId
+          : Math.max(USER_SPACE_ID + 1, ...spaces.map((s) => s.id + 1));
+      if (
+        parsed.selectedId === null ||
+        parsed.selectedId === undefined ||
+        typeof parsed.selectedId !== "number"
+      ) {
+        this.selectedId = null;
+      } else if (this.findSpace(parsed.selectedId)) {
+        this.selectedId = parsed.selectedId;
+      } else {
+        this.selectedId = null;
+      }
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code === "ENOENT" || code === "ENOTDIR") {
+        this.resetBootstrap();
+        return;
+      }
+      // Corrupt JSON or unexpected shape → bootstrap
+      this.resetBootstrap();
+    }
+  }
+
+  async save(): Promise<void> {
+    if (!this.persistPath) return;
+    const payload: PersistShape = {
+      nextId: this.nextId,
+      selectedId: this.selectedId,
+      spaces: this.spaces.map(cloneSpace),
+    };
+    await mkdir(dirname(this.persistPath), { recursive: true });
+    await writeFile(this.persistPath, JSON.stringify(payload, null, 2), "utf8");
+  }
+
+  /** Internal list including targetIds. */
+  list(): Space[] {
+    return this.spaces.map(cloneSpace);
+  }
+
+  /** Public records without targetIds (ego listTaskSpaces shape). */
+  listPublic(): Array<Omit<Space, "targetIds"> & { recentTabTitles?: string[] }> {
+    return this.spaces.map((s) => {
+      const { targetIds: _t, ...rest } = s;
+      return {
+        ...rest,
+        ...(s.recentTabTitles
+          ? { recentTabTitles: [...s.recentTabTitles] }
+          : {}),
+      };
+    });
+  }
+
+  createAgentSpace(name: string): Space {
+    const id = this.nextId++;
+    const space: Space = {
+      taskId: String(id),
+      id,
+      name,
+      createdBy: "agent",
+      ownership: "agent",
+      targetIds: [],
+    };
+    this.spaces.push(space);
+    return cloneSpace(space);
+  }
+
+  use(id: number): UseResult {
+    const space = this.findSpace(id);
+    if (!space) {
+      return {
+        ok: false,
+        error_code: "EGO_TASK_SPACE_NOT_FOUND",
+        error: `task space not found: ${id}`,
+      };
+    }
+    this.selectedId = id;
+    return { ok: true, space: cloneSpace(space) };
+  }
+
+  claim(id: number, name?: string): Space {
+    const space = this.findSpace(id);
+    if (!space) {
+      throw Object.assign(new Error(`task space not found: ${id}`), {
+        error_code: "EGO_TASK_SPACE_NOT_FOUND",
+      });
+    }
+    space.ownership = "agent";
+    if (name !== undefined && name !== "") {
+      space.name = name;
+    }
+    this.selectedId = id;
+    return cloneSpace(space);
+  }
+
+  handOff(): void {
+    const space = this.selectedSpace();
+    if (!space) return;
+    if (space.ownership === "agent") {
+      space.ownership = "agentDelegatedToUser";
+    }
+  }
+
+  takeOver(): void {
+    const space = this.selectedSpace();
+    if (!space) return;
+    if (space.ownership === "agentDelegatedToUser") {
+      space.ownership = "agent";
+    }
+  }
+
+  /**
+   * Complete selected agent space but keep its tabs: ownership becomes user.
+   */
+  completeKeep(): void {
+    const space = this.selectedSpace();
+    if (!space) return;
+    if (space.id === USER_SPACE_ID && space.createdBy === "user") {
+      // Bootstrap user space stays user-owned; nothing to complete.
+      space.ownership = "user";
+      return;
+    }
+    space.ownership = "user";
+  }
+
+  /**
+   * Close the selected space. Returns targetIds the host should close in Chrome.
+   * Protects bootstrap user space id 1 (clears its tabs, does not remove the space).
+   */
+  closeSelected(): string[] {
+    if (this.selectedId === null) return [];
+    const space = this.findSpace(this.selectedId);
+    if (!space) {
+      this.selectedId = null;
+      return [];
+    }
+    const targetIds = [...space.targetIds];
+    if (space.id === USER_SPACE_ID) {
+      space.targetIds = [];
+      space.ownership = "user";
+      this.selectedId = null;
+      return targetIds;
+    }
+    this.spaces = this.spaces.filter((s) => s.id !== space.id);
+    this.selectedId = null;
+    return targetIds;
+  }
+
+  selected(): Space | null {
+    const space = this.selectedSpace();
+    return space ? cloneSpace(space) : null;
+  }
+
+  /**
+   * Page ops / snapshot blocked when no selection or ownership is user /
+   * agentDelegatedToUser (agent control required).
+   */
+  isPageControlBlocked(): boolean {
+    const space = this.selectedSpace();
+    if (!space) return true;
+    return (
+      space.ownership === "user" || space.ownership === "agentDelegatedToUser"
+    );
+  }
+
+  assignTarget(targetId: string, spaceId?: number): void {
+    const destId = spaceId ?? this.selectedId;
+    if (destId === null || destId === undefined) {
+      throw Object.assign(new Error("task space not selected"), {
+        error_code: "EGO_TASK_SPACE_NOT_SELECTED",
+      });
+    }
+    const dest = this.findSpace(destId);
+    if (!dest) {
+      throw Object.assign(new Error(`task space not found: ${destId}`), {
+        error_code: "EGO_TASK_SPACE_NOT_FOUND",
+      });
+    }
+    for (const s of this.spaces) {
+      const idx = s.targetIds.indexOf(targetId);
+      if (idx !== -1) s.targetIds.splice(idx, 1);
+    }
+    if (!dest.targetIds.includes(targetId)) {
+      dest.targetIds.push(targetId);
+    }
+  }
+
+  targetsForSelected(): string[] {
+    const space = this.selectedSpace();
+    return space ? [...space.targetIds] : [];
+  }
+
+  spaceIdForTarget(targetId: string): number | null {
+    for (const s of this.spaces) {
+      if (s.targetIds.includes(targetId)) return s.id;
+    }
+    return null;
+  }
+
+  /** Assign unknown targets to the user space (id 1). Known targets unchanged. */
+  adoptOrphanTargets(targetIds: string[]): void {
+    const user = this.findSpace(USER_SPACE_ID);
+    if (!user) {
+      this.spaces.unshift(bootstrapUserSpace());
+    }
+    const userSpace = this.findSpace(USER_SPACE_ID)!;
+    for (const tid of targetIds) {
+      if (this.spaceIdForTarget(tid) === null) {
+        userSpace.targetIds.push(tid);
+      }
+    }
+  }
+
+  private findSpace(id: number): Space | undefined {
+    return this.spaces.find((s) => s.id === id);
+  }
+
+  private selectedSpace(): Space | undefined {
+    if (this.selectedId === null) return undefined;
+    return this.findSpace(this.selectedId);
+  }
+
+  private resetBootstrap(): void {
+    this.nextId = USER_SPACE_ID + 1;
+    this.selectedId = null;
+    this.spaces = [bootstrapUserSpace()];
+  }
+}

--- a/package/ego-linux-host/tsconfig.json
+++ b/package/ego-linux-host/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/skills/ego-browser/references/install.md
+++ b/skills/ego-browser/references/install.md
@@ -2,13 +2,93 @@
 
 Read this file only when ego lite isn't installed yet, or when the user asks to install ego lite. For day-to-day browser work, go back to `SKILL.md`.
 
-The ego-browser skill depends on the ego lite browser: the `ego-browser` command is provided by the ego lite app. Once ego lite is installed and you've gone through onboarding once, the environment is ready and there are no further environment issues.
+The ego-browser skill depends on a working `ego-browser` command on `PATH`. On **macOS**, that command comes from the Citro **ego lite** app (DMG + onboarding). On **Linux / WSL**, this monorepo ships an **ego-shaped Linux host** (`package/ego-linux-host`) that approximates the same product model (shared Chromium profile, Task Spaces, CDP) without the proprietary Citro app.
 
-ego lite website: https://lite.ego.app/
+ego lite website (macOS product): https://lite.ego.app/
+
+---
+
+## Install steps (Linux / WSL)
+
+Use this path on Linux and WSL. **Do not** run the macOS DMG installer (`scripts/install.sh`) here — it only supports Darwin and downloads the Citro app.
+
+This install builds the OSS packages in the monorepo and symlinks a CLI shim:
+
+- Host: `package/ego-linux-host` (daemon + `ego-browser` shim)
+- Harness: `package/ego-browser` (helper runtime injected into heredocs)
+
+### Requirements
+
+- Linux kernel (`uname -s` → `Linux`), including WSL2
+- Node.js ≥ 22 and npm
+- Chrome or Chromium **on the Linux side** (not Windows `chrome.exe` for MVP)
+- For headed mode: a display (`DISPLAY` set) — prefer **WSLg** on Windows
+- For headless: `EGO_HEADLESS=1` (opt-in; no GUI required)
+
+### Run the installer
+
+From the ego-lite repo root (adjust the path if your checkout lives elsewhere):
+
+```bash
+bash skills/ego-browser/scripts/install-linux.sh
+```
+
+What it does:
+
+1. Checks Linux + Node ≥ 22
+2. `npm ci` + `npm run build` for `package/ego-browser` and `package/ego-linux-host`
+3. Creates data/config dirs (`~/.local/share/ego-lite`, `~/.config/ego-lite`)
+4. Symlinks `~/.local/bin/ego-browser` → `package/ego-linux-host/bin/ego-browser.mjs`
+5. Detects Chrome/Chromium (warns with install hints if missing; does not auto-`apt install`)
+6. Checks that `~/.local/bin` is on `PATH`
+7. Runs `ego-browser --doctor` (skip with `--no-doctor`)
+
+Optional flags:
+
+```bash
+bash skills/ego-browser/scripts/install-linux.sh --no-doctor
+bash skills/ego-browser/scripts/install-linux.sh --doctor   # default
+```
+
+### Optional profile seed (`--seed-chrome`) — risky, off by default
+
+Copying cookies/logins from your **system Chrome** into the ego profile is **not** done by default and is not wired into the installer yet.
+
+- Config flag `seedFromChrome` in `~/.config/ego-lite/config.json` defaults to `false` (feature flag only).
+- A future installer `--seed-chrome` would copy only selected Default-profile dirs **when the source Chrome is fully closed**.
+- Seeding while Chrome is running (or blindly copying a live profile) can **corrupt Chrome data**. Leave seeding disabled unless you understand that risk.
+
+Until an explicit, guarded implementation lands, use Chrome’s own export/import or sign in again inside the ego profile.
+
+### Headed vs headless (WSL notes)
+
+| Mode | When | How |
+|------|------|-----|
+| Headed (preferred) | Interactive browsing, visual debug | WSLg or native Linux desktop; ensure `DISPLAY` is set |
+| Headless | CI / no GUI | `export EGO_HEADLESS=1` before `ego-browser` |
+
+MVP targets **Linux-side** Chrome/Chromium only. Pointing at Windows Chrome under `/mnt/c/...` is out of scope.
+
+If Chrome lives in a non-standard path:
+
+```bash
+export EGO_CHROME_PATH=/opt/google/chrome/chrome
+```
+
+### Confirm install
+
+```bash
+command -v ego-browser
+ego-browser --doctor
+```
+
+If `command -v` fails, put `~/.local/bin` on `PATH` (see below) and retry.
+
+---
 
 ## Install steps (macOS only)
 
-The install script lives at `scripts/install.sh` in this skill and supports macOS only. It will:
+The install script lives at `scripts/install.sh` in this skill and supports **macOS only**. It will:
 
 - Download the ego lite installer (a DMG) for your CPU architecture (arm64 / x64).
 - Install `ego lite.app` to `/Applications` (falling back to `~/Applications` when needed).
@@ -30,9 +110,11 @@ After the script opens the ego lite app, the user completes the first-run onboar
 
 Onboarding is a step the user completes in the GUI. After the script opens ego lite, wait for the user to confirm they've finished onboarding before continuing.
 
+---
+
 ## After installing: confirm `ego-browser` is available
 
-Once the user has finished onboarding, confirm the command is ready:
+Once install (and on macOS, onboarding) is done, confirm the command is ready:
 
 ```bash
 command -v ego-browser
@@ -55,13 +137,23 @@ EOF
 
 Printing `ego-browser ready` means the environment is ready.
 
+On Linux, you can also run diagnostics without a full heredoc:
+
+```bash
+ego-browser --doctor
+```
+
 ## After that, return to the original task
 
 Once the environment is ready, return to the user's original task and continue with the task space flow in `SKILL.md` — start from `taskSpaces.useOrCreate(name)` and proceed as usual.
 
 ## Troubleshooting
 
-- **Not macOS**: the script supports macOS only (`uname -s` is `Darwin`). On other platforms, have the user download and install from the ego lite website at https://lite.ego.app/.
-- **Download failed**: the script retries 3 times automatically; if it still fails, it's usually a network issue — have the user check their network and retry.
-- **Gatekeeper still blocks it**: the script already tries to strip quarantine; if the first launch is still blocked, have the user allow ego lite manually under System Settings → Privacy & Security.
-- **Command still unavailable after onboarding**: confirm `~/.local/bin` is on the PATH (see above); or have the user reopen ego lite, finish onboarding, and retry.
+- **Linux / WSL**: use `scripts/install-linux.sh`, not the macOS DMG script. See **Install steps (Linux / WSL)** above.
+- **Not macOS**: the DMG script supports macOS only (`uname -s` is `Darwin`). On Linux use `install-linux.sh`. On other platforms, check https://lite.ego.app/ or build from this monorepo.
+- **This is not the Citro app on Linux**: the Linux host is an OSS-friendly approximation (shared Chromium + CDP + Task Spaces). It does not download or install `ego lite.app`.
+- **Chrome missing on Linux**: install Chromium/Chrome for Linux, or set `EGO_CHROME_PATH`. The installer warns but does not run package managers without consent.
+- **No display (WSL without WSLg)**: use `EGO_HEADLESS=1`, or enable WSLg / a display server.
+- **Download failed (macOS)**: the DMG script retries 3 times automatically; if it still fails, it's usually a network issue — have the user check their network and retry.
+- **Gatekeeper still blocks it (macOS)**: the script already tries to strip quarantine; if the first launch is still blocked, have the user allow ego lite manually under System Settings → Privacy & Security.
+- **Command still unavailable**: confirm `~/.local/bin` is on the PATH (see above). On macOS, reopen ego lite, finish onboarding, and retry. On Linux, re-run `install-linux.sh` or re-create the symlink to `package/ego-linux-host/bin/ego-browser.mjs`.

--- a/skills/ego-browser/scripts/install-linux.sh
+++ b/skills/ego-browser/scripts/install-linux.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# Install ego-browser Linux host (ego-shaped OSS host — not the Citro/macOS app).
+#
+# This script builds the monorepo packages and places an `ego-browser` shim on PATH.
+# It does NOT download the macOS DMG from cdn.ego.app.
+#
+# Usage (from anywhere; resolves repo root relative to this script):
+#   bash skills/ego-browser/scripts/install-linux.sh
+#   bash skills/ego-browser/scripts/install-linux.sh --doctor   # install + force doctor
+#
+# Requirements:
+#   - Linux (or WSL with Linux-side Chrome/Chromium)
+#   - Node.js ≥ 22 and npm
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+EGO_BROWSER_PKG="$REPO_ROOT/package/ego-browser"
+EGO_LINUX_HOST_PKG="$REPO_ROOT/package/ego-linux-host"
+BIN_DIR="${HOME}/.local/bin"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/ego-lite"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/ego-lite"
+SHIM_TARGET="$EGO_LINUX_HOST_PKG/bin/ego-browser.mjs"
+SHIM_LINK="$BIN_DIR/ego-browser"
+RUN_DOCTOR=1
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+die() {
+  log "error: $*"
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: install-linux.sh [--doctor|--no-doctor] [-h|--help]
+
+  Install the ego-shaped Linux host for ego-browser (not the Citro macOS app).
+
+  --doctor      Run `ego-browser --doctor` after install (default)
+  --no-doctor   Skip the doctor smoke check
+  -h, --help    Show this help
+EOF
+}
+
+parse_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --doctor)
+        RUN_DOCTOR=1
+        shift
+        ;;
+      --no-doctor)
+        RUN_DOCTOR=0
+        shift
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *)
+        die "unknown argument: $1 (try --help)"
+        ;;
+    esac
+  done
+}
+
+require_linux() {
+  local os
+  os="$(uname -s)"
+  [ "$os" = "Linux" ] || die "this script only supports Linux (got uname -s=$os). On macOS use scripts/install.sh (Citro DMG)."
+}
+
+require_node22() {
+  require_command node
+  require_command npm
+  local version major
+  version="$(node -v 2>/dev/null || true)"
+  version="${version#v}"
+  major="${version%%.*}"
+  case "$major" in
+    '' | *[!0-9]*)
+      die "could not parse Node version from: $(node -v 2>&1 || true)"
+      ;;
+  esac
+  if [ "$major" -lt 22 ]; then
+    die "Node.js ≥ 22 required (found v$version). Install a newer Node and retry."
+  fi
+  log "Node $(node -v) OK"
+}
+
+build_packages() {
+  [ -d "$EGO_BROWSER_PKG" ] || die "missing package: $EGO_BROWSER_PKG"
+  [ -d "$EGO_LINUX_HOST_PKG" ] || die "missing package: $EGO_LINUX_HOST_PKG"
+  [ -f "$SHIM_TARGET" ] || die "missing CLI entry: $SHIM_TARGET"
+
+  log "Building package/ego-browser ..."
+  (
+    cd "$EGO_BROWSER_PKG"
+    # Skip lefthook prepare hook outside the intentional git setup.
+    CI=true npm ci
+    npm run build
+  )
+
+  log "Building package/ego-linux-host ..."
+  (
+    cd "$EGO_LINUX_HOST_PKG"
+    CI=true npm ci
+    npm run build
+  )
+}
+
+create_dirs_and_symlink() {
+  mkdir -p "$BIN_DIR" "$DATA_DIR" "$CONFIG_DIR"
+  chmod 700 "$DATA_DIR" 2>/dev/null || true
+
+  chmod +x \
+    "$EGO_LINUX_HOST_PKG/bin/ego-browser.mjs" \
+    "$EGO_LINUX_HOST_PKG/bin/ego-linux-hostd.mjs"
+
+  ln -sfn "$SHIM_TARGET" "$SHIM_LINK"
+  log "Linked $SHIM_LINK -> $SHIM_TARGET"
+  log "Data dir:   $DATA_DIR"
+  log "Config dir: $CONFIG_DIR"
+}
+
+detect_chrome() {
+  if [ -n "${EGO_CHROME_PATH:-}" ]; then
+    if [ -x "$EGO_CHROME_PATH" ]; then
+      log "Chrome: EGO_CHROME_PATH=$EGO_CHROME_PATH"
+      return 0
+    fi
+    log "warning: EGO_CHROME_PATH is set but not executable: $EGO_CHROME_PATH"
+  fi
+
+  local candidate found=""
+  for candidate in \
+    google-chrome-stable \
+    google-chrome \
+    chromium \
+    chromium-browser \
+    /usr/bin/google-chrome \
+    /usr/bin/google-chrome-stable \
+    /usr/bin/chromium \
+    /usr/bin/chromium-browser \
+    /opt/google/chrome/chrome \
+    /snap/bin/chromium
+  do
+    if [[ "$candidate" == /* ]]; then
+      if [ -x "$candidate" ]; then
+        found="$candidate"
+        break
+      fi
+    else
+      if command -v "$candidate" >/dev/null 2>&1; then
+        found="$(command -v "$candidate")"
+        break
+      fi
+    fi
+  done
+
+  if [ -n "$found" ]; then
+    log "Chrome: found $found"
+    return 0
+  fi
+
+  cat >&2 <<'EOF'
+warning: Chrome/Chromium not found on PATH.
+
+  Install a Linux-side browser (WSL: not Windows chrome.exe), for example:
+    # Debian/Ubuntu
+    sudo apt-get install -y chromium-browser
+    # or Google Chrome from https://www.google.com/chrome/
+  Then set EGO_CHROME_PATH if the binary is non-standard:
+    export EGO_CHROME_PATH=/path/to/chrome
+
+  Headed mode needs a display (native Linux or WSLg). For headless:
+    export EGO_HEADLESS=1
+EOF
+  return 0
+}
+
+check_path() {
+  case ":$PATH:" in
+    *":$BIN_DIR:"*)
+      log "PATH: $BIN_DIR is already on PATH"
+      ;;
+    *)
+      cat >&2 <<EOF
+warning: $BIN_DIR is not on PATH in this shell.
+
+  Add it for this session:
+    export PATH="\$HOME/.local/bin:\$PATH"
+
+  Persist it in ~/.bashrc or ~/.zshrc:
+    export PATH="\$HOME/.local/bin:\$PATH"
+EOF
+      # Ensure doctor / post-checks work in this script.
+      export PATH="$BIN_DIR:$PATH"
+      ;;
+  esac
+}
+
+run_doctor() {
+  if [ "$RUN_DOCTOR" -eq 0 ]; then
+    log "Skipping ego-browser --doctor (--no-doctor)"
+    return 0
+  fi
+
+  log "Running ego-browser --doctor ..."
+  if command -v ego-browser >/dev/null 2>&1; then
+    ego-browser --doctor || log "warning: ego-browser --doctor exited non-zero (Chrome/display may be missing)"
+  else
+    # Fallback if PATH still odd
+    node "$SHIM_TARGET" --doctor || log "warning: ego-browser --doctor exited non-zero (Chrome/display may be missing)"
+  fi
+}
+
+main() {
+  parse_args "$@"
+  require_linux
+  require_node22
+  build_packages
+  create_dirs_and_symlink
+  detect_chrome
+  check_path
+  run_doctor
+
+  cat >&2 <<EOF
+
+Install complete (ego-shaped Linux host — not Citro/macOS ego lite).
+
+  command:  $(command -v ego-browser 2>/dev/null || echo "$SHIM_LINK")
+  host:     package/ego-linux-host
+  harness:  package/ego-browser
+
+Next:
+  command -v ego-browser
+  ego-browser --doctor
+  ego-browser nodejs <<'EOFJS'
+console.log('ego-browser ready')
+EOFJS
+
+For headed browsing under WSL, prefer WSLg (DISPLAY set). Headless:
+  EGO_HEADLESS=1 ego-browser ...
+EOF
+}
+
+main "$@"


### PR DESCRIPTION
## What

Adds an **ego-shaped Linux host** so agents can use the existing `ego-browser` skill and open-source harness on Linux/WSL without the macOS-only Citro app.

New package: `package/ego-linux-host/`

- Long-lived Chromium + host daemon (Unix socket, loopback CDP)
- Shared profile (logins inherited); task spaces = tab sets + ownership
- AX snapshot engine (`backendNodeId` refs)
- CLI shim: `ego-browser` / `ego-browser nodejs <<EOF`
- `skills/ego-browser/scripts/install-linux.sh` + Linux section in `install.md`
- Design + plan under `docs/superpowers/`

## Why

ego lite product model is you and agents sharing one browser in parallel. Today install is macOS-only. This delivers the agent-facing contract (`globalThis.ego`) on stock Chromium so Claude/Codex/etc. can run browser tasks on Linux.

This is **not** a reverse-engineered Citro app (no kernel-level snapshot parity, no native Spaces UI). Gaps are documented in the host README and design spec.

## How to verify

```bash
bash skills/ego-browser/scripts/install-linux.sh
ego-browser --doctor

ego-browser nodejs <<'EOF'
const task = await taskSpaces.useOrCreate('pr-smoke')
await browser.openOrReuseTab('https://example.com', { wait: true, timeout: 20000 })
console.log(await page.title())
console.log(String(await page.snapshot()).slice(0, 200))
EOF

cd package/ego-linux-host && npm test
cd ../ego-browser && npm test
```

Optional: `EGO_LINUX_E2E=1 npm test` in `package/ego-linux-host` (Chrome + display).

## Notes

- CDP only — no Playwright/Puppeteer
- Headed by default; `EGO_HEADLESS=1` opt-in
- Private backup mirror (independent track): https://github.com/iagogfe/ego-lite-linux
