### PR TITLE
feat(learnings/github): add GitHub site learning pack

### DIFF
--- a/package/ego-browser/src/learning/github-learning.test.mjs
+++ b/package/ego-browser/src/learning/github-learning.test.mjs
@@ -1,0 +1,149 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { cp, mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+import {
+  loadLearnedContext,
+  runNodeSiteTool,
+  validateLearning,
+} from "../../dist/src/learning/index.js";
+
+const packagedGithubDir = fileURLToPath(
+  new URL("../../../../skills/ego-browser/learnings/github", import.meta.url),
+);
+
+// Copy the packaged learning into a temp workspace so the suite runs
+// independently of any package.json module scope above the repository.
+async function tempLearningsRoot() {
+  const root = await mkdtemp(join(tmpdir(), "ego-github-learning-"));
+  await cp(packagedGithubDir, join(root, "github"), { recursive: true });
+  return root;
+}
+
+function stubCtx(attributes = {}) {
+  const opened = [];
+  return {
+    opened,
+    browser: {
+      openOrReuseTab: async (url) => {
+        opened.push(url);
+      },
+    },
+    page: {
+      waitForLoadState: async () => {},
+      waitForSelector: async () => {},
+      locator: (selector) => ({
+        evaluateAll: async () => [],
+        getAttribute: async (name) => attributes[`${selector} ${name}`] ?? null,
+      }),
+    },
+  };
+}
+
+test("github learning pack passes format validation", async () => {
+  const root = await tempLearningsRoot();
+  assert.deepEqual(await validateLearning(join(root, "github")), []);
+});
+
+test("loadLearnedContext surfaces github tools for repository URLs", async () => {
+  const root = await tempLearningsRoot();
+  const context = await loadLearnedContext(
+    "https://github.com/citrolabs/ego-lite",
+    { root },
+  );
+
+  assert.equal(context.exists, true);
+  assert.equal(context.siteId, "github");
+  const toolNames = context.tools.map((tool) => tool.toolName);
+  assert.deepEqual(toolNames.sort(), [
+    "extract_readme",
+    "get_repo_info",
+    "get_trending_repos",
+    "search_repositories",
+  ]);
+});
+
+test("search_repositories requires a query and encodes the search URL", async () => {
+  const root = await tempLearningsRoot();
+  const ctx = stubCtx();
+
+  await assert.rejects(
+    runNodeSiteTool("github", "search_repositories", {}, ctx, { root }),
+    /search query is required/,
+  );
+
+  const results = await runNodeSiteTool(
+    "github",
+    "search_repositories",
+    { query: "browser automation" },
+    ctx,
+    { root },
+  );
+
+  assert.deepEqual(results, []);
+  assert.deepEqual(ctx.opened, [
+    "https://github.com/search?q=browser%20automation&type=repositories",
+  ]);
+});
+
+test("get_repo_info parses exact counts from counter title attributes", async () => {
+  const root = await tempLearningsRoot();
+  const ctx = stubCtx({
+    "#repo-stars-counter-star title": "4,126",
+    "#repo-network-counter title": "312",
+    'meta[property="og:description"] content': " A shared browser. ",
+  });
+
+  const info = await runNodeSiteTool(
+    "github",
+    "get_repo_info",
+    { owner: "citrolabs", repo: "ego-lite" },
+    ctx,
+    { root },
+  );
+
+  assert.deepEqual(info, {
+    name: "citrolabs/ego-lite",
+    url: "https://github.com/citrolabs/ego-lite",
+    description: "A shared browser.",
+    stars: 4126,
+    forks: 312,
+  });
+
+  await assert.rejects(
+    runNodeSiteTool("github", "get_repo_info", { owner: "citrolabs" }, ctx, {
+      root,
+    }),
+    /owner and repo are required/,
+  );
+});
+
+test("get_trending_repos builds the language and window URL", async () => {
+  const root = await tempLearningsRoot();
+  const ctx = stubCtx();
+
+  await runNodeSiteTool(
+    "github",
+    "get_trending_repos",
+    { language: "TypeScript", since: "weekly" },
+    ctx,
+    { root },
+  );
+  await runNodeSiteTool(
+    "github",
+    "get_trending_repos",
+    { since: "hourly" },
+    ctx,
+    {
+      root,
+    },
+  );
+
+  assert.deepEqual(ctx.opened, [
+    "https://github.com/trending/typescript?since=weekly",
+    "https://github.com/trending?since=daily",
+  ]);
+});

--- a/skills/ego-browser/learnings/github/browser-tools/extract-readme.js
+++ b/skills/ego-browser/learnings/github/browser-tools/extract-readme.js
@@ -1,0 +1,11 @@
+async function(args) {
+  const readme = document.querySelector('article.markdown-body');
+  if (!readme) return { error: 'no README rendered on this page' };
+  const maxChars = Number.isFinite(Number(args.maxChars)) && Number(args.maxChars) > 0
+    ? Math.trunc(Number(args.maxChars))
+    : 4000;
+  const headings = [...readme.querySelectorAll('h1, h2, h3')]
+    .map((el) => el.innerText?.trim() || '')
+    .filter(Boolean);
+  return { headings, text: (readme.innerText || '').trim().slice(0, maxChars) };
+}

--- a/skills/ego-browser/learnings/github/manifest.json
+++ b/skills/ego-browser/learnings/github/manifest.json
@@ -1,0 +1,93 @@
+{
+  "id": "github",
+  "name": "GitHub",
+  "domains": ["github.com", "*.github.com"],
+  "notes": ["notes/overview.md"],
+  "nodeTools": {
+    "search_repositories": {
+      "description": "Search GitHub repositories and extract the top results.",
+      "path": "tools/search-repos.js",
+      "callable": "searchRepositories",
+      "args": {
+        "query": {
+          "type": "string",
+          "required": true,
+          "description": "Search query string."
+        },
+        "maxResults": {
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of results to extract."
+        }
+      },
+      "returns": {
+        "type": "array",
+        "description": "Array of {name, url, description} objects."
+      }
+    },
+    "get_repo_info": {
+      "description": "Open a repository page and extract name, description, stars, and forks.",
+      "path": "tools/repo-info.js",
+      "callable": "getRepoInfo",
+      "args": {
+        "owner": {
+          "type": "string",
+          "required": true,
+          "description": "Repository owner (user or organization)."
+        },
+        "repo": {
+          "type": "string",
+          "required": true,
+          "description": "Repository name."
+        }
+      },
+      "returns": {
+        "type": "object",
+        "description": "Object with name, url, description, stars, forks."
+      }
+    },
+    "get_trending_repos": {
+      "description": "Extract repositories from the GitHub trending page.",
+      "path": "tools/trending.js",
+      "callable": "getTrendingRepos",
+      "args": {
+        "language": {
+          "type": "string",
+          "required": false,
+          "description": "Filter by programming language (e.g. typescript)."
+        },
+        "since": {
+          "type": "string",
+          "required": false,
+          "description": "Trending window: daily, weekly, or monthly. Defaults to daily."
+        },
+        "maxResults": {
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of repositories to extract."
+        }
+      },
+      "returns": {
+        "type": "array",
+        "description": "Array of {name, url, description, language, stars} objects."
+      }
+    }
+  },
+  "browserTools": {
+    "extract_readme": {
+      "description": "Extract headings and text from the README rendered on the current repository page.",
+      "path": "browser-tools/extract-readme.js",
+      "args": {
+        "maxChars": {
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of README text characters to return."
+        }
+      },
+      "returns": {
+        "type": "object",
+        "description": "Object with headings array and truncated README text."
+      }
+    }
+  }
+}

--- a/skills/ego-browser/learnings/github/notes/overview.md
+++ b/skills/ego-browser/learnings/github/notes/overview.md
@@ -1,0 +1,42 @@
+# GitHub Overview
+
+## Stable URL patterns
+
+- Repository search: `https://github.com/search?q=<query>&type=repositories`
+- Repository home: `https://github.com/<owner>/<repo>`
+- Trending: `https://github.com/trending/<language>?since=daily|weekly|monthly` (language segment optional)
+- Issues / PRs: prefer URL query filters over UI clicks, e.g. `/issues?q=is%3Aissue+is%3Aopen+label%3Abug`
+- Raw file content: `https://raw.githubusercontent.com/<owner>/<repo>/<branch>/<path>`
+
+## Repository page (server-rendered)
+
+- Star count: `#repo-stars-counter-star` — the `title` attribute holds the exact count (`"4,126"`); the visible text is abbreviated (`"4.1k"`)
+- Fork count: `#repo-network-counter` — same `title` attribute pattern
+- Description: `meta[property="og:description"]` is the most stable source; the About sidebar paragraph has no stable class
+- README: `article.markdown-body` — fully server-rendered, safe to read text from
+
+## Repository search (client-rendered React)
+
+- Results container: `[data-testid="results-list"]`
+- Result title link: `.search-title a` — href is `/owner/repo`
+- Result description: the `span.search-match` outside `.search-title` (the one inside `.search-title` is the repo name)
+- Most other class names are hashed CSS modules (`Repositories-module__resultRow__...`) — never rely on them; stick to `data-testid`, `search-title`, and `search-match`
+- Wait for `[data-testid="results-list"]` before extracting; the list hydrates after document load
+
+## Trending page (server-rendered)
+
+- Repo rows: `article.Box-row`
+- Repo link: `h2 a` — href is `/owner/repo`
+- Description: the `p` element inside the row
+- Language: `span[itemprop="programmingLanguage"]`
+- Stars: text of `a[href$="/stargazers"]`
+
+## Issues and PR lists
+
+- The issue/PR list UI is React-rendered with hashed class names — avoid scraping it
+- Encode filters in the URL `q` parameter instead (`is:issue`, `is:open`, `label:...`, `author:...`)
+
+## Login
+
+- Search, repository pages, and trending all work logged out
+- Writing actions (star, follow, comment, PR review) require the user's login session; hand off to the user if GitHub shows a login or 2FA prompt

--- a/skills/ego-browser/learnings/github/tools/repo-info.js
+++ b/skills/ego-browser/learnings/github/tools/repo-info.js
@@ -1,0 +1,33 @@
+function parseCounter(raw) {
+  const number = Number(String(raw || "").replace(/,/g, "").trim());
+  return Number.isFinite(number) ? number : 0;
+}
+
+export async function getRepoInfo(ctx, args = {}) {
+  const owner = String(args.owner || "").trim();
+  const repo = String(args.repo || "").trim();
+  if (!owner || !repo) throw new Error("owner and repo are required");
+
+  const url = `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+  await ctx.browser.openOrReuseTab(url, { wait: true });
+  await ctx.page.waitForLoadState("load");
+
+  // The title attribute holds the exact count; the visible text is abbreviated.
+  const stars = await ctx.page
+    .locator("#repo-stars-counter-star")
+    .getAttribute("title");
+  const forks = await ctx.page
+    .locator("#repo-network-counter")
+    .getAttribute("title");
+  const description = await ctx.page
+    .locator('meta[property="og:description"]')
+    .getAttribute("content");
+
+  return {
+    name: `${owner}/${repo}`,
+    url,
+    description: (description || "").trim(),
+    stars: parseCounter(stars),
+    forks: parseCounter(forks),
+  };
+}

--- a/skills/ego-browser/learnings/github/tools/search-repos.js
+++ b/skills/ego-browser/learnings/github/tools/search-repos.js
@@ -1,0 +1,39 @@
+function boundedInteger(value, fallback, max) {
+  const number = value === undefined ? fallback : Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.max(1, Math.min(max, Math.trunc(number)));
+}
+
+export async function searchRepositories(ctx, args = {}) {
+  const query = args.query || "";
+  const maxResults = boundedInteger(args.maxResults, 10, 100);
+  if (!query) throw new Error("search query is required");
+
+  await ctx.browser.openOrReuseTab(
+    `https://github.com/search?q=${encodeURIComponent(query)}&type=repositories`,
+    { wait: true },
+  );
+  await ctx.page.waitForLoadState("load");
+  await ctx.page.waitForSelector('[data-testid="results-list"]');
+
+  const results = await ctx.page
+    .locator('[data-testid="results-list"] .search-title')
+    .evaluateAll((titles, limit) => {
+      return titles
+        .slice(0, limit)
+        .map((title) => {
+          const link = title.querySelector("a");
+          const descriptionEl = title
+            .closest("h3")
+            ?.nextElementSibling?.querySelector("span.search-match");
+          return {
+            name: link?.innerText?.trim() || "",
+            url: link?.href || "",
+            description: descriptionEl?.innerText?.trim() || "",
+          };
+        })
+        .filter((r) => r.name);
+    }, maxResults);
+
+  return results;
+}

