### PR TITLE
docs: backport README tagline to dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="docs/assets/banner.png" alt="ego lite" width="100%" />
 
-**The best browser for both you and your AI agents work in parallel.**
+**The fastest browser for AI agents to run web automation**
 
 <p>
   <a href="https://cdn.ego.app/channel/github_github_referral/setup/macos/arm64/egolite.dmg"><img src="https://img.shields.io/badge/Download-Apple%20Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for Apple Silicon" /></a>


### PR DESCRIPTION
## Summary

- Backport the README tagline introduced by #124 from `main` to `dev`.
- Preserve the exact one-line content change from original commit `e854e63`.

## Why

PR #124 was merged directly into `main`, so `dev` retained the previous README tagline. This backport keeps the documentation content aligned across the two branches without mixing it into unrelated changes.

## Impact

Documentation-only. The README now describes ego lite as “The fastest browser for AI agents to run web automation” on `dev`; runtime behavior is unchanged.

## Validation

- `git diff --check`
- Confirmed the backport and original commit have the same stable patch ID
- Diff contains one insertion and one deletion in `README.md`