### PR TITLE
fix(ego-browser): toggle setChecked with a real click

### DIFF
--- a/package/ego-browser/scripts/real-browser-e2e/cases/keyboard.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/cases/keyboard.mjs
@@ -75,6 +75,24 @@ export function keyboardCase() {
     assertEqual(await page.locator("#checkbox").isChecked(), false, "isChecked reads unchecked state");
     await page.locator("#checkbox").setChecked(true);
     await waitForJsValue("window.__fixtureState.checkboxChecked", true, "setChecked sets explicit state");
+    await page.locator("#checkbox").setChecked(true);
+    await waitForJsValue("window.__fixtureState.checkboxChecked", true, "setChecked is a no-op when the state already matches");
+
+    /* A controlled input only advances on a real click; a property write is dropped. */
+    await page.locator("#controlled-checkbox").check();
+    await waitForJsValue("window.__fixtureState.controlledChecked", true, "check drives a controlled checkbox");
+    await waitForJsValue("window.__fixtureState.controlledChanges", 1, "check fires exactly one controlled change");
+    await page.locator("#controlled-checkbox").uncheck();
+    await waitForJsValue("window.__fixtureState.controlledChecked", false, "uncheck clears a controlled checkbox");
+
+    await page.locator("#controlled-radio-pro").setChecked(true);
+    await waitForJsValue("window.__fixtureState.controlledPlan", "pro", "setChecked drives a controlled radio");
+    assertEqual(await page.locator("#controlled-radio-basic").isChecked(), false, "controlled radio group keeps a single selection");
+    await assertRejects(
+      () => page.locator("#controlled-radio-pro").uncheck(),
+      "cannot uncheck a radio",
+      "uncheck rejects radio inputs"
+    );
 
     await page.locator("#text-input").fill("select me", { timeout: 3000 });
     await page.keyboard.press("ControlOrMeta+a");

--- a/package/ego-browser/scripts/real-browser-e2e/fixture.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/fixture.mjs
@@ -574,6 +574,13 @@ function pageHtml(kind) {
       <div id="inner-scroll"><div id="inner-scroll-content">Inner scroll marker</div></div>
       <section id="scroll-area"><div id="bottom-marker">Bottom marker</div></section>
 
+      <!-- Kept below #scroll-area: new nodes above it shift the page and break the wheel cases. -->
+      <div id="controlled-checkable">
+        <label><input type="checkbox" id="controlled-checkbox"> Nonstop only</label>
+        <label><input type="radio" name="controlled-plan" id="controlled-radio-basic" value="basic"> Plan basic</label>
+        <label><input type="radio" name="controlled-plan" id="controlled-radio-pro" value="pro"> Plan pro</label>
+      </div>
+
       ${kind === "frame" ? '<div id="iframe-marker" data-iframe="true" style="border:2px solid var(--accent);padding:4px 8px;margin-top:4px;border-radius:4px;font-size:0.8rem">iframe target</div>' : ""}
     </main>
     <script>
@@ -591,6 +598,10 @@ function pageHtml(kind) {
         dynamicElementExists: false,
         tabOrder: [],
         checkboxChecked: false,
+        controlledChecked: false,
+        controlledChanges: 0,
+        controlledPlan: "",
+        controlledPlanChanges: 0,
         dropdownValue: "alpha",
         valueEvents: {},
         canvasStrokes: 0,
@@ -690,6 +701,62 @@ function pageHtml(kind) {
         el.addEventListener("input", () => { state = el.value; render(); });
         el.addEventListener("change", () => { stateEl.textContent = state + " (change)"; });
         render();
+      })();
+
+      /* ---- react-style controlled checkbox / radio ----
+         Mirrors React's input value tracker: writing the checked property runs the
+         instance setter, which records the new value, so the event that follows
+         looks like a no-op and the state never advances. A real click sets
+         checkedness internally and bypasses the setter, so the tracker still sees
+         a change. React derives checkbox/radio onChange from the click event, so
+         this listens there too. */
+      (function () {
+        const native = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "checked");
+        function track(node) {
+          let tracked = String(native.get.call(node));
+          Object.defineProperty(node, "checked", {
+            configurable: true,
+            get() { return native.get.call(this); },
+            set(value) { tracked = String(value); native.set.call(this, value); },
+          });
+          return {
+            changed() {
+              const next = String(native.get.call(node));
+              if (next === tracked) return false;
+              tracked = next;
+              return true;
+            },
+            sync(value) { tracked = String(value); native.set.call(node, value); },
+          };
+        }
+
+        const box = document.querySelector("#controlled-checkbox");
+        const boxTracker = track(box);
+        function renderBox(checked) {
+          window.__fixtureState.controlledChecked = checked;
+          boxTracker.sync(checked);
+        }
+        box.addEventListener("click", () => {
+          if (!boxTracker.changed()) return;
+          window.__fixtureState.controlledChanges += 1;
+          renderBox(native.get.call(box));
+        });
+        renderBox(false);
+
+        const radios = Array.from(document.querySelectorAll("input[name='controlled-plan']"));
+        const radioTrackers = new Map(radios.map((radio) => [radio, track(radio)]));
+        function renderPlan(plan) {
+          window.__fixtureState.controlledPlan = plan;
+          for (const radio of radios) radioTrackers.get(radio).sync(radio.value === plan);
+        }
+        for (const radio of radios) {
+          radio.addEventListener("click", () => {
+            if (!radioTrackers.get(radio).changed()) return;
+            window.__fixtureState.controlledPlanChanges += 1;
+            renderPlan(radio.value);
+          });
+        }
+        renderPlan("");
       })();
 
       /* ---- context menu ---- */

--- a/package/ego-browser/src/driver/keyboard.test.mjs
+++ b/package/ego-browser/src/driver/keyboard.test.mjs
@@ -343,25 +343,110 @@ test("focus resolves a selector and focuses the element", async () => {
   assert.match(call.params.functionDeclaration, /this\.focus\(\)/);
 });
 
-test("setChecked, check, and uncheck use Playwright-style checked state", async () => {
-  const { calls, restore } = selectorCallHarness();
+// setChecked toggles through a real click, so the harness has to answer the
+// whole click path: handle resolution, the visibility gate, the click point,
+// and the checked reads that bracket it. `states` is the queue of checked
+// values those reads return; the last entry answers every later read.
+function checkedStateHarness(states) {
+  const calls = [];
+  const reads = [];
+  const queue = [...states];
+  const restore = setOverrides({
+    cdpOverride(method, params, sessionId) {
+      calls.push({ method, params, sessionId });
+      if (
+        method === "Runtime.evaluate" &&
+        params.objectGroup === "ego-browser"
+      ) {
+        return { result: { objectId: "object-1" } };
+      }
+      if (method === "Runtime.evaluate") {
+        return { result: { value: { x: 40, y: 60 } } };
+      }
+      if (method === "Runtime.callFunctionOn") {
+        const source = params.functionDeclaration;
+        if (source.includes("setChecked target must be")) {
+          reads.push(params.arguments);
+          return {
+            result: { value: queue.length > 1 ? queue.shift() : queue[0] },
+          };
+        }
+        if (source.includes("checkVisibility")) {
+          return { result: { value: true } };
+        }
+      }
+      return {};
+    },
+  });
+  return { calls, reads, restore };
+}
+
+test("setChecked toggles a checkbox with a real click, not a property write", async () => {
+  const { calls, restore } = checkedStateHarness([false, true]);
   try {
     await setChecked("#agree", true);
-    await check("#agree");
-    await uncheck("#agree");
   } finally {
     restore();
   }
 
-  const callsOnElement = calls.filter(
-    (entry) => entry.method === "Runtime.callFunctionOn",
-  );
-  assert.equal(callsOnElement.length, 3);
   assert.deepEqual(
-    callsOnElement.map((entry) => entry.params.arguments),
-    [[{ value: true }], [{ value: true }], [{ value: false }]],
+    calls
+      .filter((entry) => entry.method === "Input.dispatchMouseEvent")
+      .map((entry) => entry.params.type),
+    ["mouseMoved", "mousePressed", "mouseReleased"],
   );
-  assert.match(callsOnElement[0].params.functionDeclaration, /this\.checked/);
+  assert.ok(
+    calls
+      .filter((entry) => entry.method === "Runtime.callFunctionOn")
+      .every(
+        (entry) => !/this\.checked\s*=/.test(entry.params.functionDeclaration),
+      ),
+    "never assigns the checked property page-side",
+  );
+});
+
+test("setChecked skips the click when the state already matches", async () => {
+  const { calls, restore } = checkedStateHarness([true]);
+  try {
+    await setChecked("#agree", true);
+  } finally {
+    restore();
+  }
+
+  assert.equal(
+    calls.filter((entry) => entry.method === "Input.dispatchMouseEvent").length,
+    0,
+  );
+});
+
+test("setChecked throws when the click leaves the state unchanged", async () => {
+  const { restore } = checkedStateHarness([false]);
+  try {
+    await assert.rejects(
+      () => setChecked("#agree", true),
+      /did not make it checked/,
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("check and uncheck request the matching target state", async () => {
+  const { reads, restore } = checkedStateHarness([false, true]);
+  try {
+    await check("#agree");
+  } finally {
+    restore();
+  }
+  assert.deepEqual(reads[0], [{ value: true }]);
+
+  const unchecking = checkedStateHarness([true, false]);
+  try {
+    await uncheck("#agree");
+  } finally {
+    unchecking.restore();
+  }
+  assert.deepEqual(unchecking.reads[0], [{ value: false }]);
 });
 
 test("selectOption returns selected values", async () => {

--- a/package/ego-browser/src/driver/keyboard.ts
+++ b/package/ego-browser/src/driver/keyboard.ts
@@ -1,6 +1,7 @@
 import { cdp } from "../cdp-eval.js";
 import { browserCdp } from "../browser-runtime.js";
 import { withHandle, resolveAndCall } from "./element-ops.js";
+import { click } from "./pointer.js";
 import { waitForSelector } from "./waits.js";
 import { state } from "../state.js";
 
@@ -390,29 +391,47 @@ export async function uncheck(selector) {
   await setChecked(selector, false);
 }
 
+// Page-side guard shared by the read before the click and the read after it:
+// rejects non checkbox/radio targets and radio unchecking, then reports the
+// current state. One source string so both reads validate identically.
+const CHECKED_STATE_SOURCE = `function(checked){
+  if (!(this instanceof HTMLInputElement) || (this.type !== "checkbox" && this.type !== "radio")) {
+    throw new Error("setChecked target must be a checkbox or radio input");
+  }
+  if (this.type === "radio" && !checked) {
+    throw new Error("setChecked cannot uncheck a radio input");
+  }
+  return this.checked;
+}`;
+
 /**
  * Set the checked state of a checkbox or radio, Playwright-style.
+ *
+ * Toggles through a real click rather than assigning `this.checked`: an
+ * assignment updates the DOM property without the activation behavior a click
+ * runs, so frameworks that track the property (React's controlled inputs) never
+ * see a change and silently drop the update. The state is read back afterwards
+ * and a click that did not take throws instead of reporting success.
  * @param {string} selector CSS selector / @ref / loc= / xpath= for the input.
  * @param {boolean} checked Desired checked state.
  * @returns {Promise<void>}
  */
 export async function setChecked(selector, checked) {
-  await resolveAndCall(
-    selector,
-    `function(checked){
-      if (!(this instanceof HTMLInputElement) || (this.type !== "checkbox" && this.type !== "radio")) {
-        throw new Error("setChecked target must be a checkbox or radio input");
-      }
-      if (this.type === "radio" && !checked) {
-        throw new Error("setChecked cannot uncheck a radio input");
-      }
-      if (this.checked === checked) return;
-      this.checked = checked;
-      this.dispatchEvent(new Event("input", { bubbles: true }));
-      this.dispatchEvent(new Event("change", { bubbles: true }));
-    }`,
-    [Boolean(checked)],
-  );
+  const target = Boolean(checked);
+  if ((await readCheckedState(selector, target)) === target) return;
+  await click(selector);
+  if ((await readCheckedState(selector, target)) !== target) {
+    throw new Error(
+      `setChecked: clicking ${JSON.stringify(selector)} did not make it ${target ? "checked" : "unchecked"}`,
+    );
+  }
+}
+
+async function readCheckedState(selector, target: boolean) {
+  const { result } = await resolveAndCall(selector, CHECKED_STATE_SOURCE, [
+    target,
+  ]);
+  return result.result?.value;
 }
 
 /**

--- a/package/ego-browser/src/driver/pointer.test.mjs
+++ b/package/ego-browser/src/driver/pointer.test.mjs
@@ -6,6 +6,7 @@ import {
   click,
   down,
   hover,
+  scrollIntoViewIfNeeded,
   up,
   wheel,
 } from "../../dist/src/driver/pointer.js";
@@ -120,15 +121,90 @@ test("click scrolls a selector into view before resolving its click point", asyn
   }
 
   const scrollIndex = calls.findIndex(
-    (call) =>
-      call.method === "Runtime.callFunctionOn" &&
-      call.params.functionDeclaration.includes("scrollIntoView"),
+    (call) => call.method === "DOM.scrollIntoViewIfNeeded",
   );
   const dispatchIndex = calls.findIndex(
     (call) => call.method === "Input.dispatchMouseEvent",
   );
   assert.ok(scrollIndex >= 0, "scrolls the target into the viewport");
   assert.ok(scrollIndex < dispatchIndex, "scrolls before mouse dispatch");
+});
+
+// The scroll must run browser-side: an in-page scroll is animated under CSS
+// scroll-behavior:smooth unless a style override is injected, and a strict
+// style-src CSP rejects that override. CDP scrolling has neither problem.
+test("scrollIntoViewIfNeeded scrolls through CDP, not page-side JavaScript", async () => {
+  const calls = [];
+  const restore = setOverrides({
+    cdpOverride(method, params) {
+      calls.push({ method, params });
+      if (
+        method === "Runtime.evaluate" &&
+        params.objectGroup === "ego-browser"
+      ) {
+        return { result: { objectId: "object-1" } };
+      }
+      return {};
+    },
+  });
+  try {
+    await scrollIntoViewIfNeeded("#target");
+  } finally {
+    restore();
+  }
+
+  const scroll = calls.find(
+    (call) => call.method === "DOM.scrollIntoViewIfNeeded",
+  );
+  assert.ok(scroll, "scrolls via DOM.scrollIntoViewIfNeeded");
+  assert.equal(scroll.params.objectId, "object-1");
+  assert.ok(
+    !calls.some((call) => call.method === "Runtime.callFunctionOn"),
+    "does not run page-side scroll code on the CDP path",
+  );
+  assert.ok(
+    calls.some(
+      (call) =>
+        call.method === "Runtime.releaseObject" &&
+        call.params.objectId === "object-1",
+    ),
+    "releases the resolved handle",
+  );
+});
+
+test("scrollIntoViewIfNeeded falls back to an in-page scroll when the CDP scroll fails", async () => {
+  const calls = [];
+  const restore = setOverrides({
+    cdpOverride(method, params) {
+      calls.push({ method, params });
+      if (
+        method === "Runtime.evaluate" &&
+        params.objectGroup === "ego-browser"
+      ) {
+        return { result: { objectId: "object-1" } };
+      }
+      if (method === "DOM.scrollIntoViewIfNeeded") {
+        throw new Error("'DOM.scrollIntoViewIfNeeded' wasn't found");
+      }
+      return {};
+    },
+  });
+  try {
+    await scrollIntoViewIfNeeded("#target");
+  } finally {
+    restore();
+  }
+
+  const fallback = calls.find(
+    (call) =>
+      call.method === "Runtime.callFunctionOn" &&
+      call.params.functionDeclaration.includes("scrollIntoView"),
+  );
+  assert.ok(fallback, "scrolls page-side when the CDP scroll is unavailable");
+  assert.match(
+    fallback.params.functionDeclaration,
+    /scroll-behavior:auto !important/,
+  );
 });
 
 test("wheel defaults to scrolling down (positive deltaY) via CDP when visible and focused", async () => {

--- a/package/ego-browser/src/driver/pointer.ts
+++ b/package/ego-browser/src/driver/pointer.ts
@@ -553,13 +553,32 @@ async function dispatchSyntheticWheel(
 /**
  * Scroll an element into view only if it is not already fully visible,
  * mirroring Playwright's locator.scrollIntoViewIfNeeded.
+ *
+ * The scroll is forced to be instant: under CSS `scroll-behavior: smooth` it is
+ * animated instead, and callers that read the element's position right after
+ * this — click() resolving its point, for one — would aim at where the element
+ * used to be. The override covers nested scroll containers too and is removed
+ * before returning.
  * @param {string} selector CSS selector or @ref of the element to reveal.
  * @returns {Promise<void>}
  */
 export async function scrollIntoViewIfNeeded(selector: string) {
   await resolveAndCall(
     selector,
-    "function(){ if (typeof this.scrollIntoViewIfNeeded === 'function') { this.scrollIntoViewIfNeeded(true); } else { this.scrollIntoView({ block: 'center', inline: 'center' }); } }",
+    `function(){
+      const override = document.createElement("style");
+      override.textContent = "*{scroll-behavior:auto !important}";
+      (document.head || document.documentElement).appendChild(override);
+      try {
+        if (typeof this.scrollIntoViewIfNeeded === "function") {
+          this.scrollIntoViewIfNeeded(true);
+        } else {
+          this.scrollIntoView({ block: "center", inline: "center" });
+        }
+      } finally {
+        override.remove();
+      }
+    }`,
   );
 }
 

--- a/package/ego-browser/src/driver/pointer.ts
+++ b/package/ego-browser/src/driver/pointer.ts
@@ -1,7 +1,7 @@
 import { cdp, evaluate } from "../cdp-eval.js";
 import { browserCdp } from "../browser-runtime.js";
 import { elementCenter } from "./observe.js";
-import { resolveAndCall } from "./element-ops.js";
+import { resolveAndCall, withHandle } from "./element-ops.js";
 import { waitForSelector } from "./waits.js";
 
 type MouseButton = "left" | "middle" | "right";
@@ -554,15 +554,32 @@ async function dispatchSyntheticWheel(
  * Scroll an element into view only if it is not already fully visible,
  * mirroring Playwright's locator.scrollIntoViewIfNeeded.
  *
- * The scroll is forced to be instant: under CSS `scroll-behavior: smooth` it is
- * animated instead, and callers that read the element's position right after
- * this — click() resolving its point, for one — would aim at where the element
- * used to be. The override covers nested scroll containers too and is removed
- * before returning.
+ * Scrolls browser-side through CDP DOM.scrollIntoViewIfNeeded, as Playwright
+ * does: the scroll must be instant — under an animated scroll, callers that
+ * read the element's position right after this (click() resolving its point,
+ * for one) would aim at where the element used to be — and the browser-side
+ * scroll stays instant regardless of CSS `scroll-behavior: smooth`, is not
+ * subject to the page's CSP, and moves scroll containers in ancestor
+ * documents. When the CDP method fails (bridge without the DOM domain, no
+ * layout box), it falls back to an in-page scroll under a temporary
+ * scroll-behavior override; a strict `style-src` CSP can reject that override,
+ * which is why the CDP path comes first.
  * @param {string} selector CSS selector or @ref of the element to reveal.
  * @returns {Promise<void>}
  */
 export async function scrollIntoViewIfNeeded(selector: string) {
+  const scrolled = await withHandle(
+    selector,
+    async ({ objectId, sessionId }) => {
+      try {
+        await cdp("DOM.scrollIntoViewIfNeeded", { objectId }, sessionId);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  );
+  if (scrolled) return;
   await resolveAndCall(
     selector,
     `function(){


### PR DESCRIPTION
## Summary

`setChecked` set `this.checked` and dispatched synthetic `input`/`change` events. A property write is not an activation: React derives a controlled input's `onChange` from the **click** event and suppresses it when its value tracker already holds the written value, so the update was dropped. The call still resolved, and the `isChecked()` that followed read back the property that had just been written and confirmed the false result — every signal reported success while nothing had happened.

It now reads the state, clicks the input when it differs, and reads back; a click that did not take throws. `check()` / `uncheck()` are sugar over it and inherit the behaviour. This is what Playwright's `check()` / `setChecked()` do, and it matches every other input path in the driver (`press`, `wheel`, `fill`, `click`), which all prefer trusted CDP input.

## Related issue

No GitHub issue — tracked internally.

## Changes

- `driver/keyboard.ts`: `setChecked` reads the checked state, returns early when it already matches, clicks through `pointer.click()`, and re-reads. A mismatch throws instead of reporting success. Target validation (checkbox/radio only, no radio unchecking) is unchanged and now shared by both reads.
- `driver/pointer.ts`: `scrollIntoViewIfNeeded` forces an instant scroll. Under CSS `scroll-behavior: smooth` the scroll was animated, so `click()` resolved the element's point before it settled and dispatched at the old, off-screen position. This blocked `setChecked` on the ticket rush fixture and silently affects any `click()` on an off-screen target on such pages.
- `driver/keyboard.test.mjs`: the `setChecked` tests assert behaviour — mouse events dispatched, no page-side `checked` assignment, no click when the state already matches, throw when the click leaves the state unchanged — instead of matching the page-side source shape, which pinned the old implementation in place.
- `real-browser-e2e/fixture.mjs` + `cases/keyboard.mjs`: a controlled checkbox and radio group that mirror React's input value tracker. The existing `#checkbox` is uncontrolled, so a property write satisfied it; that gap is why the defect was never caught. Placed below `#scroll-area` so page layout is unchanged for the wheel cases.

## Verification

```text
npm test                       # 309/309
npm run typecheck              # clean
npm run e2e                    # 45/45
```

Reverting only the implementation (keeping the new fixture) fails the new e2e assertion, confirming it guards the defect:

```text
[FAIL] keyboard and file helpers: check drives a controlled checkbox: expected true, got false
```

Real React 18 controlled checkbox, run against this build:

```js
await page.locator('#probe').setChecked(true)
await page.locator('#controlled').setChecked(true)
console.log(JSON.stringify(await page.evaluate('window.__state')))
```

| Observation | Before | After |
| -- | -- | -- |
| `change` event `isTrusted` | `false` | `true` |
| React `onChange` calls | `0` | `1` |
| React component state | `false` | `true` |
| `isChecked()` read-back | `true` (wrong) | `true` (real) |

Known unrelated flake: `concert ticket rush` fails roughly 2 runs in 3 with `confirmed order decrements inventory: expected "1", got "2"`. Reproduced at the same rate on an unmodified `dev` build.

## Impact

- [x] Public helper API or behavior
- [ ] Agent skill or instructions
- [ ] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

Two behaviour changes callers can observe:

1. `setChecked` can now throw where it previously resolved silently. That is the point of the change — the old success was not real — but code that ignored the result may start surfacing errors.
2. `setChecked` inherits `click()`'s pre-click visibility wait. On the widespread "visually hidden input + styled label" idiom (`position:absolute; width:1px; height:1px; opacity:0`) that wait always expires, because ego's visibility test counts `opacity:0` as invisible while Playwright's counts only an empty box or `visibility:hidden`. Measured on the ticket rush fixture: plain `.click()` on such an input takes 10.7s versus 125ms on a visible button, so the case goes from 1.7s to 35s. The wait does not gate anything — the click is dispatched either way — so it is pure latency. Left alone here because aligning that definition with Playwright touches `isVisible` / `isHidden` / `waitForSelector` / `locator.waitFor` together and deserves its own change.

## Checklist

- [x] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained above.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [ ] A release-note label is selected (`feat`, `fix`, `docs`, `chore`, `ci`, or `refactor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
