### PR TITLE
fix(ego-browser): make the repo build, test, and commit on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Keep the working tree in LF on every platform. Without this, Git for Windows
+# checks files out as CRLF (core.autocrlf defaults to true), which makes
+# `prettier --check` fail on files the contributor never touched, and would ship
+# CRLF into scripts/install.sh.
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.dmg binary
+*.zip binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: package/ego-browser

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,17 @@ ego-lite/
 > command shipped inside the ego lite app, which is macOS-only today, so it
 > skips itself elsewhere. Git hooks are run by lefthook through Git Bash on
 > Windows, which Git for Windows already provides.
+>
+> On Windows, `.claude/skills/ego-browser` and `.codex/skills/ego-browser` are
+> symlinks into `skills/ego-browser`. Git for Windows defaults to
+> `core.symlinks=false` and checks them out as 24-byte text files, so agents
+> discover a file instead of the skill directory. Enable symlinks once, then
+> restore them:
+>
+> ```bash
+> git config core.symlinks true
+> git checkout -- .claude/skills/ego-browser .codex/skills/ego-browser
+> ```
 
 ```bash
 # 1. Install dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,12 @@ ego-lite/
 
 > All commands run from `package/ego-browser/`.
 
+> **Platforms**: the commands below work on macOS, Linux, and Windows. The
+> `npm run e2e` suite is the exception — it drives the real `ego-browser`
+> command shipped inside the ego lite app, which is macOS-only today, so it
+> skips itself elsewhere. Git hooks are run by lefthook through Git Bash on
+> Windows, which Git for Windows already provides.
+
 ```bash
 # 1. Install dependencies
 cd package/ego-browser

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,12 +14,12 @@ pre-commit:
   commands:
     branch-up-to-date:
       run: |
-        git fetch --quiet origin dev 2>/dev/null || { echo "⚠ skip branch-freshness check: cannot fetch origin/dev (offline?)"; exit 0; }
+        git fetch --quiet origin dev 2>/dev/null || { echo '⚠ skip branch-freshness check: cannot fetch origin/dev (offline?)'; exit 0; }
         if git merge-base --is-ancestor FETCH_HEAD HEAD; then
           exit 0
         fi
-        echo "✗ Your branch is behind origin/dev — sync before committing:"
-        echo "    git fetch origin dev && git rebase origin/dev   # or: git merge origin/dev"
+        echo '✗ Your branch is behind origin/dev — sync before committing:'
+        echo '    git fetch origin dev && git rebase origin/dev   # or: git merge origin/dev'
         exit 1
     style-check:
       run: |
@@ -45,4 +45,5 @@ pre-commit:
     e2e-test:
       run: |
         git diff --cached --name-only --diff-filter=ACMR | grep -q '^package/ego-browser/' || exit 0
+        uname -s | grep -q Darwin || { echo 'skip e2e: the real-browser suite needs the macOS ego lite app'; exit 0; }
         cd package/ego-browser && npm run e2e

