### PR TITLE
feat(learnings/hacker-news): add Hacker News site learning pack

### DIFF
--- a/package/ego-browser/src/learning/hacker-news-learning.test.mjs
+++ b/package/ego-browser/src/learning/hacker-news-learning.test.mjs
@@ -1,0 +1,173 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { cp, mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+import {
+  loadLearnedContext,
+  runNodeSiteTool,
+  validateLearning,
+} from "../../dist/src/learning/index.js";
+
+const packagedDir = fileURLToPath(
+  new URL(
+    "../../../../skills/ego-browser/learnings/hacker-news",
+    import.meta.url,
+  ),
+);
+
+// Copy the packaged learning into a temp workspace so the suite runs
+// independently of any package.json module scope above the repository.
+async function tempLearningsRoot() {
+  const root = await mkdtemp(join(tmpdir(), "ego-hn-learning-"));
+  await cp(packagedDir, join(root, "hacker-news"), { recursive: true });
+  return root;
+}
+
+function stubCtx(evaluateResults = {}) {
+  const opened = [];
+  return {
+    opened,
+    browser: {
+      openOrReuseTab: async (url) => {
+        opened.push(url);
+      },
+    },
+    page: {
+      waitForLoadState: async () => {},
+      locator: (selector) => ({
+        evaluateAll: async () => evaluateResults[selector] ?? [],
+      }),
+    },
+  };
+}
+
+test("hacker-news learning pack passes format validation", async () => {
+  const root = await tempLearningsRoot();
+  assert.deepEqual(await validateLearning(join(root, "hacker-news")), []);
+});
+
+test("loadLearnedContext surfaces hacker-news tools for item URLs", async () => {
+  const root = await tempLearningsRoot();
+  const context = await loadLearnedContext(
+    "https://news.ycombinator.com/item?id=1",
+    { root },
+  );
+
+  assert.equal(context.exists, true);
+  assert.equal(context.siteId, "hacker-news");
+  const toolNames = context.tools.map((tool) => tool.toolName);
+  assert.deepEqual(toolNames.sort(), [
+    "extract_comments",
+    "get_item",
+    "get_posts",
+    "search_posts",
+  ]);
+});
+
+test("get_posts falls back to the news feed and bounds the page number", async () => {
+  const root = await tempLearningsRoot();
+  const ctx = stubCtx();
+
+  await runNodeSiteTool(
+    "hacker-news",
+    "get_posts",
+    { feed: "ask", page: 2 },
+    ctx,
+    { root },
+  );
+  await runNodeSiteTool(
+    "hacker-news",
+    "get_posts",
+    { feed: "jobs-invalid", page: 0 },
+    ctx,
+    { root },
+  );
+
+  assert.deepEqual(ctx.opened, [
+    "https://news.ycombinator.com/ask?p=2",
+    "https://news.ycombinator.com/news?p=1",
+  ]);
+});
+
+test("get_item requires a numeric id and builds the item URL", async () => {
+  const root = await tempLearningsRoot();
+  const ctx = stubCtx();
+
+  await assert.rejects(
+    runNodeSiteTool("hacker-news", "get_item", { id: "abc" }, ctx, { root }),
+    /numeric item id is required/,
+  );
+
+  const item = await runNodeSiteTool(
+    "hacker-news",
+    "get_item",
+    { id: "49056112" },
+    ctx,
+    { root },
+  );
+
+  assert.deepEqual(ctx.opened, [
+    "https://news.ycombinator.com/item?id=49056112",
+  ]);
+  assert.equal(item.id, "49056112");
+  assert.deepEqual(item.comments, []);
+});
+
+test("search_posts parses Algolia hits from the response body", async () => {
+  const root = await tempLearningsRoot();
+  const payload = JSON.stringify({
+    hits: [
+      {
+        objectID: 42,
+        title: "A story",
+        url: "https://example.com",
+        author: "pg",
+        points: 100,
+        num_comments: 7,
+        created_at: "2026-07-26T00:00:00Z",
+      },
+      { objectID: 43, title: "Ask HN: no url", author: "dang" },
+    ],
+  });
+  const ctx = stubCtx({ body: payload });
+
+  await assert.rejects(
+    runNodeSiteTool("hacker-news", "search_posts", {}, ctx, { root }),
+    /search query is required/,
+  );
+
+  const results = await runNodeSiteTool(
+    "hacker-news",
+    "search_posts",
+    { query: "browser automation", maxResults: 5 },
+    ctx,
+    { root },
+  );
+
+  assert.deepEqual(ctx.opened, [
+    "https://hn.algolia.com/api/v1/search?query=browser%20automation&tags=story&hitsPerPage=5",
+  ]);
+  assert.deepEqual(results, [
+    {
+      id: "42",
+      title: "A story",
+      url: "https://example.com",
+      author: "pg",
+      points: 100,
+      numComments: 7,
+      createdAt: "2026-07-26T00:00:00Z",
+    },
+    {
+      id: "43",
+      title: "Ask HN: no url",
+      url: "https://news.ycombinator.com/item?id=43",
+      author: "dang",
+      points: 0,
+      numComments: 0,
+      createdAt: "",
+    },
+  ]);
+});

--- a/skills/ego-browser/learnings/hacker-news/browser-tools/extract-comments.js
+++ b/skills/ego-browser/learnings/hacker-news/browser-tools/extract-comments.js
@@ -1,0 +1,13 @@
+async function(args) {
+  const rows = [...document.querySelectorAll('tr.athing.comtr')];
+  if (!rows.length) return { error: 'no comments found on this page' };
+  const maxComments = Number.isFinite(Number(args.maxComments)) && Number(args.maxComments) > 0
+    ? Math.trunc(Number(args.maxComments))
+    : 30;
+  return rows.slice(0, maxComments).map((row) => ({
+    id: row.id || '',
+    author: row.querySelector('a.hnuser')?.innerText?.trim() || '',
+    indent: Number(row.querySelector('td.ind')?.getAttribute('indent') || 0),
+    text: row.querySelector('.commtext')?.innerText?.trim() || '',
+  }));
+}

--- a/skills/ego-browser/learnings/hacker-news/manifest.json
+++ b/skills/ego-browser/learnings/hacker-news/manifest.json
@@ -1,0 +1,93 @@
+{
+  "id": "hacker-news",
+  "name": "Hacker News",
+  "domains": ["news.ycombinator.com", "hn.algolia.com"],
+  "notes": ["notes/overview.md"],
+  "nodeTools": {
+    "get_posts": {
+      "description": "Extract posts from a Hacker News feed page (front page, newest, ask, show, best).",
+      "path": "tools/posts.js",
+      "callable": "getPosts",
+      "args": {
+        "feed": {
+          "type": "string",
+          "required": false,
+          "description": "Feed to read: news, newest, front, ask, show, or best. Defaults to news."
+        },
+        "page": {
+          "type": "integer",
+          "required": false,
+          "description": "1-based feed page number. Defaults to 1."
+        },
+        "maxResults": {
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of posts to extract (a feed page holds 30)."
+        }
+      },
+      "returns": {
+        "type": "array",
+        "description": "Array of {id, rank, title, url, score, author, age, comments} objects."
+      }
+    },
+    "get_item": {
+      "description": "Open a Hacker News item page and extract the story plus its comment thread.",
+      "path": "tools/item.js",
+      "callable": "getItem",
+      "args": {
+        "id": {
+          "type": "string",
+          "required": true,
+          "description": "Numeric Hacker News item id."
+        },
+        "maxComments": {
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of comments to extract."
+        }
+      },
+      "returns": {
+        "type": "object",
+        "description": "Object with title, url, author, score, age, text, and a comments array of {id, author, indent, age, text}."
+      }
+    },
+    "search_posts": {
+      "description": "Search Hacker News stories via the public Algolia API (the on-site search UI is client-rendered).",
+      "path": "tools/search.js",
+      "callable": "searchPosts",
+      "args": {
+        "query": {
+          "type": "string",
+          "required": true,
+          "description": "Search query string."
+        },
+        "maxResults": {
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of stories to return."
+        }
+      },
+      "returns": {
+        "type": "array",
+        "description": "Array of {id, title, url, author, points, numComments, createdAt} objects."
+      }
+    }
+  },
+  "browserTools": {
+    "extract_comments": {
+      "description": "Extract the visible comment thread from the current Hacker News item page.",
+      "path": "browser-tools/extract-comments.js",
+      "args": {
+        "maxComments": {
+          "type": "integer",
+          "required": false,
+          "description": "Maximum number of comments to extract."
+        }
+      },
+      "returns": {
+        "type": "array",
+        "description": "Array of {id, author, indent, text} objects."
+      }
+    }
+  }
+}

--- a/skills/ego-browser/learnings/hacker-news/notes/overview.md
+++ b/skills/ego-browser/learnings/hacker-news/notes/overview.md
@@ -1,0 +1,34 @@
+# Hacker News Overview
+
+## Stable URL patterns
+
+- Feeds: `https://news.ycombinator.com/<feed>?p=<page>` where feed is `news` (front page), `newest`, `front` (past days), `ask`, `show`, or `best`; pages are 1-based with 30 posts each
+- Item (story + comments): `https://news.ycombinator.com/item?id=<id>`
+- User profile: `https://news.ycombinator.com/user?id=<username>`
+- Search API: `https://hn.algolia.com/api/v1/search?query=<q>&tags=story` — the on-site search UI at hn.algolia.com is client-rendered React, but this JSON API is public, documented, and stable
+
+## Feed pages (server-rendered, identical markup across all feeds)
+
+- Post row: `tr.athing.submission` — the `id` attribute is the item id
+- Rank: `span.rank` (text like `1.`)
+- Title and outbound link: `span.titleline > a` (first anchor)
+- Metadata lives in the **next sibling row**, under `td.subtext`:
+  - Score: `span.score` (text like `223 points`)
+  - Author: `a.hnuser`
+  - Age: `span.age` — the `title` attribute holds the exact ISO timestamp plus epoch seconds; the text is relative (`6 hours ago`)
+  - Comment count: the last `a[href^="item?id="]` in the subtext (text like `128 comments`)
+
+## Item pages
+
+- Story header: `.fatitem` — contains the same `titleline` / `score` / `hnuser` / `age` markup as feeds
+- Self-text (Ask HN etc.): `.toptext`
+- Comment rows: `tr.athing.comtr` — `id` attribute is the comment id
+- Comment text: `.commtext`; author: `a.hnuser`
+- Thread depth: `td.ind` has an `indent` attribute (0 = top level)
+- Long threads paginate with a "More" link at the bottom (`a.morelink`)
+
+## Behavior and limits
+
+- The whole site is server-rendered static HTML — no hydration to wait for; `load` state is enough
+- HN rate-limits aggressive fetching ("we're not able to serve your requests this quickly") — navigate at a human pace and avoid tight page loops
+- Reading is fully public; voting, commenting, and flagging require the user's login session — hand off to the user if a login form appears

--- a/skills/ego-browser/learnings/hacker-news/tools/item.js
+++ b/skills/ego-browser/learnings/hacker-news/tools/item.js
@@ -1,0 +1,50 @@
+function boundedInteger(value, fallback, max) {
+  const number = value === undefined ? fallback : Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.max(1, Math.min(max, Math.trunc(number)));
+}
+
+export async function getItem(ctx, args = {}) {
+  const id = String(args.id || "").trim();
+  if (!/^\d+$/.test(id)) throw new Error("a numeric item id is required");
+  const maxComments = boundedInteger(args.maxComments, 30, 100);
+
+  await ctx.browser.openOrReuseTab(
+    `https://news.ycombinator.com/item?id=${id}`,
+    { wait: true },
+  );
+  await ctx.page.waitForLoadState("load");
+
+  const story = await ctx.page.locator(".fatitem").evaluateAll((items) => {
+    const el = items[0];
+    if (!el) return {};
+    const titleLink = el.querySelector("span.titleline > a");
+    return {
+      title: titleLink?.innerText?.trim() || "",
+      url: titleLink?.href || "",
+      author: el.querySelector("a.hnuser")?.innerText?.trim() || "",
+      score: el.querySelector("span.score")?.innerText?.trim() || "",
+      age: el.querySelector("span.age")?.getAttribute("title") || "",
+      text: el.querySelector(".toptext")?.innerText?.trim() || "",
+    };
+  });
+
+  const comments = await ctx.page
+    .locator("tr.athing.comtr")
+    .evaluateAll((rows, limit) => {
+      return rows
+        .slice(0, limit)
+        .map((row) => ({
+          id: row.id || "",
+          author: row.querySelector("a.hnuser")?.innerText?.trim() || "",
+          indent: Number(
+            row.querySelector("td.ind")?.getAttribute("indent") || 0,
+          ),
+          age: row.querySelector("span.age")?.getAttribute("title") || "",
+          text: row.querySelector(".commtext")?.innerText?.trim() || "",
+        }))
+        .filter((c) => c.text);
+    }, maxComments);
+
+  return { id, ...story, comments };
+}

--- a/skills/ego-browser/learnings/hacker-news/tools/posts.js
+++ b/skills/ego-browser/learnings/hacker-news/tools/posts.js
@@ -1,0 +1,50 @@
+const FEEDS = new Set(["news", "newest", "front", "ask", "show", "best"]);
+
+function boundedInteger(value, fallback, max) {
+  const number = value === undefined ? fallback : Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.max(1, Math.min(max, Math.trunc(number)));
+}
+
+export async function getPosts(ctx, args = {}) {
+  const feed = FEEDS.has(args.feed) ? args.feed : "news";
+  const page = boundedInteger(args.page, 1, 20);
+  const maxResults = boundedInteger(args.maxResults, 30, 30);
+
+  await ctx.browser.openOrReuseTab(
+    `https://news.ycombinator.com/${feed}?p=${page}`,
+    { wait: true },
+  );
+  await ctx.page.waitForLoadState("load");
+
+  const posts = await ctx.page
+    .locator("tr.athing.submission")
+    .evaluateAll((rows, limit) => {
+      return rows
+        .slice(0, limit)
+        .map((row) => {
+          const titleLink = row.querySelector("span.titleline > a");
+          const subtext = row.nextElementSibling?.querySelector("td.subtext");
+          const commentsLink = [
+            ...(subtext?.querySelectorAll('a[href^="item?id="]') || []),
+          ].pop();
+          return {
+            id: row.id || "",
+            rank:
+              row
+                .querySelector("span.rank")
+                ?.innerText?.replace(".", "")
+                .trim() || "",
+            title: titleLink?.innerText?.trim() || "",
+            url: titleLink?.href || "",
+            score: subtext?.querySelector("span.score")?.innerText?.trim() || "",
+            author: subtext?.querySelector("a.hnuser")?.innerText?.trim() || "",
+            age: subtext?.querySelector("span.age")?.getAttribute("title") || "",
+            comments: commentsLink?.innerText?.trim() || "",
+          };
+        })
+        .filter((p) => p.title);
+    }, maxResults);
+
+  return posts;
+}

--- a/skills/ego-browser/learnings/hacker-news/tools/search.js
+++ b/skills/ego-browser/learnings/hacker-news/tools/search.js
@@ -1,0 +1,40 @@
+function boundedInteger(value, fallback, max) {
+  const number = value === undefined ? fallback : Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.max(1, Math.min(max, Math.trunc(number)));
+}
+
+export async function searchPosts(ctx, args = {}) {
+  const query = String(args.query || "").trim();
+  if (!query) throw new Error("search query is required");
+  const maxResults = boundedInteger(args.maxResults, 10, 50);
+
+  await ctx.browser.openOrReuseTab(
+    `https://hn.algolia.com/api/v1/search?query=${encodeURIComponent(query)}&tags=story&hitsPerPage=${maxResults}`,
+    { wait: true },
+  );
+  await ctx.page.waitForLoadState("load");
+
+  const raw = await ctx.page
+    .locator("body")
+    .evaluateAll((bodies) => bodies[0]?.innerText || "");
+
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    throw new Error(
+      "unexpected search response; hn.algolia.com may be unavailable",
+    );
+  }
+
+  return (payload.hits || []).map((hit) => ({
+    id: String(hit.objectID || ""),
+    title: hit.title || "",
+    url: hit.url || `https://news.ycombinator.com/item?id=${hit.objectID}`,
+    author: hit.author || "",
+    points: hit.points ?? 0,
+    numComments: hit.num_comments ?? 0,
+    createdAt: hit.created_at || "",
+  }));
+}


