### PR TITLE
feat(ego-browser): add first-class JS dialog helpers

### DIFF
--- a/package/ego-browser/src/driver/dialogs.test.mjs
+++ b/package/ego-browser/src/driver/dialogs.test.mjs
@@ -1,0 +1,200 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  clearPreferredTarget,
+  drainBrowserEvents,
+  invalidateSession,
+} from "../../dist/src/browser-runtime.js";
+import { state } from "../../dist/src/state.js";
+import {
+  acceptDialog,
+  dialog,
+  dismissDialog,
+  waitForDialog,
+} from "../../dist/src/driver/dialogs.js";
+import { waitForEvent } from "../../dist/src/driver/downloads.js";
+
+function installAutoEgo(options = {}) {
+  const calls = [];
+  globalThis.ego = {
+    async listTabs() {
+      return { tabs: [{ targetId: "tab-1", active: true }] };
+    },
+    sendCDPMessage(payload) {
+      const parsed = JSON.parse(payload);
+      calls.push(parsed);
+      setTimeout(() => {
+        const result =
+          parsed.method === "Target.attachToTarget"
+            ? { sessionId: `sess-${parsed.id}` }
+            : {};
+        globalThis.ego?.onCDPMessage?.(
+          JSON.stringify({ id: parsed.id, result }),
+        );
+      }, 0);
+    },
+  };
+  return calls;
+}
+
+function fireEvent(method, params = {}, sessionId = "sess-1") {
+  globalThis.ego.onCDPMessage(JSON.stringify({ method, params, sessionId }));
+}
+
+function cleanup() {
+  delete globalThis.ego;
+  invalidateSession();
+  clearPreferredTarget();
+  drainBrowserEvents();
+}
+
+test("dialog() returns null when no dialog is pending", async () => {
+  installAutoEgo();
+  try {
+    assert.equal(await dialog(), null);
+  } finally {
+    cleanup();
+  }
+});
+
+test("dialog() returns pending dialog info", async () => {
+  installAutoEgo();
+  try {
+    assert.equal(await dialog(), null);
+    fireEvent(
+      "Page.javascriptDialogOpening",
+      {
+        type: "alert",
+        message: "Hello",
+        url: "https://example.com/",
+      },
+      state.sessionId,
+    );
+    assert.deepEqual(await dialog(), {
+      type: "alert",
+      message: "Hello",
+      url: "https://example.com/",
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test("acceptDialog sends Page.handleJavaScriptDialog with accept true", async () => {
+  const calls = installAutoEgo();
+  try {
+    await acceptDialog();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const handleCall = calls.find(
+      (call) => call.method === "Page.handleJavaScriptDialog",
+    );
+    assert.ok(handleCall, "sends handleJavaScriptDialog");
+    assert.deepEqual(handleCall.params, { accept: true });
+  } finally {
+    cleanup();
+  }
+});
+
+test("acceptDialog sends promptText for prompt dialogs", async () => {
+  const calls = installAutoEgo();
+  try {
+    await acceptDialog("typed value");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const handleCall = calls.find(
+      (call) => call.method === "Page.handleJavaScriptDialog",
+    );
+    assert.deepEqual(handleCall.params, {
+      accept: true,
+      promptText: "typed value",
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test("dismissDialog sends Page.handleJavaScriptDialog with accept false", async () => {
+  const calls = installAutoEgo();
+  try {
+    await dismissDialog();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const handleCall = calls.find(
+      (call) => call.method === "Page.handleJavaScriptDialog",
+    );
+    assert.deepEqual(handleCall.params, { accept: false });
+  } finally {
+    cleanup();
+  }
+});
+
+test("waitForDialog resolves when a dialog opens", async () => {
+  installAutoEgo();
+  try {
+    const promise = waitForDialog({ timeout: 1000 });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    fireEvent("Page.javascriptDialogOpening", {
+      type: "confirm",
+      message: "Continue?",
+      url: "https://example.com/confirm",
+    });
+    assert.deepEqual(await promise, {
+      type: "confirm",
+      message: "Continue?",
+      url: "https://example.com/confirm",
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test("waitForDialog returns immediately when a dialog is already pending", async () => {
+  installAutoEgo();
+  try {
+    assert.equal(await dialog(), null);
+    fireEvent(
+      "Page.javascriptDialogOpening",
+      {
+        type: "prompt",
+        message: "Name?",
+        url: "https://example.com/prompt",
+        defaultPrompt: "guest",
+      },
+      state.sessionId,
+    );
+    assert.deepEqual(await waitForDialog({ timeout: 1000 }), {
+      type: "prompt",
+      message: "Name?",
+      url: "https://example.com/prompt",
+      defaultPrompt: "guest",
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test("waitForEvent('dialog') delegates to waitForDialog", async () => {
+  installAutoEgo();
+  try {
+    const promise = waitForEvent("dialog", { timeout: 1000 });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    fireEvent("Page.javascriptDialogOpening", {
+      type: "alert",
+      message: "Delegated",
+      url: "https://example.com/",
+    });
+    assert.deepEqual(await promise, {
+      type: "alert",
+      message: "Delegated",
+      url: "https://example.com/",
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test("waitForEvent rejects unsupported event names", async () => {
+  await assert.rejects(
+    waitForEvent("popup", { timeout: 1000 }),
+    /supports only "download" and "dialog"/,
+  );
+});

--- a/package/ego-browser/src/driver/dialogs.ts
+++ b/package/ego-browser/src/driver/dialogs.ts
@@ -1,0 +1,97 @@
+import { cdp } from "../cdp-eval.js";
+import {
+  ensureSession,
+  isBrowserRuntime,
+  pendingDialog,
+  waitForBrowserEvent,
+} from "../browser-runtime.js";
+import { state } from "../state.js";
+
+type DialogInfo = {
+  type: string;
+  message: string;
+  url: string;
+  defaultPrompt?: string;
+};
+
+type WaitForDialogOptions = {
+  timeout?: number;
+};
+
+type DialogOpeningEvent = {
+  method: "Page.javascriptDialogOpening";
+  params?: {
+    type?: string;
+    message?: string;
+    url?: string;
+    defaultPrompt?: string;
+  };
+};
+
+function formatDialog(params): DialogInfo | null {
+  if (!params) {
+    return null;
+  }
+  const info: DialogInfo = {
+    type: params.type,
+    message: params.message ?? "",
+    url: params.url ?? "",
+  };
+  if (params.defaultPrompt !== undefined) {
+    info.defaultPrompt = params.defaultPrompt;
+  }
+  return info;
+}
+
+/**
+ * Return the currently pending JavaScript dialog, if any.
+ * @returns {Promise<{type:string,message:string,url:string,defaultPrompt?:string}|null>}
+ */
+export async function dialog() {
+  if (isBrowserRuntime()) {
+    await ensureSession();
+  }
+  return formatDialog(pendingDialog());
+}
+
+/**
+ * Accept the pending JavaScript dialog.
+ * @param {string} [promptText] Optional prompt input for prompt dialogs.
+ * @returns {Promise<void>}
+ */
+export async function acceptDialog(promptText?) {
+  const params: any = { accept: true };
+  if (promptText !== undefined) {
+    params.promptText = promptText;
+  }
+  await cdp("Page.handleJavaScriptDialog", params);
+}
+
+/**
+ * Dismiss the pending JavaScript dialog.
+ * @returns {Promise<void>}
+ */
+export async function dismissDialog() {
+  await cdp("Page.handleJavaScriptDialog", { accept: false });
+}
+
+/**
+ * Wait for a JavaScript dialog to open.
+ * @param {{timeout?: number}} [options] Timeout in milliseconds.
+ * @returns {Promise<{type:string,message:string,url:string,defaultPrompt?:string}>}
+ */
+export async function waitForDialog(options: WaitForDialogOptions = {}) {
+  const timeout = options.timeout ?? state.defaultTimeout;
+  if (isBrowserRuntime()) {
+    await ensureSession();
+  }
+  const existing = formatDialog(pendingDialog());
+  if (existing) {
+    return existing;
+  }
+  const event = (await waitForBrowserEvent(
+    (evt) => evt?.method === "Page.javascriptDialogOpening",
+    timeout,
+  )) as DialogOpeningEvent;
+  return formatDialog(event?.params || pendingDialog());
+}

--- a/package/ego-browser/src/driver/downloads.ts
+++ b/package/ego-browser/src/driver/downloads.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { cdp } from "../cdp-eval.js";
 import { ensureSession, waitForBrowserEvent } from "../browser-runtime.js";
 import { state } from "../state.js";
+import { waitForDialog } from "./dialogs.js";
 
 type WaitForEventOptions = {
   timeout?: number;
@@ -29,21 +30,24 @@ type DownloadProgress = {
 };
 
 /**
- * Wait for a Playwright-style page event. Currently supports "download".
- * @param {"download"} eventName Event name.
+ * Wait for a Playwright-style page event. Supports "download" and "dialog".
+ * @param {"download"|"dialog"} eventName Event name.
  * @param {{timeout?: number}} [options] Timeout in milliseconds.
- * @returns {Promise<object>} Download facade with suggestedFilename(), path(), saveAs(path), url().
+ * @returns {Promise<object>} Event-specific result.
  */
 export async function waitForEvent(
   eventName,
   options: WaitForEventOptions = {},
 ) {
-  if (eventName !== "download") {
-    throw new Error(
-      `page.waitForEvent currently supports only "download", got ${JSON.stringify(eventName)}`,
-    );
+  if (eventName === "download") {
+    return waitForDownload(options);
   }
-  return waitForDownload(options);
+  if (eventName === "dialog") {
+    return waitForDialog(options);
+  }
+  throw new Error(
+    `page.waitForEvent currently supports only "download" and "dialog", got ${JSON.stringify(eventName)}`,
+  );
 }
 
 async function waitForDownload(options: WaitForEventOptions = {}) {

--- a/package/ego-browser/src/format.ts
+++ b/package/ego-browser/src/format.ts
@@ -357,13 +357,13 @@ const FUNCTION_DOCS: Record<string, FunctionDoc> = {
   },
   "page.waitForEvent": {
     signature: "page.waitForEvent(eventName, options?) => Promise<any>",
-    description: "Wait for a page event. Currently useful for download events.",
+    description: "Wait for a page event. Supports download and dialog events.",
     params: [
       {
         name: "eventName",
         type: "string",
         required: true,
-        description: "Event name, such as download.",
+        description: 'Event name, such as "download" or "dialog".',
       },
       {
         name: "options",
@@ -373,6 +373,46 @@ const FUNCTION_DOCS: Record<string, FunctionDoc> = {
     ],
     returns: "Promise<any>",
     example: "const download = await page.waitForEvent('download')",
+  },
+  "page.dialog": {
+    signature: "page.dialog() => Promise<DialogInfo | null>",
+    description:
+      "Return the currently pending JavaScript dialog, if any. Returns null when no dialog is open.",
+    returns: "Promise<{ type, message, url, defaultPrompt? } | null>",
+    example: "const open = await page.dialog()",
+  },
+  "page.acceptDialog": {
+    signature: "page.acceptDialog(promptText?) => Promise<void>",
+    description: "Accept the pending JavaScript dialog.",
+    params: [
+      {
+        name: "promptText",
+        type: "string",
+        description: "Optional input for prompt dialogs.",
+      },
+    ],
+    returns: "Promise<void>",
+    example: "await page.acceptDialog()",
+  },
+  "page.dismissDialog": {
+    signature: "page.dismissDialog() => Promise<void>",
+    description: "Dismiss the pending JavaScript dialog.",
+    returns: "Promise<void>",
+    example: "await page.dismissDialog()",
+  },
+  "page.waitForDialog": {
+    signature: "page.waitForDialog(options?) => Promise<DialogInfo>",
+    description:
+      "Wait for a JavaScript dialog to open. Returns immediately when a dialog is already pending.",
+    params: [
+      {
+        name: "options",
+        type: "{ timeout?: number }",
+        description: "Timeout in milliseconds.",
+      },
+    ],
+    returns: "Promise<{ type, message, url, defaultPrompt? }>",
+    example: "const dialog = await page.waitForDialog({ timeout: 5000 })",
   },
   "page.evaluate": {
     signature: "page.evaluate(expression) => Promise<any>",

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -14,6 +14,7 @@ import * as observe from "./driver/observe.js";
 import * as waits from "./driver/waits.js";
 import * as files from "./driver/files.js";
 import * as downloads from "./driver/downloads.js";
+import * as dialogs from "./driver/dialogs.js";
 import * as screencast from "./driver/screencast.js";
 import { browserFetch, serverFetch } from "./http.js";
 import {
@@ -97,6 +98,12 @@ export {
   waitForResponse,
 } from "./driver/waits.js";
 export { setInputFiles } from "./driver/files.js";
+export {
+  dialog,
+  acceptDialog,
+  dismissDialog,
+  waitForDialog,
+} from "./driver/dialogs.js";
 export { startScreencast, stopScreencast } from "./driver/screencast.js";
 export { browserFetch, serverFetch } from "./http.js";
 
@@ -728,6 +735,10 @@ function createPageFacade() {
     waitForRequest: waits.waitForRequest,
     waitForResponse: waits.waitForResponse,
     waitForEvent: downloads.waitForEvent,
+    dialog: dialogs.dialog,
+    acceptDialog: dialogs.acceptDialog,
+    dismissDialog: dialogs.dismissDialog,
+    waitForDialog: dialogs.waitForDialog,
     evaluate,
     screenshot: observe.screenshot,
     snapshot: observe.snapshot,
@@ -807,7 +818,7 @@ function createSiteFacade() {
 }
 
 const FACADE_HELP: Record<string, string> = {
-  page: 'page: Playwright-style page facade. page.url() asynchronously returns the current URL; always call await page.url() before using the string. Use page.goto(url), page.locator(selector), page.getByText(text), page.getByLabel(text), page.getByPlaceholder(text), page.getByTestId(testId), page.setDefaultTimeout(ms), page.waitForEvent("download"), page.waitForLoadState(state, options), page.waitForURL(url, options), page.waitForRequest(urlOrPredicate, options), page.waitForResponse(urlOrPredicate, options), page.evaluate(expression), page.screenshot(options), page.screencast.start({ path, size, quality }), page.screencast.stop(), page.keyboard.press(key), page.keyboard.type(text), and page.mouse.click(x, y). waitForURL predicates receive URL objects and waitUntil defaults to load.',
+  page: 'page: Playwright-style page facade. page.url() asynchronously returns the current URL; always call await page.url() before using the string. Use page.goto(url), page.locator(selector), page.getByText(text), page.getByLabel(text), page.getByPlaceholder(text), page.getByTestId(testId), page.setDefaultTimeout(ms), page.waitForEvent("download"), page.waitForEvent("dialog"), page.dialog(), page.acceptDialog(promptText?), page.dismissDialog(), page.waitForDialog(options), page.waitForLoadState(state, options), page.waitForURL(url, options), page.waitForRequest(urlOrPredicate, options), page.waitForResponse(urlOrPredicate, options), page.evaluate(expression), page.screenshot(options), page.screencast.start({ path, size, quality }), page.screencast.stop(), page.keyboard.press(key), page.keyboard.type(text), and page.mouse.click(x, y). waitForURL predicates receive URL objects and waitUntil defaults to load.',
   locator:
     "page.locator(selector): returns a strict, auto-waiting locator facade with locator(), getByRole(), getByText(), filter(), first(), nth(index), last(), click(), hover(), dragTo(target), scrollIntoViewIfNeeded(), fill(value), clear(), press(key), check(), selectOption(value), textContent(), innerText(), innerHTML(), isVisible(), isEnabled(), getAttribute(name), screenshot(), count(), evaluate(fn, arg), evaluateAll(fn, arg), and waitFor(options). Narrow multiple matches; use first()/nth() only for confirmed legitimate duplicates.",
   browser:

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -47,7 +47,7 @@ The heredoc body runs as a Node.js script that controls the selected ego-browser
 Notes:
 - `cliLog(value)` — prints to the terminal; it is the only output mechanism inside a heredoc, and all final results must go through it.
 - `await pageInfo()` — normally resolves to `{ url, title, w, h, sx, sy, pw, ph }`; if a native browser dialog is open, resolves to `{ dialog: ... }` instead because page JavaScript is blocked.
-- If `await pageInfo()` resolves to `{ dialog: ... }`, handle the dialog with `await cdp('Page.handleJavaScriptDialog', { accept: true })` or `accept: false` before running page JavaScript.
+- If `await pageInfo()` resolves to `{ dialog: ... }`, handle the dialog with `await page.acceptDialog()` or `await page.dismissDialog()` (or `await page.waitForDialog()` when waiting for one) before running page JavaScript.
 - `await ensureRealTab()` — switches to an existing non-internal page tab if needed and resolves to it; resolves to `null` when none exists. It does not create a tab — use `await openOrReuseTab(...)` for that.
 - `await closeTab(target?)` — closes the given target id / tab object, or the current tab when omitted.
 - `await drainEvents()` — consumes and returns the async event queue produced by the page (navigation events, network events, etc.).


### PR DESCRIPTION
## Summary
- Adds `page.dialog()`, `page.acceptDialog()`, `page.dismissDialog()`, and `page.waitForDialog()` so agents no longer need raw CDP for JS alerts/confirms/prompts
- Extends `page.waitForEvent("dialog")` to match the existing download event pattern
- Documents the helpers in `help()` / SKILL.md and covers them with unit tests

## Test plan
- [x] `cd package/ego-browser && npm test`
- [x] Smoke with a live page that opens `alert` / `confirm` / `prompt` and accept/dismiss via the new helpers
- [x] Confirm `page.info()` dialog short-circuit still works, then clear with `acceptDialog` / `dismissDialog`