--- a/package/ego-browser/package.json
+++ b/package/ego-browser/package.json
@@ -7,17 +7,17 @@
     "ego-browser": "./dist/out/index.js"
   },
   "scripts": {
-    "clean": "rm -rf dist artifacts",
+    "clean": "node scripts/clean.mjs",
     "build": "node scripts/build.mjs",
     "e2e": "node scripts/run-real-browser-e2e.mjs",
-    "prepare": "if [ \"$CI\" = \"true\" ]; then exit 0; fi; cd ../.. && lefthook install",
+    "prepare": "node scripts/prepare.mjs",
     "style:check": "prettier --check",
     "typecheck": "tsc --noEmit",
     "test": "npm run build && npm run typecheck && node --test \"src/**/*.test.mjs\" \"test/*.test.js\"",
     "mutation-check": "npm run build && node scripts/mutation-check.mjs",
     "validate:agent-style": "node scripts/validate-agent-style.mjs",
-    "validate:learnings": "npm run build && EGO_BROWSER_AGENT_WORKSPACE=../../skills/ego-browser node dist/scripts/validate-site-skills.js",
-    "validate:site-skills": "npm run build && EGO_BROWSER_AGENT_WORKSPACE=../../skills/ego-browser node dist/scripts/validate-site-skills.js"
+    "validate:learnings": "npm run validate:site-skills",
+    "validate:site-skills": "npm run build && node dist/scripts/validate-site-skills.js"
   },
   "engines": {
     "node": ">=22"

--- a/package/ego-browser/scripts/clean.mjs
+++ b/package/ego-browser/scripts/clean.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+// Removes build output. Kept in Node rather than `rm -rf` because npm runs
+// package scripts through cmd.exe on Windows, which has no `rm`.
+import { rmSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+for (const target of ["dist", "artifacts"]) {
+  rmSync(join(packageDir, target), { recursive: true, force: true });
+}

--- a/package/ego-browser/scripts/prepare.mjs
+++ b/package/ego-browser/scripts/prepare.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Installs the repository git hooks after a local `npm install`.
+// Kept in Node rather than inline shell because npm runs package scripts through
+// cmd.exe on Windows, where POSIX `if [ ... ]` syntax is a syntax error.
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+if (process.env.CI === "true") {
+  process.exit(0);
+}
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolve(packageDir, "..", "..");
+const lefthook = join(
+  packageDir,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "lefthook.cmd" : "lefthook",
+);
+
+const result = spawnSync(lefthook, ["install"], {
+  cwd: repoRoot,
+  stdio: "inherit",
+});
+
+process.exit(result.status ?? 0);

--- a/package/ego-browser/scripts/real-browser-e2e/runner.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/runner.mjs
@@ -204,7 +204,16 @@ export async function runRealBrowserE2e() {
 
   try {
     console.log("== build ==");
-    await runCommand("npm", ["run", "build"], { cwd: packageDir });
+    // Call the build script through the current Node binary: spawning the bare
+    // name "npm" resolves to npm.cmd on Windows, which spawn() cannot launch
+    // without a shell (ENOENT).
+    await runCommand(
+      process.execPath,
+      [join(packageDir, "scripts", "build.mjs")],
+      {
+        cwd: packageDir,
+      },
+    );
     await stat(egoBrowserSdkPath);
 
     tempDir = await mkdtemp(join(tmpdir(), "ego-browser-real-e2e-"));

--- a/package/ego-browser/scripts/run-real-browser-e2e.mjs
+++ b/package/ego-browser/scripts/run-real-browser-e2e.mjs
@@ -1,4 +1,15 @@
 #!/usr/bin/env node
 import { runRealBrowserE2e } from "./real-browser-e2e/runner.mjs";
 
+// The suite drives the real `ego-browser` command, which ships inside the ego
+// lite app. That app is macOS-only today, so bail out with an explanation
+// instead of failing later on an opaque ENOENT.
+if (process.platform !== "darwin" && !process.env.EGO_BROWSER_REAL_E2E_FORCE) {
+  console.log(
+    `skip: the real-browser e2e suite requires the ego lite app (macOS only); ` +
+      `platform is ${process.platform}. Set EGO_BROWSER_REAL_E2E_FORCE=1 to run it anyway.`,
+  );
+  process.exit(0);
+}
+
 await runRealBrowserE2e();

--- a/package/ego-browser/scripts/validate-site-skills.ts
+++ b/package/ego-browser/scripts/validate-site-skills.ts
@@ -1,17 +1,29 @@
 #!/usr/bin/env node
-import { pathToFileURL } from "node:url";
-import { resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, resolve } from "node:path";
 
 import { siteSkillsRoot, validateSiteSkills } from "../src/learning/index.js";
 
 export { validateSiteSkills };
 
+// Default the workspace to this checkout's skill directory. It used to be an
+// inline `EGO_BROWSER_AGENT_WORKSPACE=... node ...` prefix in package.json,
+// which cmd.exe parses as a command name on Windows. Anchored on this file
+// rather than the cwd so it holds wherever npm is invoked from.
+function defaultAgentWorkspace() {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(scriptDir, "..", "..", "..", "..", "skills", "ego-browser");
+}
+
 export async function main(argv = process.argv.slice(2)) {
+  process.env.EGO_BROWSER_AGENT_WORKSPACE ??= defaultAgentWorkspace();
   const rootArg = argv[0] || siteSkillsRoot();
   const root = resolve(rootArg);
   const canonicalRoot = resolve(siteSkillsRoot());
   if (root !== canonicalRoot) {
-    console.warn(`warning: validating ${root} which differs from siteSkillsRoot() ${canonicalRoot}`);
+    console.warn(
+      `warning: validating ${root} which differs from siteSkillsRoot() ${canonicalRoot}`,
+    );
   }
   const errors = await validateSiteSkills(root);
   if (errors.length > 0) {
@@ -24,6 +36,9 @@ export async function main(argv = process.argv.slice(2)) {
   return 0;
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   process.exitCode = await main();
 }

--- a/package/ego-browser/src/env.test.mjs
+++ b/package/ego-browser/src/env.test.mjs
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+
+import { resolvePath } from "../dist/src/env.js";
+
+function withHome(home, fn) {
+  const previous = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+  };
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  try {
+    return fn();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+test("resolvePath expands ~ against the home directory", () => {
+  const home = resolve("/tmp/ego-home");
+  withHome(home, () => {
+    // Regression: path.slice(1) leaves a leading separator, which resolve()
+    // treats as absolute and would drop the home base on every platform.
+    assert.equal(
+      resolvePath("~/Downloads/a.png"),
+      resolve(home, "Downloads/a.png"),
+    );
+    assert.equal(resolvePath("~"), home);
+  });
+});
+
+test("resolvePath leaves non-tilde paths to resolve()", () => {
+  assert.equal(resolvePath("relative/file.txt"), resolve("relative/file.txt"));
+});

--- a/package/ego-browser/src/env.ts
+++ b/package/ego-browser/src/env.ts
@@ -20,7 +20,10 @@ export function agentWorkspace() {
 
 export function resolvePath(path) {
   if (path.startsWith("~")) {
-    return resolve(process.env.HOME || process.env.USERPROFILE || ".", path.slice(1));
+    // Strip the leading separator: resolve() treats "/Downloads" as absolute and
+    // would drop the home base entirely (on every platform, not just Windows).
+    const rest = path.slice(1).replace(/^[\\/]+/, "");
+    return resolve(process.env.HOME || process.env.USERPROFILE || ".", rest);
   }
   return resolve(path);
 }
@@ -36,7 +39,10 @@ export function loadEnvFile(path) {
     }
     const index = line.indexOf("=");
     const key = line.slice(0, index).trim();
-    const value = line.slice(index + 1).trim().replace(/^['"]|['"]$/g, "");
+    const value = line
+      .slice(index + 1)
+      .trim()
+      .replace(/^['"]|['"]$/g, "");
     if (key && process.env[key] === undefined) {
       process.env[key] = value;
     }

--- a/package/ego-browser/src/learning/index.test.mjs
+++ b/package/ego-browser/src/learning/index.test.mjs
@@ -4,7 +4,11 @@ import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { loadLearnedContext } from "../../dist/src/learning/index.js";
+import {
+  loadBrowserToolSource,
+  loadLearnedContext,
+  runNodeSiteTool,
+} from "../../dist/src/learning/index.js";
 
 test("loadLearnedContext includes declared tool return schemas", async () => {
   const root = await mkdtemp(join(tmpdir(), "ego-learning-"));
@@ -70,5 +74,74 @@ test("loadLearnedContext includes declared tool return schemas", async () => {
   assert.deepEqual(
     context.tools.find((tool) => tool.toolName === "active_item").returns,
     { type: "object", description: "Active item object." },
+  );
+});
+
+test("site tool paths resolve on every platform and stay confined", async () => {
+  const root = await mkdtemp(join(tmpdir(), "ego-learning-"));
+  const siteDir = join(root, "example");
+  await mkdir(join(siteDir, "tools"), { recursive: true });
+  await mkdir(join(siteDir, "browser-tools"));
+  const manifest = {
+    id: "example",
+    name: "Example",
+    domains: ["example.com"],
+    nodeTools: {
+      read_items: {
+        description: "Read items.",
+        path: "tools/read-items.js",
+        callable: "readItems",
+        args: {},
+      },
+    },
+    browserTools: {
+      active_item: {
+        description: "Read the active item.",
+        path: "browser-tools/active-item.js",
+        args: {},
+      },
+    },
+  };
+  await writeFile(join(siteDir, "manifest.json"), JSON.stringify(manifest));
+  await writeFile(
+    join(siteDir, "tools/read-items.js"),
+    "export async function readItems() { return ['ok']; }\n",
+  );
+  await writeFile(
+    join(siteDir, "browser-tools/active-item.js"),
+    "async function() { return {}; }\n",
+  );
+
+  // Regression: the confinement check used to compare against a hard-coded "/"
+  // separator, so every declared tool path was rejected on Windows.
+  const source = await loadBrowserToolSource("example", "active_item", {
+    root,
+  });
+  assert.match(source, /async function/);
+  assert.deepEqual(
+    await runNodeSiteTool("example", "read_items", {}, undefined, { root }),
+    ["ok"],
+  );
+
+  // Escaping the site directory must still be refused.
+  const escaping = await mkdtemp(join(tmpdir(), "ego-learning-"));
+  const escapingSite = join(escaping, "example");
+  await mkdir(escapingSite, { recursive: true });
+  await writeFile(
+    join(escapingSite, "manifest.json"),
+    JSON.stringify({
+      ...manifest,
+      browserTools: {
+        active_item: {
+          description: "Escape.",
+          path: "../outside.js",
+          args: {},
+        },
+      },
+    }),
+  );
+  await assert.rejects(
+    () => loadBrowserToolSource("example", "active_item", { root: escaping }),
+    /must stay inside the site skill directory|must be relative/,
   );
 });

--- a/package/ego-browser/src/learning/index.ts
+++ b/package/ego-browser/src/learning/index.ts
@@ -1,6 +1,6 @@
 import { pathToFileURL } from "node:url";
 import { readFile } from "node:fs/promises";
-import { isAbsolute, relative, resolve } from "node:path";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 
 import {
   iterLearningDirs,
@@ -230,7 +230,7 @@ function relativeSitePath(siteDir, manifestPath, label) {
   }
   const resolved = resolve(siteDir, manifestPath);
   const siteRoot = resolve(siteDir);
-  if (resolved !== siteRoot && !resolved.startsWith(`${siteRoot}/`)) {
+  if (resolved !== siteRoot && !resolved.startsWith(`${siteRoot}${sep}`)) {
     throw new Error(`${label} path must stay inside the site skill directory`);
   }
   return resolved;


### PR DESCRIPTION
## Summary

The repo's own toolchain could not run on Windows: `npm ci` exited 1 before installing anything, so a Windows contributor was blocked at step 1 of CONTRIBUTING §4 and never reached the test suite. Fixing that surfaced two genuine path bugs in `src/`, one of which is not Windows-specific at all.

This does not make the ego lite browser itself run on Windows — that app is macOS-only and lives outside this repo. It makes *this* repo buildable, testable, and committable on Windows, which is a prerequisite for the Windows support already on the roadmap.

Every change is a no-op on macOS, Linux, and the existing ubuntu CI runners.

## Related issue

No existing issue. The README lists Windows as roadmap work; this only covers the harness/toolchain side of it.

## Changes

- **`src/learning/index.ts`** — `relativeSitePath()` compared the resolved path against `` `${siteRoot}/` ``. `path.resolve()` returns backslashes on Windows, so the containment guard never matched and **every declared site skill tool was rejected**: `runNodeSiteTool()` and `loadBrowserToolSource()` both threw `path must stay inside the site skill directory`. Now uses `path.sep`, which is `/` on POSIX, so the check is byte-identical there. Escaping the site directory is still refused (covered by test).
- **`src/env.ts`** — `resolvePath()` expanded `~` via `path.slice(1)`, leaving a leading separator that `resolve()` treats as absolute, discarding the home base. `~/Downloads/a.png` resolved to `/Downloads/a.png` on POSIX and `C:\Downloads\a.png` on Windows. **This one was never platform-specific.**
- **`package.json`** — `prepare` (inline `if [ "$CI" = "true" ]`), `clean` (`rm -rf`) and `validate:*` (inline `VAR=value cmd` prefix) are POSIX shell; npm runs scripts through `cmd.exe` on Windows. Moved to `scripts/prepare.mjs`, `scripts/clean.mjs`, and a default resolved inside `scripts/validate-site-skills.ts` (anchored on the script's own location, not the cwd; an externally provided `EGO_BROWSER_AGENT_WORKSPACE` still wins).
- **`.gitattributes`** (new) — without it, Git for Windows checks the tree out as CRLF and `prettier --check` fails on files the contributor never touched, in both the pre-commit gate and the changed-file style job. Existing blobs are already LF, so no file content changes.
- **`lefthook.yml`** — the `e2e-test` gate ran the macOS-only suite unconditionally, so no commit touching the package was possible elsewhere; it now skips off macOS. Echo strings are single-quoted because lefthook on Windows delegates to Git Bash but mangles double-quoted literals containing spaces, which made the first hook fail to parse and blocked every commit.
- **`run-real-browser-e2e.mjs` / `runner.mjs`** — the suite reports why it skips instead of dying on an opaque `ENOENT` (`EGO_BROWSER_REAL_E2E_FORCE=1` still forces it), and the build step no longer spawns the bare name `npm`, which resolves to `npm.cmd` on Windows and cannot be launched without a shell.
- **`.github/workflows/ci.yml`** — the test job runs on `ubuntu-latest` **and** `windows-latest` so this cannot regress silently.

Two pre-existing Prettier deviations (in `src/env.ts` and `scripts/validate-site-skills.ts`) were formatted because the changed-file style job would otherwise fail on files this PR touches.

## Verification

Run on Windows 11 (Node 22.21.1) — the full CONTRIBUTING §4 sequence, which previously stopped at step 1:

```text
npm ci                        -> ok (was: exit 1 in `prepare`)
npm run build                 -> ok
npm run typecheck             -> ok
npm test                      -> 309 pass, 0 fail
npm run validate:site-skills  -> site skills ok (was: 'EGO_BROWSER_AGENT_WORKSPACE' is not recognized)
npm run e2e                   -> skip: requires the ego lite app (macOS only)
npm run clean                 -> ok (was: 'rm' is not recognized)
git commit                    -> all 7 lefthook gates pass (was: hook failed to parse)
```

No regression on Linux, same tree in `node:22` (Docker):

```text
npm ci                        -> ok
npm test                      -> 309 pass, 0 fail
npm run validate:site-skills  -> site skills ok: /work/skills/ego-browser/learnings
npm run e2e                   -> skip (platform is linux)
npm run clean                 -> ok
```

`scripts/prepare.mjs` was also compared against the previous inline shell in the failure case (no git repository): both exit 1 with the same lefthook message, so the contract is unchanged.

The two `src/` fixes are covered by regression tests that **fail without the fix** (verified by reverting each fix against the new tests):

- `resolvePath expands ~ against the home directory` — got `E:\Downloads\a.png`, expected `<home>\Downloads\a.png`
- `site tool paths resolve on every platform and stay confined` — `loadBrowserToolSource` threw `path must stay inside the site skill directory`

I could not run the macOS path myself. The real-browser e2e suite is unchanged in behaviour there (`process.platform === "darwin"` and `uname -s` both keep the existing route), but it is worth a maintainer running `npm run e2e` on macOS before merge.

## Impact

- [x] Public helper API or behavior
- [ ] Agent skill or instructions
- [ ] Site learning
- [ ] Installation or update flow
- [x] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

Behaviour changes, both fixing previously broken paths: `runSiteTool` / `runSiteBrowserTool` now work on Windows (they always did on macOS), and `EGO_BROWSER_AGENT_WORKSPACE=~/...` now expands to the home directory instead of the filesystem root. The `validate:*` scripts change precedence slightly: an externally set `EGO_BROWSER_AGENT_WORKSPACE` now wins over the built-in default, where the old inline prefix always overrode it. Nothing in CI sets that variable.

## Checklist

- [x] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained above.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [x] A release-note label is selected (`feat`, `fix`, `docs`, `chore`, `ci`, or `refactor`).