--- a/skills/ego-browser/learnings/github/tools/trending.js
+++ b/skills/ego-browser/learnings/github/tools/trending.js
@@ -1,0 +1,47 @@
+const TRENDING_WINDOWS = new Set(["daily", "weekly", "monthly"]);
+
+function boundedInteger(value, fallback, max) {
+  const number = value === undefined ? fallback : Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.max(1, Math.min(max, Math.trunc(number)));
+}
+
+export async function getTrendingRepos(ctx, args = {}) {
+  const language = String(args.language || "").trim().toLowerCase();
+  const since = TRENDING_WINDOWS.has(args.since) ? args.since : "daily";
+  const maxResults = boundedInteger(args.maxResults, 25, 25);
+
+  const path = language
+    ? `/trending/${encodeURIComponent(language)}`
+    : "/trending";
+  await ctx.browser.openOrReuseTab(
+    `https://github.com${path}?since=${since}`,
+    { wait: true },
+  );
+  await ctx.page.waitForLoadState("load");
+
+  const repos = await ctx.page
+    .locator("article.Box-row")
+    .evaluateAll((articles, limit) => {
+      return articles
+        .slice(0, limit)
+        .map((el) => {
+          const link = el.querySelector("h2 a");
+          return {
+            name: (link?.getAttribute("href") || "").replace(/^\//, ""),
+            url: link?.href || "",
+            description: el.querySelector("p")?.innerText?.trim() || "",
+            language:
+              el
+                .querySelector('span[itemprop="programmingLanguage"]')
+                ?.innerText?.trim() || "",
+            stars:
+              el.querySelector('a[href$="/stargazers"]')?.innerText?.trim() ||
+              "",
+          };
+        })
+        .filter((r) => r.name);
+    }, maxResults);
+
+  return repos;
+}


### PR DESCRIPTION
## Summary

Adds the `learnings/github` site learning pack. `CONTRIBUTING.md` §7 already recommends copying `learnings/github/` as the template for new packs, but the pack itself does not exist — only `google` and `x-com` do. This fills that gap with a minimal pack covering the highest-traffic read paths on GitHub: repository search, repository info, trending, and README extraction.

## Related issue

No open issue; the pack is the missing template that `CONTRIBUTING.md` §7 ("recommend `learnings/github/`") already points contributors at.

## Changes

- `skills/ego-browser/learnings/github/manifest.json` — declares three Node tools and one browser tool with parameter schemas
- `tools/search-repos.js` — `search_repositories(query, maxResults)` extracts name/url/description from `/search?type=repositories` via `[data-testid="results-list"]`, `.search-title`, and `span.search-match` (the only stable anchors in the React search UI; CSS-module class names are avoided)
- `tools/repo-info.js` — `get_repo_info(owner, repo)` reads exact star/fork counts from the `title` attribute of `#repo-stars-counter-star` / `#repo-network-counter` (visible text is abbreviated, e.g. "4.1k") and the description from `meta[property="og:description"]`
- `tools/trending.js` — `get_trending_repos(language, since, maxResults)` scrapes the server-rendered `/trending` page via `article.Box-row`
- `browser-tools/extract-readme.js` — `extract_readme(maxChars)` returns headings and truncated text from `article.markdown-body` on the current page
- `notes/overview.md` — stable URL patterns and selector map; documents that issue/PR list UIs are React-rendered with hashed class names and should be driven by URL query filters instead
- `package/ego-browser/src/learning/github-learning.test.mjs` — five behavior tests that copy the pack into a temp workspace and run it through `runNodeSiteTool` with a stubbed `ctx` (no real browser), covering format validation, context loading, URL construction/encoding, argument validation, and counter parsing

All selectors were verified against live GitHub HTML (repo page, search results, trending) at authoring time, and only stable anchors are used: element ids, `data-testid`, semantic classes (`search-title`, `search-match`, `Box-row`, `markdown-body`), `itemprop`, and meta tags.

## Verification

```text
npm test                       # 304/304 pass (includes build + typecheck)
npm run validate:site-skills   # site skills ok
```

Example heredoc:

```js
const repos = await site.runTool("github", "search_repositories", { query: "browser automation", maxResults: 5 })
const info = await site.runTool("github", "get_repo_info", { owner: "citrolabs", repo: "ego-lite" })
```

## Impact

- [ ] Public helper API or behavior
- [ ] Agent skill or instructions
- [x] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

New pack only; no existing helper surface or pack is touched.

## Checklist

- [x] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained above.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [x] A release-note label is selected (`feat`, `fix`, `docs`, `chore`, `ci`, or `refactor`).