### PR DESCRIPTION
## Summary

Adds a `learnings/hacker-news` site learning pack. Hacker News is a common target for agent research tasks ("what's on HN about X", "summarize this thread"), and its server-rendered markup has been stable for years, making it a low-maintenance pack. This complements the existing `google` and `x-com` packs (and the `github` pack proposed in #152) with no changes to any existing code.

## Related issue

No open issue; new site learnings are explicitly welcomed by `CONTRIBUTING.md` ("Issues, PRs, and new site learnings are all welcome").

## Changes

- `skills/ego-browser/learnings/hacker-news/manifest.json` — declares three Node tools and one browser tool with parameter schemas
- `tools/posts.js` — `get_posts(feed, page, maxResults)` extracts posts from any feed (`news`, `newest`, `front`, `ask`, `show`, `best` — all share identical `tr.athing.submission` + `td.subtext` markup), pairing each row with its sibling metadata row; exact timestamps come from the `title` attribute of `span.age`
- `tools/item.js` — `get_item(id, maxComments)` extracts the story (`.fatitem`, including `.toptext` self-text) and the comment thread (`tr.athing.comtr`, with depth from the `indent` attribute of `td.ind`)
- `tools/search.js` — `search_posts(query, maxResults)` uses the public Algolia API (`hn.algolia.com/api/v1/search`) through a browser tab, since the on-site search UI is client-rendered React; response JSON is parsed Node-side with defensive error handling
- `browser-tools/extract-comments.js` — `extract_comments(maxComments)` extracts the visible comment thread from the current item page in place
- `notes/overview.md` — stable URL patterns and selector map; notes the identical cross-feed markup, HN's rate limiting, and that reading is public while voting/commenting needs the user's login
- `package/ego-browser/src/learning/hacker-news-learning.test.mjs` — five behavior tests that copy the pack into a temp workspace and run it through `runNodeSiteTool` with a stubbed `ctx` (no real browser), covering format validation, context loading, feed fallback and page bounding, id validation, and Algolia response parsing

All selectors were verified against live Hacker News HTML (front page, `newest`, `ask`, and an item page with a 128-comment thread) at authoring time.

## Verification

```text
npm test                       # 311/311 pass (includes build + typecheck)
npm run validate:site-skills   # site skills ok
```

Example heredoc:

```js
const posts = await site.runTool("hacker-news", "get_posts", { feed: "ask", maxResults: 10 })
const thread = await site.runTool("hacker-news", "get_item", { id: posts[0].id })
const hits = await site.runTool("hacker-news", "search_posts", { query: "browser automation" })
```

## Impact

- [ ] Public helper API or behavior
- [ ] Agent skill or instructions
- [x] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

New pack only; no existing helper surface or pack is touched. Independent of #152 — the two packs share no files and can land in either order.

## Checklist

- [x] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained above.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [x] A release-note label is selected (`feat`, `fix`, `docs`, `chore`, `ci`, or `refactor`).
