### PR TITLE
feat(ego-browser): validate browser-tool sources parse as a function

### DIFF
--- a/package/ego-browser/src/learning/index.ts
+++ b/package/ego-browser/src/learning/index.ts
@@ -191,9 +191,7 @@ export async function loadBrowserToolSource(
   return readFile(toolPath, "utf8");
 }
 
-export function wrapBrowserTool(source, args: any = {}) {
-  return `(async () => { const __egoBrowserTool = ${source}; return await __egoBrowserTool(${JSON.stringify(args || {})}); })()`;
-}
+export { wrapBrowserTool } from "./wrap-browser-tool.js";
 
 export { learningEntry };
 

--- a/package/ego-browser/src/learning/validate-learning-format.test.mjs
+++ b/package/ego-browser/src/learning/validate-learning-format.test.mjs
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { validateLearning } from "../../dist/src/learning/index.js";
+
+async function writePack(browserToolSource) {
+  const root = await mkdtemp(join(tmpdir(), "ego-validate-"));
+  const siteDir = join(root, "example");
+  await mkdir(join(siteDir, "notes"), { recursive: true });
+  await mkdir(join(siteDir, "browser-tools"));
+  await writeFile(
+    join(siteDir, "manifest.json"),
+    JSON.stringify({
+      id: "example",
+      name: "Example",
+      domains: ["example.com"],
+      notes: ["notes/overview.md"],
+      browserTools: {
+        active_item: {
+          description: "Read the active item.",
+          path: "browser-tools/active-item.js",
+          args: {},
+          returns: {
+            type: "object",
+            description: "Active item object.",
+          },
+        },
+      },
+    }),
+  );
+  await writeFile(join(siteDir, "notes/overview.md"), "# Example\n");
+  await writeFile(
+    join(siteDir, "browser-tools/active-item.js"),
+    browserToolSource,
+  );
+  return siteDir;
+}
+
+test("accepts an anonymous async function browser tool", async () => {
+  const siteDir = await writePack(
+    "async function(args) { return { ok: true }; }\n",
+  );
+  assert.deepEqual(await validateLearning(siteDir), []);
+});
+
+test("accepts an arrow function browser tool", async () => {
+  const siteDir = await writePack("async (args) => ({ ok: true })\n");
+  assert.deepEqual(await validateLearning(siteDir), []);
+});
+
+test("reports a browser tool that does not parse", async () => {
+  const siteDir = await writePack("async function(args) { return oops(( }\n");
+  const errors = await validateLearning(siteDir);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /cannot parse "browser-tools\/active-item\.js"/);
+});
+
+test("reports a browser tool that is not a function expression", async () => {
+  const siteDir = await writePack("({ run: (args) => args })\n");
+  const errors = await validateLearning(siteDir);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /must contain a single function expression/);
+});

--- a/package/ego-browser/src/learning/validate-learning-format.ts
+++ b/package/ego-browser/src/learning/validate-learning-format.ts
@@ -5,10 +5,17 @@ import { isAbsolute, join } from "node:path";
 import {
   iterLearningDirs,
   learningsRoot,
-  pathExists
+  pathExists,
 } from "./check-domain-learning.js";
 
