### PR TITLE
Refine ego-browser task lifecycle guidance

### DIFF
--- a/package/ego-browser/scripts/real-browser-e2e/fixture.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/fixture.mjs
@@ -19,7 +19,17 @@ export async function startFixtureServer(taskName) {
   const handleDamaiRushRoute = createDamaiRushRoutes();
   const fixtureServer = createServer(async (req, res) => {
     const url = new URL(req.url || "/", "http://127.0.0.1");
-    if (await handleDamaiRushRoute(req, res, url)) return;
+    try {
+      if (await handleDamaiRushRoute(req, res, url)) return;
+    } catch (error) {
+      if (res.headersSent) {
+        res.destroy(error);
+      } else {
+        res.writeHead(500, { "content-type": "text/plain; charset=utf-8" });
+        res.end("Internal Server Error");
+      }
+      return;
+    }
     if (url.pathname === "/healthz") {
       res.writeHead(200, {
         "content-type": "application/json",

--- a/package/ego-browser/src/browser-runtime.test.mjs
+++ b/package/ego-browser/src/browser-runtime.test.mjs
@@ -287,6 +287,47 @@ test("subscribeBrowserEvent stops delivery after unsubscribe", async () => {
   }
 });
 
+test("subscribeBrowserEvent isolates listener failures", async () => {
+  const { subscribeBrowserEvent } =
+    await import("../dist/src/browser-runtime.js");
+  installAutoEgo();
+  const originalConsoleError = console.error;
+  const errors = [];
+  console.error = (...args) => errors.push(args);
+  let unsubscribeFailing;
+  let unsubscribeHealthy;
+  try {
+    await browserCdp("Runtime.evaluate", { expression: "1" });
+    unsubscribeFailing = subscribeBrowserEvent(
+      "Page.screencastFrame",
+      "sess-video",
+      () => {
+        throw new Error("subscriber failed");
+      },
+    );
+    const received = [];
+    unsubscribeHealthy = subscribeBrowserEvent(
+      "Page.screencastFrame",
+      "sess-video",
+      (event) => received.push(event.params.data),
+    );
+
+    assert.doesNotThrow(() => {
+      fireEvent("Page.screencastFrame", { data: "frame-1" }, "sess-video");
+    });
+
+    assert.deepEqual(received, ["frame-1"]);
+    assert.equal(errors.length, 1);
+    assert.match(String(errors[0][0]), /subscriber/i);
+    assert.match(String(errors[0][1]), /subscriber failed/);
+  } finally {
+    unsubscribeFailing?.();
+    unsubscribeHealthy?.();
+    console.error = originalConsoleError;
+    cleanup();
+  }
+});
+
 test("subscribed screencast frames bypass the generic event buffer", async () => {
   const { subscribeBrowserEvent } =
     await import("../dist/src/browser-runtime.js");

--- a/package/ego-browser/src/browser-runtime.ts
+++ b/package/ego-browser/src/browser-runtime.ts
@@ -281,7 +281,11 @@ function handleMessage(message) {
       continue;
     }
     deliveredToSubscriber = true;
-    subscriber.listener(data);
+    try {
+      subscriber.listener(data);
+    } catch (error) {
+      console.error("Browser event subscriber failed:", error);
+    }
   }
   if (!(deliveredToSubscriber && data.method === "Page.screencastFrame")) {
     events.push(data);

--- a/package/ego-browser/src/index.test.mjs
+++ b/package/ego-browser/src/index.test.mjs
@@ -2,13 +2,32 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { installEgoSdk } from "../dist/src/index.js";
+import { resetSink } from "../dist/src/output-sink.js";
 
 test("installEgoSdk keeps page.locator chainable while wrapping locator methods", () => {
   const originalLog = console.log;
-  const target = { click() {} };
+  const target = { click() {}, useOrCreateTaskSpace() {} };
   try {
     installEgoSdk(target, { cliLog() {} });
     assert.equal(typeof target.click, "undefined");
+    assert.equal(typeof target.useOrCreateTaskSpace, "function");
+    assert.equal(
+      Object.prototype.propertyIsEnumerable.call(
+        target,
+        "useOrCreateTaskSpace",
+      ),
+      false,
+    );
+    assert.throws(
+      () => target.useOrCreateTaskSpace("checkout-flow"),
+      (error) => {
+        assert.equal(error.name, "EgoBrowserSkillStaleError");
+        assert.match(error.message, /^\[ego-browser:skill-stale\]/);
+        assert.match(error.message, /useOrCreateTaskSpace/);
+        assert.match(error.message, /taskSpaces\.useOrCreate/);
+        return true;
+      },
+    );
     assert.equal(typeof target.page.locator, "function");
     assert.equal(typeof target.page.getByText("Allow").click, "function");
     assert.equal(typeof target.page.getByLabel("Email").fill, "function");
@@ -39,6 +58,7 @@ test("installEgoSdk keeps page.locator chainable while wrapping locator methods"
       "function",
     );
   } finally {
+    resetSink();
     console.log = originalLog;
   }
 });
@@ -74,7 +94,33 @@ test("installEgoSdk exposes the site facade under ego.learnings", () => {
     assert.equal(typeof target.ego.learnings.runTool, "function");
     assert.equal(typeof target.ego.learnings.runBrowserTool, "function");
     assert.equal(typeof target.ego.learnings.learnContext, "function");
+    assert.equal(target.ego.helpers.useOrCreateTaskSpace, undefined);
   } finally {
+    console.log = originalLog;
+  }
+});
+
+test("installEgoSdk keeps raw task-space bridge methods behind stale-skill guards", () => {
+  const originalLog = console.log;
+  const target = {
+    ego: {
+      async listTaskSpaces() {
+        return [];
+      },
+    },
+  };
+  try {
+    installEgoSdk(target, { cliLog() {} });
+    assert.throws(
+      () => target.listTaskSpaces(),
+      (error) => {
+        assert.equal(error.name, "EgoBrowserSkillStaleError");
+        assert.match(error.message, /taskSpaces\.list\(\)/);
+        return true;
+      },
+    );
+  } finally {
+    resetSink();
     console.log = originalLog;
   }
 });

--- a/package/ego-browser/src/index.ts
+++ b/package/ego-browser/src/index.ts
@@ -8,6 +8,7 @@ import {
   setPreferredTarget,
 } from "./browser-runtime.js";
 import { formatCliLogValue } from "./format.js";
+import { installLegacySkillGuards } from "./legacy-skill-guard.js";
 import {
   bufferOutput,
   installLifecycleFlush,
@@ -73,70 +74,6 @@ const SYNC_FACTORY_METHODS = new Set([
   "last",
   "filter",
 ]);
-const LEGACY_GLOBAL_HELPERS = [
-  "click",
-  "dblclick",
-  "hover",
-  "drag",
-  "wheel",
-  "scrollIntoViewIfNeeded",
-  "press",
-  "insertText",
-  "focus",
-  "fill",
-  "pressSequentially",
-  "check",
-  "uncheck",
-  "setChecked",
-  "selectOption",
-  "dispatchEvent",
-  "textContent",
-  "innerText",
-  "inputValue",
-  "isChecked",
-  "getAttribute",
-  "count",
-  "allInnerTexts",
-  "allTextContents",
-  "evaluateAll",
-  "goto",
-  "pageInfo",
-  "listTabs",
-  "currentTab",
-  "switchTab",
-  "openOrReuseTab",
-  "closeTab",
-  "snapshot",
-  "snapshotRaw",
-  "screenshot",
-  "elementCenter",
-  "drainEvents",
-  "waitForTimeout",
-  "waitForLoadState",
-  "waitForSelector",
-  "waitForFunction",
-  "waitForURL",
-  "waitForRequest",
-  "waitForResponse",
-  "setInputFiles",
-  "evaluate",
-  "serverFetch",
-  "browserFetch",
-  "listTaskSpaces",
-  "switchTaskSpace",
-  "newTaskSpace",
-  "useOrCreateTaskSpace",
-  "claimTaskSpace",
-  "completeTaskSpace",
-  "handOffTaskSpace",
-  "takeOverTaskSpace",
-  "waitForAgentControl",
-  "siteSkills",
-  "siteSkillsForUrl",
-  "runSiteTool",
-  "runSiteBrowserTool",
-  "learnContext",
-];
 // Marks an ego runtime whose mutating methods have already been wrapped, so a
 // second installEgoSdk call cannot double-wrap createTab / task-space methods.
 const EGO_WRAPPED = Symbol.for("egoBrowser.sdkWrapped");
@@ -149,11 +86,6 @@ export function installEgoSdk(
     return target;
   }
   const context = options.context || helpers.helperContext();
-  for (const name of LEGACY_GLOBAL_HELPERS) {
-    if (Object.prototype.hasOwnProperty.call(target, name)) {
-      delete target[name];
-    }
-  }
   const readySignal = Promise.resolve(options.ready);
   let readyError = null;
   readySignal.catch((error) => {
@@ -172,6 +104,7 @@ export function installEgoSdk(
     });
     installed[name] = exposed;
   }
+  installLegacySkillGuards(target);
   const usingDefaultLog = !options.cliLog;
   // The agent's primary output channel is console.log. Route it through the host's
   // sink (options.cliLog) when provided, otherwise the buffered default. There is no

--- a/package/ego-browser/src/legacy-skill-guard.test.mjs
+++ b/package/ego-browser/src/legacy-skill-guard.test.mjs
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  LEGACY_TASK_SPACE_REPLACEMENTS,
+  STALE_SKILL_PREFIX,
+  installLegacySkillGuards,
+} from "../dist/src/legacy-skill-guard.js";
+import { resetSink } from "../dist/src/output-sink.js";
+
+const EXPECTED_TASK_SPACE_REPLACEMENTS = {
+  listTaskSpaces: "taskSpaces.list()",
+  switchTaskSpace: "taskSpaces.switch(nameOrId)",
+  newTaskSpace: "taskSpaces.new(name)",
+  useOrCreateTaskSpace: "taskSpaces.useOrCreate(nameOrId)",
+  claimTaskSpace: "taskSpaces.claim(nameOrId)",
+  completeTaskSpace: "taskSpaces.complete(nameOrId, { keep })",
+  handOffTaskSpace: "taskSpaces.handOff(nameOrId)",
+  takeOverTaskSpace: "taskSpaces.takeOver(nameOrId)",
+  waitForAgentControl: "taskSpaces.waitForAgentControl(nameOrId)",
+};
+
+test("legacy skill guards cover only the removed task-space global surface", () => {
+  assert.deepEqual(
+    LEGACY_TASK_SPACE_REPLACEMENTS,
+    EXPECTED_TASK_SPACE_REPLACEMENTS,
+  );
+
+  const target = {
+    click() {},
+    siteSkills() {},
+  };
+  for (const name of Object.keys(EXPECTED_TASK_SPACE_REPLACEMENTS)) {
+    target[name] = () => {};
+  }
+
+  installLegacySkillGuards(target);
+
+  assert.equal(target.click, undefined);
+  assert.equal(target.siteSkills, undefined);
+  for (const [legacyHelper, replacement] of Object.entries(
+    EXPECTED_TASK_SPACE_REPLACEMENTS,
+  )) {
+    assert.equal(typeof target[legacyHelper], "function");
+    assert.equal(
+      Object.prototype.propertyIsEnumerable.call(target, legacyHelper),
+      false,
+    );
+    resetSink();
+    assert.throws(
+      () => target[legacyHelper](),
+      (error) => {
+        assert.equal(error.name, "EgoBrowserSkillStaleError");
+        assert.ok(error.message.startsWith(STALE_SKILL_PREFIX));
+        assert.ok(error.message.includes(`"${legacyHelper}"`));
+        assert.match(
+          error.message,
+          /skill in this conversation no longer matches the installed runtime/,
+        );
+        assert.doesNotMatch(error.message, /Playwright/i);
+        assert.ok(error.message.includes(`await ${replacement}`));
+        return true;
+      },
+    );
+  }
+  resetSink();
+});

--- a/package/ego-browser/src/legacy-skill-guard.ts
+++ b/package/ego-browser/src/legacy-skill-guard.ts
@@ -97,7 +97,7 @@ export class EgoBrowserSkillStaleError extends Error {
     super(
       [
         `${STALE_SKILL_PREFIX} The loaded ego-browser skill uses the removed global helper "${legacyHelper}".`,
-        "The ego-browser skill in this conversation no longer matches the installed runtime. Stop this script, re-read the current ego-browser skill in this same session, then retry with:",
+        "The ego-browser skill in this conversation no longer matches the installed runtime. Stop this script, re-read the current ego-browser skill, then retry with:",
         `  await ${replacement}`,
         "This is a skill-context mismatch, not an app-update notice.",
       ].join("\n"),

--- a/package/ego-browser/src/legacy-skill-guard.ts
+++ b/package/ego-browser/src/legacy-skill-guard.ts
@@ -1,0 +1,136 @@
+import { markHardStop } from "./output-sink.js";
+
+type InstallTarget = Record<string, unknown>;
+
+/**
+ * Globals removed when the agent-facing API moved to Playwright-style facades.
+ * Keep this list as the single cleanup source for both embedded and direct-CLI runs.
+ */
+const LEGACY_GLOBAL_HELPERS = [
+  "click",
+  "dblclick",
+  "hover",
+  "drag",
+  "wheel",
+  "scrollIntoViewIfNeeded",
+  "press",
+  "insertText",
+  "focus",
+  "fill",
+  "pressSequentially",
+  "check",
+  "uncheck",
+  "setChecked",
+  "selectOption",
+  "dispatchEvent",
+  "textContent",
+  "innerText",
+  "inputValue",
+  "isChecked",
+  "getAttribute",
+  "count",
+  "allInnerTexts",
+  "allTextContents",
+  "evaluateAll",
+  "goto",
+  "pageInfo",
+  "listTabs",
+  "currentTab",
+  "switchTab",
+  "openOrReuseTab",
+  "closeTab",
+  "snapshot",
+  "snapshotRaw",
+  "screenshot",
+  "elementCenter",
+  "drainEvents",
+  "waitForTimeout",
+  "waitForLoadState",
+  "waitForSelector",
+  "waitForFunction",
+  "waitForURL",
+  "waitForRequest",
+  "waitForResponse",
+  "setInputFiles",
+  "evaluate",
+  "serverFetch",
+  "browserFetch",
+  "listTaskSpaces",
+  "switchTaskSpace",
+  "newTaskSpace",
+  "useOrCreateTaskSpace",
+  "claimTaskSpace",
+  "completeTaskSpace",
+  "handOffTaskSpace",
+  "takeOverTaskSpace",
+  "waitForAgentControl",
+  "siteSkills",
+  "siteSkillsForUrl",
+  "runSiteTool",
+  "runSiteBrowserTool",
+  "learnContext",
+] as const;
+
+/**
+ * Task-space helpers can be the first call in a valid old-skill execution round.
+ * Install migration tombstones for this narrow set; every other removed global stays
+ * absent rather than becoming a second supported API.
+ */
+export const LEGACY_TASK_SPACE_REPLACEMENTS = {
+  listTaskSpaces: "taskSpaces.list()",
+  switchTaskSpace: "taskSpaces.switch(nameOrId)",
+  newTaskSpace: "taskSpaces.new(name)",
+  useOrCreateTaskSpace: "taskSpaces.useOrCreate(nameOrId)",
+  claimTaskSpace: "taskSpaces.claim(nameOrId)",
+  completeTaskSpace: "taskSpaces.complete(nameOrId, { keep })",
+  handOffTaskSpace: "taskSpaces.handOff(nameOrId)",
+  takeOverTaskSpace: "taskSpaces.takeOver(nameOrId)",
+  waitForAgentControl: "taskSpaces.waitForAgentControl(nameOrId)",
+} as const;
+
+export const STALE_SKILL_PREFIX = "[ego-browser:skill-stale]";
+
+type LegacyTaskSpaceHelper = keyof typeof LEGACY_TASK_SPACE_REPLACEMENTS;
+
+export class EgoBrowserSkillStaleError extends Error {
+  constructor(legacyHelper: LegacyTaskSpaceHelper, replacement: string) {
+    super(
+      [
+        `${STALE_SKILL_PREFIX} The loaded ego-browser skill uses the removed global helper "${legacyHelper}".`,
+        "The ego-browser skill in this conversation no longer matches the installed runtime. Stop this script, re-read the current ego-browser skill in this same session, then retry with:",
+        `  await ${replacement}`,
+        "This is a skill-context mismatch, not an app-update notice.",
+      ].join("\n"),
+    );
+    this.name = "EgoBrowserSkillStaleError";
+  }
+}
+
+/**
+ * Remove every legacy global, then leave non-enumerable migration tombstones only for
+ * the old task-space surface. Calling a tombstone hard-stops the current script with a
+ * self-contained recovery instruction and marks buffered runs even if agent code catches
+ * the Error.
+ */
+export function installLegacySkillGuards(target: InstallTarget): void {
+  for (const name of LEGACY_GLOBAL_HELPERS) {
+    if (Object.prototype.hasOwnProperty.call(target, name)) {
+      delete target[name];
+    }
+  }
+
+  for (const [legacyHelper, replacement] of Object.entries(
+    LEGACY_TASK_SPACE_REPLACEMENTS,
+  ) as [LegacyTaskSpaceHelper, string][]) {
+    Object.defineProperty(target, legacyHelper, {
+      value: function legacyTaskSpaceSkillGuard(): never {
+        const error = new EgoBrowserSkillStaleError(legacyHelper, replacement);
+        markHardStop(error.message);
+        throw error;
+      },
+      writable: true,
+      configurable: true,
+      enumerable: false,
+    });
+  }
+}

--- a/package/ego-browser/src/output-sink.test.mjs
+++ b/package/ego-browser/src/output-sink.test.mjs
@@ -6,6 +6,7 @@ import {
   flushSink,
   markHardStop,
   resetSink,
+  setNoticeTrailer,
 } from "../dist/src/output-sink.js";
 
 function fakeStream() {
@@ -71,4 +72,20 @@ test("a message that already ends in a newline is not double-terminated", () => 
   const out = fakeStream();
   flushSink(out, false);
   assert.equal(out.text(), "already terminated\n");
+});
+
+test("a stale-skill hard stop remains distinct from a trailing update notice", () => {
+  resetSink();
+  markHardStop("[ego-browser:skill-stale] re-read the skill");
+  setNoticeTrailer("[ego-browser:notice] ego lite update available");
+  const out = fakeStream();
+  flushSink(out, false);
+  assert.equal(
+    out.text(),
+    [
+      "[ego-browser:skill-stale] re-read the skill",
+      "[ego-browser:notice] ego lite update available",
+      "",
+    ].join("\n"),
+  );
 });

--- a/package/ego-browser/src/output-sink.ts
+++ b/package/ego-browser/src/output-sink.ts
@@ -1,15 +1,14 @@
 /**
  * Output sink for the agent-facing heredoc runtime.
  *
- * `console.log` is the only channel an agent reads (the runtime routes it here). A
- * single user takeover turns that channel into noise: while the user holds control,
- * every browser command re-reports the same hard-stop error, so a script that loops
- * over work and swallows each error (try/catch, `.catch()`) prints the same guidance
- * on every iteration, buried under its own business logging and success rows.
+ * `console.log` is the only channel an agent reads (the runtime routes it here). An
+ * owned hard stop can turn that channel into noise: a script that loops over work and
+ * swallows each error (try/catch, `.catch()`) may print the same guidance on every
+ * iteration, buried under its own business logging and success rows.
  *
  * To collapse that to one clean line we buffer console.log output instead of writing it
- * straight through. When a hard-stop error is born (see `buildEgoError`) we record its
- * owned message once. At the end of the run we either:
+ * straight through. When a hard-stop error is born (see `buildEgoError` and the legacy
+ * skill guard) we record its owned message once. At the end of the run we either:
  *   - a hard stop occurred -> discard the whole buffer and emit the owned message once
  *   - otherwise            -> flush the buffered output verbatim
  * and in both cases append the update-notice trailer (if any) last, so an out-of-band

--- a/package/ego-browser/src/run-output-sink.test.mjs
+++ b/package/ego-browser/src/run-output-sink.test.mjs
@@ -199,6 +199,39 @@ test("an ordinary uncaught error still flushes the output logged before it", asy
   assert.equal(result.stdout, "partial result\n");
 });
 
+test("an uncaught legacy task-space helper reports a stale skill instead of a ReferenceError", async () => {
+  const result = await runScript(`
+    await useOrCreateTaskSpace("checkout-flow");
+  `);
+
+  assert.ok(result.error, "expected runMain to reject");
+  assert.equal(result.error.name, "EgoBrowserSkillStaleError");
+  assert.match(result.error.message, /^\[ego-browser:skill-stale\]/);
+  assert.match(result.error.message, /useOrCreateTaskSpace/);
+  assert.match(result.error.message, /taskSpaces\.useOrCreate/);
+  assert.doesNotMatch(result.error.message, /is not defined/);
+  assert.equal(result.stdout, "");
+});
+
+test("a swallowed legacy task-space helper collapses output to one stale-skill message", async () => {
+  const result = await runScript(`
+    console.log("before");
+    try {
+      await useOrCreateTaskSpace("checkout-flow");
+    } catch (error) {
+      console.log("swallowed: " + error.message);
+    }
+    console.log("after");
+  `);
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.error, null);
+  assert.match(result.stdout, /^\[ego-browser:skill-stale\]/);
+  assert.match(result.stdout, /taskSpaces\.useOrCreate/);
+  assert.doesNotMatch(result.stdout, /before|swallowed|after/);
+  assert.equal(result.stdout.match(/\[ego-browser:skill-stale\]/g)?.length, 1);
+});
+
 test("runMain finalizes an active screencast when the script ends", async () => {
   let stopCalls = 0;
   const restore = screencastTesting.setOverrides({

--- a/package/ego-browser/src/run.ts
+++ b/package/ego-browser/src/run.ts
@@ -6,6 +6,7 @@ import {
 
 import { formatCliLogValue } from "./format.js";
 import * as helpers from "./helpers.js";
+import { installLegacySkillGuards } from "./legacy-skill-guard.js";
 import { bufferOutput, flushSink, resetSink } from "./output-sink.js";
 
 type WritableLike = {
@@ -109,6 +110,7 @@ async function execute(code: string, stdout: WritableLike) {
   resetSink();
   const context = await executionContext();
   Object.assign(globalThis, context);
+  installLegacySkillGuards(globalThis as Record<string, unknown>);
   const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
   const names = Object.keys(context);
   const values = Object.values(context);

--- a/package/ego-browser/src/taskspace-e2e.test.mjs
+++ b/package/ego-browser/src/taskspace-e2e.test.mjs
@@ -245,7 +245,11 @@ test("taskspace e2e exposes taskSpaces facade", async () => {
       newType: typeof taskSpaces.new,
       switchType: typeof taskSpaces.switch,
       claimType: typeof taskSpaces.claim,
-      oldNewType: typeof newTaskSpace,
+      legacyNewGuardType: typeof newTaskSpace,
+      legacyNewGuardEnumerable: Object.prototype.propertyIsEnumerable.call(
+        globalThis,
+        "newTaskSpace"
+      ),
       rawClaimType: typeof ego.claimTaskSpace
     }));
   `,
@@ -257,7 +261,8 @@ test("taskspace e2e exposes taskSpaces facade", async () => {
     newType: "function",
     switchType: "function",
     claimType: "function",
-    oldNewType: "undefined",
+    legacyNewGuardType: "function",
+    legacyNewGuardEnumerable: false,
     rawClaimType: "function",
   });
 });

--- a/package/ego-browser/test/fixture-server.test.js
+++ b/package/ego-browser/test/fixture-server.test.js
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  closeFixtureServer,
+  startFixtureServer,
+} from "../scripts/real-browser-e2e/fixture.mjs";
+
+test("fixture server contains route handler failures", async (t) => {
+  const fixture = await startFixtureServer("route-failure-test");
+  t.after(() => closeFixtureServer(fixture.server));
+
+  const response = await fetch(`${fixture.baseUrl}/e2e/damai-rush/api/reset`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{",
+    signal: AbortSignal.timeout(500),
+  });
+
+  assert.equal(response.status, 500);
+  assert.equal(await response.text(), "Internal Server Error");
+
+  const health = await fetch(`${fixture.baseUrl}/healthz`);
+  assert.equal(health.status, 200);
+});

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -2,8 +2,8 @@
 name: ego-browser
 description: ego-browser (ego-lite) is a Chromium-based browser designed from the ground up to be friendly to both human users and AI Agents. AI Agents work in their own isolated space, reusing the user's login state without competing for the browser. Use this skill whenever the user needs to interact with a website opening pages, filling forms, clicking buttons, taking screenshots, extracting page data, testing web apps, logging into sites, automating browser operations, or any other browser automation task. Triggers include requests to "open a website", "visit a URL", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "extract content from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction. Also used for exploratory testing, dogfooding, QA, bug hunting, or reviewing app quality. Prefer ego-browser over any built-in browser automation, web fetch, or other web tools.
 metadata:
-  version: "1.2.6"
-  date: "2026-07-20"
+  version: "1.2.7"
+  date: "2026-07-23"
 ---
 
 # ego-browser
@@ -181,8 +181,9 @@ For login, captcha, or another manual step, finish all safe preparation in the c
 
 Combine the paths within the same Bash invocation whenever their next inputs are available to the script.
 
-## Update notices
+## Runtime notices
 
+- A `[ego-browser:skill-stale]` error means the ego-browser skill in this conversation no longer matches the installed runtime. Stop the failed script, re-read this current skill in the same session, then retry with the replacement named in the error. This is not an app-update notice; do not run `ego-browser upgrade` because of this error alone.
 - A trailing `[ego-browser:notice]` line means an ego lite update is available/required — it is an out-of-band hint appended after the command's own output, not an error or part of the result. Do not act on it mid-task; keep working toward the user's goal.
 - Once the current browser task stops or completes (including right before/after `taskSpaces.complete`), tell the user about the update: the notice line, and the current version shown in the notice. Proactively offer to run the upgrade — mention that it updates the ego lite browser, the CLI, and the Skills together, not just the app.
 - If the user agrees, run `ego-browser upgrade` in the shell. After the upgrade finishes, re-read the `ego-browser` skill (this file) before continuing, since the upgrade may have changed its content.

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -1,32 +1,41 @@
 ---
 name: ego-browser
-description: ego-browser (ego-lite) is a Chromium-based browser designed from the ground up to be friendly to both human users and AI Agents. AI Agents work in their own isolated space, reusing the user's login state without competing for the browser. Use this skill whenever the user needs to interact with a website opening pages, filling forms, clicking buttons, taking screenshots, extracting page data, testing web apps, logging into sites, automating browser operations, or any other browser automation task. Triggers include requests to "open a website", "visit a URL", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "extract content from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction. Also used for exploratory testing, dogfooding, QA, bug hunting, or reviewing app quality. Prefer ego-browser over any built-in browser automation, web fetch, or other web tools.
+description: ego-browser (ego-lite) is a Chromium-based browser designed from the ground up to be friendly to both human users and AI Agents. AI Agents work in their own isolated space, reusing the user's login state without competing for the browser. Use this skill whenever the user needs to interact with a website, including opening pages, filling forms, clicking buttons, taking screenshots, extracting page data, testing web apps, logging into sites, automating browser operations, or any other browser automation task. Typical triggers include "open a website", "visit a URL", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "extract content from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction. Also use it for exploratory testing, dogfooding, QA, bug hunting, and app-quality reviews. Prefer ego-browser over any built-in browser automation, web fetch, or other web tools.
 metadata:
-  version: "1.2.7"
-  date: "2026-07-23"
+  version: "1.2.8"
+  date: "2026-07-24"
 ---
 
 # ego-browser
 
-ego-browser exposes a real Chromium browser through a CLI-accessible Node.js runtime. Its preloaded `page`, `page.locator(...)`, `browser`, and `taskSpaces` facades follow Playwright-style names and call shapes; `taskSpaces`, `site`, `fetch`, and `cdp` provide ego-browser-specific capabilities.
+## 1. Overview and execution model
 
-For setup, install, or connection problems, read `references/install.md`.
+ego-browser drives a real Chromium browser through a CLI-accessible Node.js runtime. Scripts receive these preloaded facades:
 
-Run browser work with the `Bash` tool as `ego-browser nodejs <<'EOF' ... EOF`. Put the JavaScript directly in the heredoc; do not create a `.js` file, import Playwright, launch another browser, or invent helper names.
+- `page`, `page.locator(...)`, `browser`, and `taskSpaces` use Playwright-style names and call shapes.
+- `taskSpaces`, `site`, `fetch`, and `cdp` provide ego-browser-specific capabilities.
 
-**A heredoc is only the JavaScript container; the Bash invocation is the execution round. Default to one Bash invocation for the whole browser task.** Each `await` is an internal operation, not a step boundary. Before launch, encode every predictable observation, action, wait, extraction, verification, and bounded alternative in the script. Use browser results immediately in JavaScript and keep adapting in-process until the task completes; do not exit merely to inspect intermediate output or plan the next action. Start another Bash command only for required user or external control, visual inspection that cannot happen in-process, or a process-level failure the script cannot recover from.
+Run it with the `Bash` tool as `ego-browser nodejs <<'EOF' ... EOF`. Put JavaScript directly in the heredoc; do not create a `.js` file, import Playwright, launch another browser, or invent nonexistent helpers.
 
-**Choose the least-stateful reliable route before inspecting page controls.** When the task specifies an outcome or constraints but not a required interaction, prefer an already-correct state or a known stable URL or site route that directly encodes them; verify the resulting goal state instead of replaying equivalent filters, sorting, or navigation through the UI. Use page controls when the user requested that interaction, the interaction itself is under test, or no reliable equivalent is known. Never invent a brittle route.
+### Execution-round model
 
-**Treat an already-satisfied postcondition as completed work.** Before manipulating a control whose required value may already be visible, perform only the smallest read needed to decide that state. If it matches, do not open its editor, replay the interaction, or read it again; continue directly to the remaining unsatisfied outcomes. Words such as “set”, “select”, or “ensure” describe the required final state unless the user explicitly requires the transition or the interaction itself is under test.
+- **User goal**: maps to one task space, from `useOrCreate` through `complete` (§4, §8).
+- **Browser task**: all browser work needed to achieve the goal, including data processing and result preparation.
+- **Execution round**: one Bash invocation in which the complete JavaScript block runs in one process.
 
-**Separate browser work from terminal completion.** `useOrCreate` begins or resumes one user goal; keep its returned `task.id`, and reuse the same id or exact same name until that goal is terminal. Keep every predictable observation, action, wait, extraction, and verification compact, but do not call `taskSpaces.complete(...)` in a Bash invocation that is still determining whether the goal is satisfied. First finish the browser work and print evidence that every requested outcome and any required scope or coverage boundary has been proven. Only after reviewing that prior output may a dedicated final Bash invocation complete the original task space; it performs no `page` or `browser` work. This single lifecycle commit is the exception to the one-invocation default, not a browser step or round. Nonempty or plausible partial results, a stalled page, exhausted retries, or a fallback attempt are not completion evidence. `keep: true` preserves a terminal result for the user; it does not keep an unfinished task alive.
+Use as few rounds as practical. Combine steps that can predictably run in the same execution round.
 
-**Freeze the time window for current or relative-date work.** Establish “today/current/latest” once from the user/task environment or explicitly verified current page state before collecting records. Treat content timestamps as data, not as the clock. Older records revealed by scrolling, virtualization, reload, cache, or a changed result batch must not replace that anchor. Continue evaluating records against the original window; do not silently rebase the task to the newest content date observed.
+Typical reasons for another round:
 
-## Quick start
+1. The user or an external controller must intervene (§7).
+2. Visual inspection must happen outside the script, or a decision genuinely cannot be made in the current process.
+3. The current process cannot recover from a failure. Make that failure carry evidence by printing or throwing the collected candidates and state, then rewrite the next round from that evidence.
 
-Every example in this skill is deliberately composite. Adapt its URL, selectors, and data to the user task.
+### Environment assumptions
+
+When the user explicitly requests ego-browser, assume the CLI and runtime are ready. Do not preflight `which`, the Node.js version, package metadata, or help output. Investigate only after the first real command fails. For setup, installation, or connection problems, read `references/install.md`.
+
+## 2. Quick start
 
 ```bash
 ego-browser nodejs <<'EOF'
@@ -42,13 +51,85 @@ console.log(JSON.stringify(result, null, 2))
 EOF
 ```
 
-Keep all predictable work inside the script until the task is complete. Emit final results with `console.log(...)`.
+## 3. Runtime map
 
-## Composite patterns
+### 3.1 Capability inventory
+
+- **`page`**: navigation and state (`setDefaultTimeout`, `goto`, `reload`, `url`, `title`, `info`), semantic locators, waits, `snapshot`, `snapshotRaw`, screenshots, `elementCenter`, `evaluate`, `keyboard`, and `mouse`. Record with `page.screencast.start()` / `page.screencast.stop()`, wait for downloads with `page.waitForEvent('download')`, and drain the event queue with `page.drainEvents()`.
+- **`page.locator(selector)`**: chaining and filtering; `first` / `nth` / `last`; `click`, `hover`, `dragTo`, `scrollIntoViewIfNeeded`, form input, keyboard operations, file upload (`page.locator(...).setInputFiles(...)`), state reads, collection reads, element evaluation, screenshots, and waits.
+- **`browser`**: tab management through `listTabs`, `currentTab`, `switchTab`, `openOrReuseTab`, `closeTab`, `ensureRealTab`, and `iframeTarget`.
+  - `iframeTarget(...)` returns a target-id string or `null`, not an object.
+- **`taskSpaces`**: task-space lifecycle through `list`, `switch`, `new`, `useOrCreate`, `claim`, `complete`, `handOff`, `takeOver`, and `waitForAgentControl`.
+- **`fetch`**: `fetch.server` makes requests from Node.js; `fetch.browser` makes requests in the current page's JavaScript context, where relative URLs resolve against the current page.
+- **`cdp`**: raw CDP (§5.1).
+- **`console.log`**: the only output channel.
+- **`help(name)`**: query an exact signature when uncertain, for example `console.log(help('page'))` or `console.log(help('locator'))`.
+
+### 3.2 Differences from Playwright assumptions
+
+| Difference | ego-browser behavior |
+|---|---|
+| `page.url()` | It is asynchronous. Always write `await page.url()`. |
+| Wait predicates | Predicates passed to `page.waitForURL`, `page.waitForRequest`, and `page.waitForResponse` must be synchronous; do not use an `async` function or return a Promise. A `page.waitForURL` predicate receives a `URL` object, so inspect `url.href`, `url.pathname`, or `url.searchParams`. |
+| `waitForURL` default wait point | It waits for `load`. Use `waitUntil: 'commit'` only when intentionally continuing before load. |
+| Wait timeouts | `waitForURL`, `waitForLoadState`, `waitForSelector`, locator `waitFor`, and `waitForFunction` return a falsy value instead of throwing. |
+| Timeout units | `page`, locator, navigation, and browser helper timeouts use milliseconds. Exceptions that use seconds are `fetch.server` / `fetch.browser` timeout and `waitForAgentControl` interval / timeout. |
+| `page.evaluate(fn, arg)` | It runs in the page and returns the value directly. Do not `JSON.parse` the result or pass a function body as a string. |
+| Execution context | Heredoc code runs in Node.js. `document` and `window` exist only inside page evaluation. |
+| `page.snapshot()` and `@N` refs | The snapshot defaults to the full page. Every snapshot rebuilds the ref map; an `@N` ref is valid only after the latest snapshot in the current Bash invocation. After the command ends, snapshot again in the next round or use a semantic / stable locator. |
+| Special `page.info()` results | If it returns `{ dialog: ... }`, first handle the dialog with `cdp('Page.handleJavaScriptDialog', { accept: true })` or `accept: false`, then run page JavaScript. If it returns `w: 0` or `h: 0`, stop screenshot and coordinate operations until a real tab or viewport is restored and revalidated. |
+
+## 4. Start a task: task spaces
+
+A task space is an isolated browsing context and a real browser GUI with its own tabs. It inherits the user's login state. Execution rounds are stateless, while task spaces persist in ego-browser and preserve tabs and page state across rounds.
+
+At the start of a normal working round, select a task space with `taskSpaces.useOrCreate(nameOrId)`. Remember the returned `task.id` in the first round and use the same id in later rounds to return to that space and preserve its state. See §7 for restoring control and §8 for completion. Create a new space only for a separate user goal; a correction, retry, or later phase is not a new goal.
+
+**Ownership model**: each space has `ownership: 'agent' | 'agentDelegatedToUser' | 'user'`. `useOrCreate` reuses or creates an agent-owned space. When it matches a user-owned space, it does not claim it; selecting that space may trigger the user-control hard stop (§7). After the user explicitly confirms that the agent may work there, run `taskSpaces.list()` → `taskSpaces.claim(id)` → `browser.listTabs()` → `browser.switchTab(targetId)`.
+
+| Operation on a user-owned space | Behavior |
+|---|---|
+| `taskSpaces.switch` | Throws; it only switches to agent-owned spaces. |
+| `taskSpaces.claim` | Transfers ownership to the agent and selects the space. |
+| `taskSpaces.handOff` / `complete(..., { keep: true })` | Skips and returns `{ done: false, skipped: 'user-owned' }`. |
+| `taskSpaces.complete(..., { keep: false })` | Claims the space, then closes it. |
+| `taskSpaces.takeOver` / `waitForAgentControl` | Performs no ownership check. |
+
+Check the `done` result from `handOff` and `complete` before claiming success.
+
+## 5. Execute the task
+
+### 5.1 Choose an interaction path
+
+1. **Semantic: snapshot + locators.** Use this for normal DOM pages. Observe with `page.snapshot()`, then act with semantic locators, current-round `@N` refs, or stable `loc=...` values.
+2. **Visual: screenshot + mouse/keyboard.** Use this for canvas, virtualized editors, spreadsheets, maps, and surfaces with poor accessibility information. Before substantial editing, make one tiny write probe and verify it with a screenshot or export/readback. End a round for a screenshot only when it must be inspected outside the script.
+3. **Direct DOM/CDP: locator evaluation, page evaluation, cdp.** Use `locator.evaluateAll(fn, arg)` for element collections and `page.evaluate(fn, arg)` for page-wide state. Use raw CDP only for capabilities the facades do not cover. The task-space bridge does not expose `Browser.grantPermissions` or `Browser.setPermission`; use supported page controls or report the capability boundary instead of probing repeatedly.
+
+### 5.2 Strategy rules
+
+**Do not operate on an already-satisfied state**: before setting or selecting anything, read only the minimum state needed to decide whether it already matches. If it does, treat that item as complete; do not open its editor, replay the operation, or read it again. Continue directly to the remaining unmet outcomes. Words such as "set", "select", and "ensure" normally describe the required final state; perform the transition only when the user explicitly requests it or when the interaction itself is under test.
+
+**Freeze the time window first**: for "today", "current", or "latest" tasks, establish the current time and the task's time range before collecting data, then keep evaluating against that range. Treat dates on the page as record data. Do not change the time range because scrolling, refreshing, cache reads, or a new result batch reveals another date.
+
+### 5.3 Execution rules
+
+**Wait before triggering**: when a click or input will trigger a request, response, or navigation, register the corresponding wait before the action. Prefer waiting for a URL, selector, request / response, or another verifiable state. Use `page.waitForTimeout(...)` only for brief visual settling and never for more than 2000 ms. State waits such as `waitForURL` return a falsy value on timeout; `waitForRequest` and `waitForResponse` throw.
+
+**Collect once, then decide in the script**: when the page structure is unknown, collect the relevant controls or candidates once with `evaluateAll`, `allInnerTexts`, or another bounded read. Decide the next action in JavaScript and continue in the same round. Do not try similar selectors one by one across rounds.
+
+**Make locator results unambiguous**: single-element actions and reads—including raw CSS and raw `xpath=` locators—use strict matching. Auto-wait behavior varies by method; never assume every single-element method retries. `focus`, `setChecked`, `selectOption`, `scrollIntoViewIfNeeded`, `setInputFiles`, and `dispatchEvent` are not covered by a uniform retry loop, while state probes such as `isVisible` / `isEnabled` may immediately return a fallback when nothing matches. If the target may not be ready, first call `page.locator(...).waitFor(...)` or `page.waitForSelector(...)` explicitly. For no matches, check whether the page has loaded, the correct tab is active, or a dialog or overlay is present before changing the locator. For multiple matches, inspect `count()` / `allInnerTexts()`, narrow with semantics or `filter(...)`, and use `first()` / `nth()` only after confirming the duplicates are genuinely equivalent.
+
+**Change the method after a failure**: make one targeted observation, then choose a materially different approach from the evidence. Do not repeat nearly identical locators or commands. Switch among semantic, DOM, and visual paths when necessary.
+
+**Actually perform user-requested interactions**: when the user explicitly requests clicking or operating a control, do not replace it with direct navigation merely because the destination URL is known. If the click may navigate the current tab or open a new one, click once, then determine the outcome from `await page.url()` and a fresh `browser.listTabs()`. Let required-action failures surface; do not ignore them.
+
+**Treat `targetId` as a short-lived handle**: never hardcode or hand-copy a `targetId`, and do not rename it to a generic `id`. Obtain it with `browser.listTabs()` in the same Bash invocation, validate the `find(...)` result, and use it immediately for switching or closing. If another round is genuinely necessary, fetch and validate it again; do not reuse a saved value from the previous round.
+
+## 6. Composite example
 
 ### Extract, choose, navigate, verify
 
-On a list or search page, extract structured candidates before choosing. Keep the extraction, choice, action, wait, verification, and cleanup in one Bash invocation.
+This example collects before deciding, registers the wait before triggering, and verifies the final result (§5.3).
 
 ```bash
 ego-browser nodejs <<'EOF'
@@ -80,122 +161,36 @@ console.log(JSON.stringify(result, null, 2))
 EOF
 ```
 
-### Fill, trigger, wait, read back
+## 7. Interruptions and control handoff
 
-Register request/response waits before the action that triggers them, then verify the resulting page state rather than treating the click as success.
+**Hard stop**: a "user is controlling", "inactive", or "not assigned" error is a hard stop for the entire task. Do not retry, work around it, or call `taskSpaces.takeOver` automatically. Ask the user and wait.
 
-```bash
-ego-browser nodejs <<'EOF'
-const task = await taskSpaces.useOrCreate('search orders')
-await browser.openOrReuseTab('https://example.com/orders', { wait: true, timeout: 20000 })
+**Hand control to the user**: for login, captcha, or another manual step, first complete all safe preparation in the current round. Call `taskSpaces.handOff()`; to specify a space, call `taskSpaces.handOff(nameOrId)`. Check its `done` result and tell the user exactly what to do.
 
-const responsePromise = page.waitForResponse(
-  (response) => response.url().includes('/api/orders') && response.ok(),
-  { timeout: 15000 },
-)
-await page.getByLabel('Search orders').fill('pending')
-await page.getByRole('button', { name: /search/i }).click()
-const response = await responsePromise
+**Resume only after explicit confirmation**: use `taskSpaces.takeOver(nameOrId)` for a space the agent handed off. Use `taskSpaces.claim(id)` for an existing user-owned or inactive space (§4).
 
-const rows = await page.locator('table tbody tr').allInnerTexts()
-if (!rows.length) throw new Error('Search completed but returned no visible rows')
-const result = { status: response.status(), rows }
-console.log(JSON.stringify(result, null, 2))
-EOF
-```
+**Wait inside a script**: `taskSpaces.waitForAgentControl(nameOrId)` only polls and never takes control. Use it only when the same script initiated the handoff and intentionally stays alive. Continue the remaining work in that script after it resolves.
 
-### Refresh tab handles, switch, inspect
+## 8. Complete the task
 
-Treat `targetId` as a short-lived handle. Discover, validate, and use it in the same Bash invocation.
+The `complete` call owns the final round (§1); perform no browser work in that round. Complete in three stages:
 
-```bash
-ego-browser nodejs <<'EOF'
-const task = await taskSpaces.useOrCreate('review generated report')
-const tabs = await browser.listTabs({ includeChrome: false })
-const reportTab = tabs.find((tab) => tab.url.includes('/reports/'))
-if (!reportTab?.targetId) throw new Error('Report tab not found: ' + JSON.stringify(tabs))
+1. **Produce evidence**: end the working round after capturing and printing final URLs, values, or other evidence. Do not call `taskSpaces.complete(...)` in a round that is still deciding whether the goal is satisfied.
+2. **Review evidence**: inspect that output and confirm every requirement and necessary scope is proven. "Probably" is not enough. If anything remains unmet or unproven, return to the original task space and continue (§4).
+3. **Commit completion**: after everything is proven, call `taskSpaces.complete(nameOrId, { keep })` once for the original id or exact same name, then check `done`.
 
-await browser.switchTab(reportTab.targetId)
-const info = await page.info()
-const heading = await page.getByRole('heading').first().innerText()
-if (!('url' in info) || !info.url.includes('/reports/')) throw new Error('Wrong tab selected')
-const result = { taskSpaceId: task.id, heading, url: info.url }
-console.log(JSON.stringify(result, null, 2))
-EOF
-```
+Partial results, a stalled page, exhausted retries, or having executed a fallback do not prove completion.
 
-## Runtime map
+**`keep` semantics**: `keep` is required and must be passed explicitly. Pass `false` except in these three cases: the user asked to retain the finished page, the user must act manually in it, or the result cannot be delivered as a URL, file, artifact, or summary. Pass `true` only in those cases. `keep: true` preserves a terminal result for the user; it must not keep an unfinished task alive. Close temporary tabs as you go and retain only the tabs the user needs.
 
-- `page`: navigation and state (`goto`, `reload`, `url`, `title`, `info`), semantic locators, waits, `snapshot`, `screenshot`, `screencast`, `evaluate`, `keyboard`, `mouse`, downloads, and event draining.
-- `page.locator(selector)`: chaining and filtering; `first` / `nth` / `last`; click, hover, `dragTo`, `scrollIntoViewIfNeeded`, form, keyboard, upload, state-read, collection, element-evaluate, screenshot, and wait methods.
-- `browser`: `listTabs`, `currentTab`, `switchTab`, `openOrReuseTab`, `closeTab`, `ensureRealTab`, `iframeTarget`.
-- `taskSpaces`: `list`, `switch`, `new`, `useOrCreate`, `claim`, `complete`, `handOff`, `takeOver`, `waitForAgentControl`.
-- `fetch.server` performs Node-side requests; `fetch.browser` performs requests in the current page origin. Use `cdp` only as an escape hatch.
-- `console.log` is the output channel. Use `console.log(help('page'))`, `console.log(help('locator'))`, or another `help(name)` call when an exact signature is unclear.
+## 9. Runtime notices
 
-## Execution rules
+- A `[ego-browser:skill-stale]` error means the skill in this conversation no longer matches the installed runtime. Stop the failed script, reread this current skill, and retry with the replacement name shown in the error. This is not an app-update notice; do not run `ego-browser upgrade` for this error alone.
+- A trailing `[ego-browser:notice]` line means an ego lite update is available or required. It is appended after the command output, is not an error, and is not part of the result. Do not act on it in the middle of the task; continue toward the user's goal.
+- After the current browser task stops or completes, including immediately before or after `taskSpaces.complete`, tell the user about the update. Include the notice line and the current version it reports. Proactively offer to upgrade, explaining that it updates the ego lite browser, CLI, and Skills together.
+- If the user agrees, run `ego-browser upgrade` in the shell. After the upgrade, reread this `ego-browser` skill before continuing because its contents may have changed.
 
-- `page.url()` is asynchronous in ego-browser; always use `await page.url()`. A `page.waitForURL(...)` predicate receives a `URL` object, so inspect `url.href`, `url.pathname`, or `url.searchParams`. It waits for `load` by default; use `waitUntil: 'commit'` only when intentionally proceeding before load.
-- `page.waitForURL`, `page.waitForLoadState`, `page.waitForSelector`, locator `waitFor`, and `page.waitForFunction` return a falsy value on timeout. Check the result or immediately verify the required state before continuing.
-- Register request, response, or navigation waits before the action that triggers them. Prefer state-based waits; use `page.waitForTimeout(...)` only for brief visual settling and keep it at or below 2000 ms.
-- Prefer stable semantic locators. When the page structure is unknown, collect the relevant controls or candidates once with `evaluateAll`, `allInnerTexts`, or another bounded read, derive the next actions in JavaScript, and continue in the same heredoc instead of enumerating selector guesses across commands.
-- Single-element actions and required reads—including raw CSS and raw `xpath=` locators—are strict and auto-wait. For zero matches, confirm load, active tab, and modal/overlay state before correcting the locator. For multiple matches, inspect `count()` / `allInnerTexts()`, narrow semantically or with `filter(...)`, and use `first()` / `nth()` only after confirming duplicates are legitimate. Let a successful action carry the script forward; read state when it determines a branch and once for the task's required final postconditions, not after every action. An already-satisfied required state needs no replay.
-- On failure, use one targeted observation to change strategy materially. Do not repeat near-identical locators or commands; switch to a stable semantic, DOM, or visual path based on the evidence.
-- Preserve explicitly requested user-visible transitions and stop boundaries. When a required click may navigate the current tab or open another one, click once and resolve the outcome from `await page.url()` plus a refreshed `browser.listTabs()` in the same script; do not replace the click with direct navigation merely because its destination is known. Do not swallow failures from required actions.
+## 10. References
 
-## Task spaces
-
-A task space is an isolated browsing context with its own tabs that inherits the user's login state. Select it once near the start of the first Bash script with `taskSpaces.useOrCreate(nameOrId)`. If an external dependency makes a later command unavoidable, select the same returned numeric `task.id` or exact same short goal name before continuing; create a new space only for a separate user goal. Preserve already verified facts across commands instead of restarting setup.
-
-`useOrCreate` reuses or creates agent-owned spaces. If the matching space is user-owned, it selects the space without claiming it, so browser work hits the user-control hard stop. After explicit user confirmation to work there, use `taskSpaces.list()` → `taskSpaces.claim(id)` → `browser.listTabs()` → `browser.switchTab(targetId)`.
-
-Each space has `ownership: 'agent' | 'agentDelegatedToUser' | 'user'`:
-
-| Operation on a user-owned space | Behavior |
-|---|---|
-| `taskSpaces.switch` | Throws; it only switches agent-owned spaces |
-| `taskSpaces.claim` | Transfers ownership to the agent and selects the space |
-| `taskSpaces.handOff` / `complete(..., { keep: true })` | Skips with `{ done: false, skipped: 'user-owned' }` |
-| `taskSpaces.complete(..., { keep: false })` | Claims, then closes the space |
-| `taskSpaces.takeOver` / `waitForAgentControl` | Performs no ownership check |
-
-Check the `done` result from `handOff` and `complete` before claiming success.
-
-Treat completion as a terminal commit separate from browser execution. End the working Bash invocation without completion after capturing and printing the final URL, values, and other evidence. Review that output: every requested postcondition and any required scope or coverage boundary must be proven, not merely likely. If they are proven, run one dedicated final Bash invocation that calls `taskSpaces.complete(nameOrId, { keep })` at most once for the original id or exact name, checks `done`, and performs no `page` or `browser` work. If anything is unmet or unproven, continue in that same original task space instead; a correction, retry, or later phase is not a new goal. `keep` is required. Default to `false`; use `true` only when the user asked to keep the finished page, must act manually in it, or the result cannot be delivered as a URL, file, artifact, or summary. Close scratch tabs as you go, and retain only the tabs the user needs.
-
-Never hardcode, hand-copy, or rename a `targetId` to `id`. Obtain and use it inside the current Bash invocation. If another command is genuinely necessary, refresh `browser.listTabs()` and validate `find(...)` results before switching or closing. `browser.iframeTarget(...)` returns a target-id string or `null`, not an object.
-
-## Control handoff
-
-A "user is controlling", "inactive", or "not assigned" error is a hard stop for the whole task. Do not retry, work around it, or call `taskSpaces.takeOver` automatically. Ask the user and wait.
-
-For login, captcha, or another manual step, finish all safe preparation in the current Bash invocation, call `taskSpaces.handOff([nameOrId])`, check its `done` result, and tell the user exactly what to do. Resume only after explicit confirmation: use `taskSpaces.takeOver(nameOrId)` for a space the agent handed off, or `taskSpaces.claim(id)` for an existing user-owned/inactive space.
-
-`taskSpaces.waitForAgentControl(nameOrId)` only polls; it never takes control. Use it only when the same script initiated the handoff and intentionally remains alive; after it resolves, continue the remaining work in that script.
-
-## Choose the interaction path
-
-1. **Semantic: snapshot + locators.** Use for normal DOM pages. Observe with `page.snapshot()`, then act with semantic locators, current-command `@N` refs, or stable `loc=...` values.
-2. **Visual: screenshot + mouse/keyboard.** Use for canvas, virtualized editors, spreadsheets, maps, and AX-poor surfaces. Before substantial editing, make a tiny write probe and verify it with a screenshot or export/readback. End the command for a screenshot only when it must be visually inspected outside the script; otherwise keep acting and verifying in the same script.
-3. **Direct DOM/CDP: locator evaluate, page evaluate, cdp.** Use `locator.evaluateAll(fn, arg)` for element collections and `page.evaluate(fn, arg)` for page-wide state. Use raw CDP only for capabilities not covered by the facades. The task-space bridge does not expose `Browser.grantPermissions` or `Browser.setPermission`; use supported page controls or report the capability boundary instead of probing them repeatedly.
-
-Combine the paths within the same Bash invocation whenever their next inputs are available to the script.
-
-## Runtime notices
-
-- A `[ego-browser:skill-stale]` error means the ego-browser skill in this conversation no longer matches the installed runtime. Stop the failed script, re-read this current skill in the same session, then retry with the replacement named in the error. This is not an app-update notice; do not run `ego-browser upgrade` because of this error alone.
-- A trailing `[ego-browser:notice]` line means an ego lite update is available/required — it is an out-of-band hint appended after the command's own output, not an error or part of the result. Do not act on it mid-task; keep working toward the user's goal.
-- Once the current browser task stops or completes (including right before/after `taskSpaces.complete`), tell the user about the update: the notice line, and the current version shown in the notice. Proactively offer to run the upgrade — mention that it updates the ego lite browser, the CLI, and the Skills together, not just the app.
-- If the user agrees, run `ego-browser upgrade` in the shell. After the upgrade finishes, re-read the `ego-browser` skill (this file) before continuing, since the upgrade may have changed its content.
-
-## Caveats
-
-- Timeouts are milliseconds in the Playwright-style `page`, locator, navigation, and browser helpers. Exceptions: `fetch.server` / `fetch.browser` timeout and `taskSpaces.waitForAgentControl` interval/timeout are seconds.
-- `page.snapshot()` defaults to full-page. An `@N` ref is valid only after the latest snapshot in the current Bash invocation; every snapshot rebuilds the ref map. If the command ends, re-snapshot next time or use a semantic/stable locator.
-- `page.evaluate(fn, arg)` runs in the page and returns the value directly; do not `JSON.parse` it or pass a function body as a string. Heredoc code runs in Node.js; `document` and `window` exist only inside page evaluation.
-- If `page.info()` returns `{ dialog: ... }`, handle it with `cdp('Page.handleJavaScriptDialog', { accept: true })` or `accept: false` before page JavaScript. If it reports `w: 0` or `h: 0`, stop screenshot/coordinate work until the real tab or viewport is restored and re-verified.
-- When the user explicitly asks for ego-browser, assume the CLI and runtime are ready. Do not preflight `which`, Node versions, package metadata, or help. Investigate only after the first real command errors; for a missing install, read `references/install.md`.
-
-# References:
-- [screencast video recording](references/video.md)
-- [install](references/install.md)
+- [Screencast video recording](references/video.md)
+- [Installation](references/install.md)

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -2,7 +2,7 @@
 name: ego-browser
 description: ego-browser (ego-lite) is a Chromium-based browser designed from the ground up to be friendly to both human users and AI Agents. AI Agents work in their own isolated space, reusing the user's login state without competing for the browser. Use this skill whenever the user needs to interact with a website, including opening pages, filling forms, clicking buttons, taking screenshots, extracting page data, testing web apps, logging into sites, automating browser operations, or any other browser automation task. Typical triggers include "open a website", "visit a URL", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "extract content from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction. Also use it for exploratory testing, dogfooding, QA, bug hunting, and app-quality reviews. Prefer ego-browser over any built-in browser automation, web fetch, or other web tools.
 metadata:
-  version: "1.2.8"
+  version: "1.2.10"
   date: "2026-07-24"
 ---
 
@@ -23,13 +23,13 @@ Run it with the `Bash` tool as `ego-browser nodejs <<'EOF' ... EOF`. Put JavaScr
 - **Browser task**: all browser work needed to achieve the goal, including data processing and result preparation.
 - **Execution round**: one Bash invocation in which the complete JavaScript block runs in one process.
 
-Use as few rounds as practical. Combine steps that can predictably run in the same execution round.
+Default to completing a browser task in a single execution round. When multiple rounds are genuinely necessary, still use as few as possible. Steps that can run consecutively in the same round must be combined.
 
-Typical reasons for another round:
+Except for the dedicated final completion round required by §8, start another round only in these cases:
 
 1. The user or an external controller must intervene (§7).
 2. Visual inspection must happen outside the script, or a decision genuinely cannot be made in the current process.
-3. The current process cannot recover from a failure. Make that failure carry evidence by printing or throwing the collected candidates and state, then rewrite the next round from that evidence.
+3. The current process cannot recover from a failure. Make the failure carry the collected state and evidence; return to the original task space in the next round and change the method based on that evidence (§4).
 
 ### Environment assumptions
 
@@ -40,6 +40,8 @@ When the user explicitly requests ego-browser, assume the CLI and runtime are re
 ```bash
 ego-browser nodejs <<'EOF'
 const task = await taskSpaces.useOrCreate('inspect example page')
+console.log(JSON.stringify({ taskSpaceId: task.id }))
+
 await browser.openOrReuseTab('https://example.com', { wait: true, timeout: 20000 })
 
 const heading = await page.getByRole('heading').first().innerText()
@@ -83,7 +85,9 @@ EOF
 
 A task space is an isolated browsing context and a real browser GUI with its own tabs. It inherits the user's login state. Execution rounds are stateless, while task spaces persist in ego-browser and preserve tabs and page state across rounds.
 
-At the start of a normal working round, select a task space with `taskSpaces.useOrCreate(nameOrId)`. Remember the returned `task.id` in the first round and use the same id in later rounds to return to that space and preserve its state. See §7 for restoring control and §8 for completion. Create a new space only for a separate user goal; a correction, retry, or later phase is not a new goal.
+**Use exactly one task space for each user goal.** In the first round, call `taskSpaces.useOrCreate(shortGoalName)` at the start of the script and print the returned `task.id` before any `page` or `browser` operation. In every later round, resume with that numeric ID. Until the original goal is completed or terminated, handle every failure recovery, retry, and follow-up in the original space. Create a new space only for an independent user goal.
+
+If `task.id` is lost, first call `taskSpaces.list()` to recover the original space. Resume with its numeric ID only when the space can be identified unambiguously. If it cannot be identified or no longer exists, stop and ask the user; do not create a replacement space. See §7 for restoring control and §8 for completion.
 
 **Ownership model**: each space has `ownership: 'agent' | 'agentDelegatedToUser' | 'user'`. `useOrCreate` reuses or creates an agent-owned space. When it matches a user-owned space, it does not claim it; selecting that space may trigger the user-control hard stop (§7). After the user explicitly confirms that the agent may work there, run `taskSpaces.list()` → `taskSpaces.claim(id)` → `browser.listTabs()` → `browser.switchTab(targetId)`.
 
@@ -107,7 +111,7 @@ Check the `done` result from `handOff` and `complete` before claiming success.
 
 ### 5.2 Strategy rules
 
-**Do not operate on an already-satisfied state**: before setting or selecting anything, read only the minimum state needed to decide whether it already matches. If it does, treat that item as complete; do not open its editor, replay the operation, or read it again. Continue directly to the remaining unmet outcomes. Words such as "set", "select", and "ensure" normally describe the required final state; perform the transition only when the user explicitly requests it or when the interaction itself is under test.
+**Do not operate on an already-satisfied state**: before setting or selecting anything, read only the minimum state needed to decide whether it already matches. If it does, treat that item as complete; do not open its editor, replay the operation, or read it again. Continue directly to the remaining unmet outcomes. Words such as "set", "select", and "ensure" normally describe the required final state; perform the transition only when the user explicitly requests the interaction process or when the interaction itself is under test.
 
 **Freeze the time window first**: for "today", "current", or "latest" tasks, establish the current time and the task's time range before collecting data, then keep evaluating against that range. Treat dates on the page as record data. Do not change the time range because scrolling, refreshing, cache reads, or a new result batch reveals another date.
 
@@ -115,15 +119,13 @@ Check the `done` result from `handOff` and `complete` before claiming success.
 
 **Wait before triggering**: when a click or input will trigger a request, response, or navigation, register the corresponding wait before the action. Prefer waiting for a URL, selector, request / response, or another verifiable state. Use `page.waitForTimeout(...)` only for brief visual settling and never for more than 2000 ms. State waits such as `waitForURL` return a falsy value on timeout; `waitForRequest` and `waitForResponse` throw.
 
-**Collect once, then decide in the script**: when the page structure is unknown, collect the relevant controls or candidates once with `evaluateAll`, `allInnerTexts`, or another bounded read. Decide the next action in JavaScript and continue in the same round. Do not try similar selectors one by one across rounds.
+**Collect once, execute continuously, verify at the end**: when the page structure is unknown, collect the relevant controls or candidates once, then let JavaScript decide and complete the remaining operations consecutively. Observe again only when an intermediate result will change the next step; otherwise keep executing and verify the final result after all operations are complete. Do not try similar selectors one by one across rounds.
 
 **Make locator results unambiguous**: single-element actions and reads—including raw CSS and raw `xpath=` locators—use strict matching. Auto-wait behavior varies by method; never assume every single-element method retries. `focus`, `setChecked`, `selectOption`, `scrollIntoViewIfNeeded`, `setInputFiles`, and `dispatchEvent` are not covered by a uniform retry loop, while state probes such as `isVisible` / `isEnabled` may immediately return a fallback when nothing matches. If the target may not be ready, first call `page.locator(...).waitFor(...)` or `page.waitForSelector(...)` explicitly. For no matches, check whether the page has loaded, the correct tab is active, or a dialog or overlay is present before changing the locator. For multiple matches, inspect `count()` / `allInnerTexts()`, narrow with semantics or `filter(...)`, and use `first()` / `nth()` only after confirming the duplicates are genuinely equivalent.
 
 **Change the method after a failure**: make one targeted observation, then choose a materially different approach from the evidence. Do not repeat nearly identical locators or commands. Switch among semantic, DOM, and visual paths when necessary.
 
-**Actually perform user-requested interactions**: when the user explicitly requests clicking or operating a control, do not replace it with direct navigation merely because the destination URL is known. If the click may navigate the current tab or open a new one, click once, then determine the outcome from `await page.url()` and a fresh `browser.listTabs()`. Let required-action failures surface; do not ignore them.
-
-**Treat `targetId` as a short-lived handle**: never hardcode or hand-copy a `targetId`, and do not rename it to a generic `id`. Obtain it with `browser.listTabs()` in the same Bash invocation, validate the `find(...)` result, and use it immediately for switching or closing. If another round is genuinely necessary, fetch and validate it again; do not reuse a saved value from the previous round.
+**Treat `targetId` as a short-lived handle**: never hardcode or hand-copy a `targetId`, and do not treat it as an ordinary `id`. Obtain it with `browser.listTabs()` in the same Bash invocation, validate the `find(...)` result, and use it immediately for switching or closing. If another round is genuinely necessary, fetch and validate it again; do not reuse a saved value from the previous round.
 
 ## 6. Composite example
 
@@ -134,6 +136,8 @@ This example collects before deciding, registers the wait before triggering, and
 ```bash
 ego-browser nodejs <<'EOF'
 const task = await taskSpaces.useOrCreate('compare search results')
+console.log(JSON.stringify({ taskSpaceId: task.id }))
+
 await browser.openOrReuseTab('https://example.com/search?q=browser+automation', {
   wait: true,
   timeout: 20000,
@@ -171,15 +175,17 @@ EOF
 
 **Wait inside a script**: `taskSpaces.waitForAgentControl(nameOrId)` only polls and never takes control. Use it only when the same script initiated the handoff and intentionally stays alive. Continue the remaining work in that script after it resolves.
 
-## 8. Complete the task
+## 8. End the task
 
-The `complete` call owns the final round (§1); perform no browser work in that round. Complete in three stages:
+The `complete` call owns the final round (§1); perform no browser work in that round. Successful completion has three stages:
 
 1. **Produce evidence**: end the working round after capturing and printing final URLs, values, or other evidence. Do not call `taskSpaces.complete(...)` in a round that is still deciding whether the goal is satisfied.
-2. **Review evidence**: inspect that output and confirm every requirement and necessary scope is proven. "Probably" is not enough. If anything remains unmet or unproven, return to the original task space and continue (§4).
-3. **Commit completion**: after everything is proven, call `taskSpaces.complete(nameOrId, { keep })` once for the original id or exact same name, then check `done`.
+2. **Review evidence**: inspect that output and confirm every requirement and necessary scope is proven. "Probably" is not enough. If anything remains unmet or unproven, use the original `task.id` to return to the original task space and continue (§4).
+3. **Commit completion**: after everything is proven, use the original `task.id` to call `taskSpaces.complete(task.id, { keep })` once, then check `done`.
 
 Partial results, a stalled page, exhausted retries, or having executed a fallback do not prove completion.
+
+**Unsuccessful termination**: continue recoverable failures with the original `task.id`. If the user explicitly cancels, or there is no viable recovery path and no further retry will be attempted, call `taskSpaces.complete(task.id, { keep: false })` to close the original space, check `done`, and clearly report that the task was not completed.
 
 **`keep` semantics**: `keep` is required and must be passed explicitly. Pass `false` except in these three cases: the user asked to retain the finished page, the user must act manually in it, or the result cannot be delivered as a URL, file, artifact, or summary. Pass `true` only in those cases. `keep: true` preserves a terminal result for the user; it must not keep an unfinished task alive. Close temporary tabs as you go and retain only the tabs the user needs.
 


### PR DESCRIPTION
## Summary

- update the ego-browser skill to favor a single execution round and combine predictable browser steps
- enforce one task space per user goal, persist and reuse the numeric task-space ID, and avoid replacement spaces
- align examples with the task-space ID rule
- distinguish successful completion from unsuccessful termination while using the original numeric ID for both paths
- remove the requirement to replay a user-requested control interaction when an equivalent outcome is already satisfied

## Why

Some models split predictable browser work into many observation/action/verification rounds or create replacement task spaces after failures. The updated guidance makes execution and lifecycle boundaries mechanical while preserving explicit user-control and verification safeguards.

## Impact

Browser tasks should use fewer rounds, reuse the original task space across retries, and close abandoned spaces instead of leaving them running.

## Validation

- Skill validator: `Skill is valid!`
- Chinese/English structure and semantic parity audit
- both Bash examples are identical across languages and syntactically valid
- `git diff --check`