-const TOOL_VALUE_TYPES = new Set(["string", "number", "integer", "boolean", "array", "object"]);
+const TOOL_VALUE_TYPES = new Set([
+  "string",
+  "number",
+  "integer",
+  "boolean",
+  "array",
+  "object",
+]);
 const TEMP_REF_RE = /(?:@\d+\b|\bref=\d+\b)/;
 
 export async function validateLearning(siteDir: string) {
@@ -44,41 +51,93 @@ export async function validateLearning(siteDir: string) {
 
   for (const note of asStringList(manifest, "notes", errors, siteId)) {
     if (!isNotePath(note)) {
-      errors.push(`${siteId}: notes must point to notes/*.md: ${JSON.stringify(note)}`);
+      errors.push(
+        `${siteId}: notes must point to notes/*.md: ${JSON.stringify(note)}`,
+      );
       continue;
     }
-    await requireFile(siteDir, note, `${siteId}: missing note ${JSON.stringify(note)}`, errors);
-    await rejectTemporaryRefs(siteDir, note, `${siteId}: note ${JSON.stringify(note)}`, errors);
+    await requireFile(
+      siteDir,
+      note,
+      `${siteId}: missing note ${JSON.stringify(note)}`,
+      errors,
+    );
+    await rejectTemporaryRefs(
+      siteDir,
+      note,
+      `${siteId}: note ${JSON.stringify(note)}`,
+      errors,
+    );
   }
 
-  const nodeTools: Record<string, any> = validateToolMap(manifest, "nodeTools", errors, siteId);
+  const nodeTools: Record<string, any> = validateToolMap(
+    manifest,
+    "nodeTools",
+    errors,
+    siteId,
+  );
   for (const [toolName, schema] of Object.entries(nodeTools)) {
     if (!schema || typeof schema !== "object" || !isNodeToolPath(schema.path)) {
       continue;
     }
     const toolPath = join(siteDir, schema.path);
-    if (!await pathExists(toolPath)) {
-      errors.push(`${siteId}: missing Node tool file ${JSON.stringify(schema.path)} for tool ${JSON.stringify(toolName)}`);
+    if (!(await pathExists(toolPath))) {
+      errors.push(
+        `${siteId}: missing Node tool file ${JSON.stringify(schema.path)} for tool ${JSON.stringify(toolName)}`,
+      );
       continue;
     }
-    await rejectTemporaryRefs(siteDir, schema.path, `${siteId}: Node tool ${JSON.stringify(toolName)}`, errors);
+    await rejectTemporaryRefs(
+      siteDir,
+      schema.path,
+      `${siteId}: Node tool ${JSON.stringify(toolName)}`,
+      errors,
+    );
     try {
-      const module = await import(`${pathToFileURL(toolPath).href}?validate=${Date.now()}`);
-      if (typeof schema.callable === "string" && typeof module[schema.callable] !== "function") {
-        errors.push(`${siteId}: missing Node callable ${JSON.stringify(schema.callable)} for tool ${JSON.stringify(toolName)}`);
+      const module = await import(
+        `${pathToFileURL(toolPath).href}?validate=${Date.now()}`
+      );
+      if (
+        typeof schema.callable === "string" &&
+        typeof module[schema.callable] !== "function"
+      ) {
+        errors.push(
+          `${siteId}: missing Node callable ${JSON.stringify(schema.callable)} for tool ${JSON.stringify(toolName)}`,
+        );
       }
     } catch (error) {
-      errors.push(`${siteId}: cannot import Node tool ${JSON.stringify(schema.path)}: ${error.message}`);
+      errors.push(
+        `${siteId}: cannot import Node tool ${JSON.stringify(schema.path)}: ${error.message}`,
+      );
     }
   }
 
-  const browserTools: Record<string, any> = validateToolMap(manifest, "browserTools", errors, siteId);
+  const browserTools: Record<string, any> = validateToolMap(
+    manifest,
+    "browserTools",
+    errors,
+    siteId,
+  );
   for (const [toolName, schema] of Object.entries(browserTools)) {
-    if (!schema || typeof schema !== "object" || !isBrowserToolPath(schema.path)) {
+    if (
+      !schema ||
+      typeof schema !== "object" ||
+      !isBrowserToolPath(schema.path)
+    ) {
       continue;
     }
-    await requireFile(siteDir, schema.path, `${siteId}: missing browser tool file ${JSON.stringify(schema.path)} for tool ${JSON.stringify(toolName)}`, errors);
-    await rejectTemporaryRefs(siteDir, schema.path, `${siteId}: browser tool ${JSON.stringify(toolName)}`, errors);
+    await requireFile(
+      siteDir,
+      schema.path,
+      `${siteId}: missing browser tool file ${JSON.stringify(schema.path)} for tool ${JSON.stringify(toolName)}`,
+      errors,
+    );
+    await rejectTemporaryRefs(
+      siteDir,
+      schema.path,
+      `${siteId}: browser tool ${JSON.stringify(toolName)}`,
+      errors,
+    );
   }
 
   return errors;
@@ -87,7 +146,7 @@ export async function validateLearning(siteDir: string) {
 export async function validateLearnings(root = learningsRoot()) {
   const errors: string[] = [];
   for (const siteDir of await iterLearningDirs(root)) {
-    errors.push(...await validateLearning(siteDir));
+    errors.push(...(await validateLearning(siteDir)));
   }
   return errors;
 }
@@ -96,14 +155,22 @@ export const validateSiteSkills = validateLearnings;
 
 function asStringList(manifest, key, errors: string[], siteId: string) {
   const value = manifest[key] || [];
-  if (!Array.isArray(value) || !value.every((item) => typeof item === "string" && item.trim())) {
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === "string" && item.trim())
+  ) {
     errors.push(`${siteId}: ${key} must be a list of non-empty strings`);
     return [];
   }
   return value;
 }
 
-function validateToolMap(manifest, key, errors: string[], siteId: string): Record<string, any> {
+function validateToolMap(
+  manifest,
+  key,
+  errors: string[],
+  siteId: string,
+): Record<string, any> {
   const value = manifest[key] || {};
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     errors.push(`${siteId}: ${key} must be an object keyed by tool name`);
@@ -115,10 +182,18 @@ function validateToolMap(manifest, key, errors: string[], siteId: string): Recor
   return value;
 }
 
-function validateToolSchema(siteId: string, key: string, toolName: string, schema, errors: string[]) {
+function validateToolSchema(
+  siteId: string,
+  key: string,
+  toolName: string,
+  schema,
+  errors: string[],
+) {
   const prefix = `${siteId}: ${key}.${toolName}`;
   if (!isSafeToolName(toolName)) {
-    errors.push(`${siteId}: ${key} contains invalid tool name ${JSON.stringify(toolName)}`);
+    errors.push(
+      `${siteId}: ${key} contains invalid tool name ${JSON.stringify(toolName)}`,
+    );
     return;
   }
   if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
@@ -139,31 +214,61 @@ function validateToolSchema(siteId: string, key: string, toolName: string, schem
     errors.push(`${prefix}: path must be a relative browser-tools/*.js path`);
   }
 
-  if (!schema.args || typeof schema.args !== "object" || Array.isArray(schema.args)) {
+  if (
+    !schema.args ||
+    typeof schema.args !== "object" ||
+    Array.isArray(schema.args)
+  ) {
     errors.push(`${prefix}: args must be an object`);
   } else {
     for (const [argName, argSchema] of Object.entries(schema.args)) {
       if (typeof argName !== "string" || !argName.trim()) {
-        errors.push(`${prefix}: args contains invalid argument name ${JSON.stringify(argName)}`);
+        errors.push(
+          `${prefix}: args contains invalid argument name ${JSON.stringify(argName)}`,
+        );
         continue;
       }
-      validateValueSchema(`${prefix}.args.${argName}`, argSchema, errors, true, "arg");
+      validateValueSchema(
+        `${prefix}.args.${argName}`,
+        argSchema,
+        errors,
+        true,
+        "arg",
+      );
     }
   }
-  if (!schema.returns || typeof schema.returns !== "object" || Array.isArray(schema.returns)) {
+  if (
+    !schema.returns ||
+    typeof schema.returns !== "object" ||
+    Array.isArray(schema.returns)
+  ) {
     errors.push(`${prefix}: returns must be an object`);
   } else {
-    validateValueSchema(`${prefix}.returns`, schema.returns, errors, false, "return");
+    validateValueSchema(
+      `${prefix}.returns`,
+      schema.returns,
+      errors,
+      false,
+      "return",
+    );
   }
 }
 
-function validateValueSchema(prefix: string, schema, errors: string[], requireRequired: boolean, typeLabel: string) {
+function validateValueSchema(
+  prefix: string,
+  schema,
+  errors: string[],
+  requireRequired: boolean,
+  typeLabel: string,
+) {
   if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
     errors.push(`${prefix}: schema must be an object`);
     return;
   }
   if (!TOOL_VALUE_TYPES.has(schema.type)) {
-    errors.push(`${prefix}: invalid ${typeLabel} type ${JSON.stringify(schema.type)}`);
+    errors.push(
+      `${prefix}: invalid ${typeLabel} type ${JSON.stringify(schema.type)}`,
+    );
   }
   if (requireRequired && typeof schema.required !== "boolean") {
     errors.push(`${prefix}: required must be a boolean`);
@@ -177,27 +282,43 @@ function isValidDomain(pattern) {
   if (typeof pattern !== "string" || !pattern) {
     return false;
   }
-  if (pattern.includes("://") || pattern.includes("/") || pattern.startsWith(".") || pattern.endsWith(".")) {
+  if (
+    pattern.includes("://") ||
+    pattern.includes("/") ||
+    pattern.startsWith(".") ||
+    pattern.endsWith(".")
+  ) {
     return false;
   }
   if (pattern.includes("*")) {
-    return pattern.startsWith("*.") && pattern.indexOf("*") === pattern.lastIndexOf("*") && pattern.length > 2;
+    return (
+      pattern.startsWith("*.") &&
+      pattern.indexOf("*") === pattern.lastIndexOf("*") &&
+      pattern.length > 2
+    );
   }
   return true;
 }
 
 function isSafeToolName(name) {
-  return typeof name === "string"
-    && Boolean(name)
-    && !name.includes("/")
-    && !name.includes("\\")
-    && name !== "."
-    && name !== ".."
-    && !name.includes("..");
+  return (
+    typeof name === "string" &&
+    Boolean(name) &&
+    !name.includes("/") &&
+    !name.includes("\\") &&
+    name !== "." &&
+    name !== ".." &&
+    !name.includes("..")
+  );
 }
 
 function isSafeRelativePath(path) {
-  if (typeof path !== "string" || !path || path.includes("\\") || isAbsolute(path)) {
+  if (
+    typeof path !== "string" ||
+    !path ||
+    path.includes("\\") ||
+    isAbsolute(path)
+  ) {
     return false;
   }
   return path.split("/").every((part) => part && part !== "." && part !== "..");
@@ -215,16 +336,30 @@ function isNodeToolPath(path) {
 
 function isBrowserToolPath(path) {
   const parts = isSafeRelativePath(path) ? path.split("/") : [];
-  return parts.length === 2 && parts[0] === "browser-tools" && parts[1].endsWith(".js");
+  return (
+    parts.length === 2 &&
+    parts[0] === "browser-tools" &&
+    parts[1].endsWith(".js")
+  );
 }
 
-async function requireFile(siteDir: string, relativePath: string, message: string, errors: string[]) {
-  if (!await pathExists(join(siteDir, relativePath))) {
+async function requireFile(
+  siteDir: string,
+  relativePath: string,
+  message: string,
+  errors: string[],
+) {
+  if (!(await pathExists(join(siteDir, relativePath)))) {
     errors.push(message);
   }
 }
 
-async function rejectTemporaryRefs(siteDir: string, relativePath: string, prefix: string, errors: string[]) {
+async function rejectTemporaryRefs(
+  siteDir: string,
+  relativePath: string,
+  prefix: string,
+  errors: string[],
+) {
   let text;
   try {
     text = await readFile(join(siteDir, relativePath), "utf8");
@@ -232,6 +367,8 @@ async function rejectTemporaryRefs(siteDir: string, relativePath: string, prefix
     return;
   }
   if (TEMP_REF_RE.test(text)) {
-    errors.push(`${prefix}: contains temporary snapshot ref; use stable locators instead`);
+    errors.push(
+      `${prefix}: contains temporary snapshot ref; use stable locators instead`,
+    );
   }
 }

--- a/package/ego-browser/src/learning/validate-learning-format.ts
+++ b/package/ego-browser/src/learning/validate-learning-format.ts
@@ -2,6 +2,10 @@ import { pathToFileURL } from "node:url";
 import { readFile } from "node:fs/promises";
 import { isAbsolute, join } from "node:path";
 
+import { parse } from "acorn";
+
+import { wrapBrowserTool } from "./wrap-browser-tool.js";
+
 import {
   iterLearningDirs,
   learningsRoot,
@@ -138,9 +142,57 @@ export async function validateLearning(siteDir: string) {
       `${siteId}: browser tool ${JSON.stringify(toolName)}`,
       errors,
     );
+    await validateBrowserToolSource(
+      siteDir,
+      schema.path,
+      `${siteId}: browser tool ${JSON.stringify(toolName)}`,
+      errors,
+    );
   }
 
   return errors;
+}
+
+async function validateBrowserToolSource(
+  siteDir: string,
+  relativePath: string,
+  prefix: string,
+  errors: string[],
+) {
+  let source;
+  try {
+    source = await readFile(join(siteDir, relativePath), "utf8");
+  } catch {
+    return;
+  }
+  let program;
+  try {
+    // Parse exactly what runSiteBrowserTool will evaluate in the page.
+    program = parse(wrapBrowserTool(source, {}), { ecmaVersion: "latest" });
+  } catch (error) {
+    errors.push(
+      `${prefix}: cannot parse ${JSON.stringify(relativePath)}: ${error.message}`,
+    );
+    return;
+  }
+  if (!isFunctionExpression(browserToolInit(program))) {
+    errors.push(
+      `${prefix}: ${JSON.stringify(relativePath)} must contain a single function expression`,
+    );
+  }
+}
+
+function browserToolInit(program) {
+  const wrapperBody = program?.body?.[0]?.expression?.callee?.body?.body;
+  const declaration = wrapperBody?.[0]?.declarations?.[0];
+  return declaration?.id?.name === "__egoBrowserTool" ? declaration.init : null;
+}
+
+function isFunctionExpression(node) {
+  return (
+    node?.type === "FunctionExpression" ||
+    node?.type === "ArrowFunctionExpression"
+  );
 }
 
 export async function validateLearnings(root = learningsRoot()) {

--- a/package/ego-browser/src/learning/wrap-browser-tool.ts
+++ b/package/ego-browser/src/learning/wrap-browser-tool.ts
@@ -1,0 +1,3 @@
+export function wrapBrowserTool(source, args: any = {}) {
+  return `(async () => { const __egoBrowserTool = ${source}; return await __egoBrowserTool(${JSON.stringify(args || {})}); })()`;
+}


### PR DESCRIPTION
## Summary

Site-skill validation is asymmetric: Node tools are actually imported (so syntax errors and missing callables are caught), but browser tools are only checked for file existence and temporary snapshot refs. A browser tool with a syntax error — or a file that isn't a function at all — passes `npm run validate:site-skills` and only fails later, at runtime, inside the page. This PR closes that gap by parsing exactly what `runSiteBrowserTool` will evaluate.

## Related issue

No open issue. The gap surfaced while authoring new learning packs (#152, #153): the validator is the contribution gate for packs, so it should catch a broken browser tool before it ships.

## Changes

- `src/learning/validate-learning-format.ts` — new `validateBrowserToolSource()` step in the browser-tools loop: parses `wrapBrowserTool(source, {})` with acorn (`ecmaVersion: "latest"`) and reports `cannot parse ...` on syntax errors; then requires the source to be a single `FunctionExpression`/`ArrowFunctionExpression` (the shape every existing pack uses and the shape the wrapper's `await __egoBrowserTool(args)` call assumes), reporting `must contain a single function expression` otherwise
- `src/learning/wrap-browser-tool.ts` — `wrapBrowserTool` moved here (verbatim) so the validator can share the runtime wrapper without creating an import cycle with `learning/index.ts`; the public export is preserved via a re-export, so `helpers.ts` and downstream imports are unchanged
- `src/learning/validate-learning-format.test.mjs` — new test file (the validator had no dedicated tests): accepts anonymous async functions and arrow functions, rejects a syntax error, rejects a non-function expression
- No new dependencies — acorn is already the package's only runtime dependency

The first commit is a prettier-only reformat of `validate-learning-format.ts` with no code changes: the file predates the quality-gates style check, which rejects any PR touching a file that is not prettier-clean. Review the second commit for the actual change.

## Verification

```text
npm test                       # 310/310 pass (includes build + typecheck)
npm run validate:site-skills   # site skills ok — all existing packs pass the new check
```

Quick repro of the previous gap: put `async function(args) { return oops(( }` in any pack's `browser-tools/*.js` — before this change `validate:site-skills` reports ok; after, it reports `cannot parse "browser-tools/....js": Unexpected token (1:...)`.

## Impact

- [ ] Public helper API or behavior
- [ ] Agent skill or instructions
- [x] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

Validation-time only; runtime behavior is unchanged. Strictly stricter validation: a hypothetical pack whose browser tool is a non-function expression that evaluates to a function at runtime (e.g. an IIFE returning a function) would now be rejected — no existing pack does this, and the single-function shape is what SKILL docs and all packs use.

## Checklist

- [x] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained above.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [x] A release-note label is selected (`feat`, `fix`, `docs`, `chore`, `ci`, or `refactor`).
