### PR TITLE
feat(ego-browser): add token-efficient snapshot filter options

### DIFF
--- a/package/ego-browser/src/driver/observe.ts
+++ b/package/ego-browser/src/driver/observe.ts
@@ -20,8 +20,12 @@ import {
   ensureRefMapForRef,
   registerSnapshotForRefRefresh,
 } from "../ref-state.js";
+import {
+  filterSnapshotContent,
+  type SnapshotFilterOptions,
+} from "./snapshot-filter.js";
 
-type SnapshotOptions = {
+export type SnapshotOptions = SnapshotFilterOptions & {
   scope?: "only_within_viewport" | "full_page";
   includeActionMarks?: boolean;
   includeStableLocator?: boolean;
@@ -42,6 +46,26 @@ type ScreenshotOptions = {
   clip?: ScreenshotClip;
 };
 
+function egoSnapshotOptions(options: SnapshotOptions = {}) {
+  const {
+    interactiveOnly: _interactiveOnly,
+    roles: _roles,
+    match: _match,
+    maxChars: _maxChars,
+    ...egoOptions
+  } = options;
+  return egoOptions;
+}
+
+function filterOptions(options: SnapshotOptions = {}): SnapshotFilterOptions {
+  return {
+    interactiveOnly: options.interactiveOnly,
+    roles: options.roles,
+    match: options.match,
+    maxChars: options.maxChars,
+  };
+}
+
 export function drainEvents() {
   return drainBrowserEvents();
 }
@@ -49,7 +73,7 @@ export function drainEvents() {
 export async function snapshotRaw(options: SnapshotOptions = {}) {
   let result;
   try {
-    result = await browserEgo().snapshot(options);
+    result = await browserEgo().snapshot(egoSnapshotOptions(options));
   } catch (err) {
     // ego.snapshot rejects directly (it never resolves with { error }), so it never
     // reached buildEgoError — the single birthplace that records a hard stop for the
@@ -59,6 +83,13 @@ export async function snapshotRaw(options: SnapshotOptions = {}) {
     throw buildEgoError(err, "snapshot");
   }
   browserSnapshotRefsToRefMap(browserRefMap, result.refs || []);
+  const filters = filterOptions(options);
+  if (result.content != null) {
+    result = {
+      ...result,
+      content: filterSnapshotContent(result.content, filters),
+    };
+  }
   return result;
 }
 
@@ -67,7 +98,7 @@ registerSnapshotForRefRefresh(() => snapshotRaw());
 /**
  * Return snapshot content with agent-friendly defaults. The text surface most
  * agents want; use snapshotRaw when you need the structured { content, refs }.
- * @param {{scope?: "only_within_viewport"|"full_page", includeActionMarks?: boolean, includeStableLocator?: boolean}} [options]
+ * @param {{scope?: "only_within_viewport"|"full_page", includeActionMarks?: boolean, includeStableLocator?: boolean, interactiveOnly?: boolean, roles?: string[], match?: string|RegExp, maxChars?: number}} [options]
  * @returns {Promise<string>}
  */
 export async function snapshot(options: SnapshotOptions = {}) {
@@ -75,6 +106,10 @@ export async function snapshot(options: SnapshotOptions = {}) {
     scope: options.scope ?? "full_page",
     includeActionMarks: options.includeActionMarks ?? true,
     includeStableLocator: options.includeStableLocator ?? true,
+    interactiveOnly: options.interactiveOnly,
+    roles: options.roles,
+    match: options.match,
+    maxChars: options.maxChars,
   });
   return result.content || "";
 }
@@ -137,3 +172,8 @@ export async function screenshot(options: ScreenshotOptions = {}) {
   await state.writeFile(path, Buffer.from(result.data, "base64"));
   return path;
 }
+
+export {
+  filterSnapshotContent,
+  type SnapshotFilterOptions,
+} from "./snapshot-filter.js";

--- a/package/ego-browser/src/driver/snapshot-filter.test.mjs
+++ b/package/ego-browser/src/driver/snapshot-filter.test.mjs
@@ -1,0 +1,152 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { filterSnapshotContent } from "../../dist/src/driver/snapshot-filter.js";
+import { snapshot, snapshotRaw } from "../../dist/src/driver/observe.js";
+import { invalidateSession } from "../../dist/src/browser-runtime.js";
+
+const SAMPLE_SNAPSHOT = `Page: Example Shop
+URL: https://example.com/shop
+  Static paragraph about shipping
+  banner "Site header" [ref=1, loc=role:banner]
+  link "Home" [ref=10, loc=role:link[name="Home"]]
+  button "Add to cart" [ref=42, loc=role:button[name="Add to cart"]]
+  textbox "Search" [ref=55, loc=role:textbox[name="Search"]]
+  heading "Featured products" [ref=5, loc=role:heading[name="Featured products"]]
+  Static ad: Buy now and save 50%
+  checkbox "Subscribe" [ref=60, loc=role:checkbox[name="Subscribe"]]`;
+
+function withSnapshotEgo(content, fn) {
+  const previous = globalThis.ego;
+  globalThis.ego = {
+    async snapshot() {
+      return {
+        content,
+        refs: [
+          { backendNodeId: 10, role: "link", name: "Home" },
+          { backendNodeId: 42, role: "button", name: "Add to cart" },
+          { backendNodeId: 55, role: "textbox", name: "Search" },
+          { backendNodeId: 60, role: "checkbox", name: "Subscribe" },
+        ],
+      };
+    },
+  };
+  invalidateSession();
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      invalidateSession();
+      if (previous === undefined) {
+        delete globalThis.ego;
+      } else {
+        globalThis.ego = previous;
+      }
+    });
+}
+
+test("filterSnapshotContent interactiveOnly keeps interactive and heading refs", () => {
+  const filtered = filterSnapshotContent(SAMPLE_SNAPSHOT, {
+    interactiveOnly: true,
+  });
+  assert.match(filtered, /Page: Example Shop/);
+  assert.match(filtered, /URL: https:\/\/example.com\/shop/);
+  assert.match(filtered, /link "Home"/);
+  assert.match(filtered, /button "Add to cart"/);
+  assert.match(filtered, /textbox "Search"/);
+  assert.match(filtered, /heading "Featured products"/);
+  assert.match(filtered, /checkbox "Subscribe"/);
+  assert.match(filtered, /banner "Site header"/);
+  assert.doesNotMatch(filtered, /Static paragraph/);
+  assert.doesNotMatch(filtered, /Static ad/);
+});
+
+test("filterSnapshotContent roles keeps only matching roles", () => {
+  const filtered = filterSnapshotContent(SAMPLE_SNAPSHOT, {
+    roles: ["button", "link"],
+  });
+  assert.match(filtered, /Page: Example Shop/);
+  assert.match(filtered, /link "Home"/);
+  assert.match(filtered, /button "Add to cart"/);
+  assert.doesNotMatch(filtered, /textbox "Search"/);
+  assert.doesNotMatch(filtered, /checkbox "Subscribe"/);
+});
+
+test("filterSnapshotContent match string is case-insensitive", () => {
+  const filtered = filterSnapshotContent(SAMPLE_SNAPSHOT, {
+    match: "ADD TO",
+  });
+  assert.match(filtered, /button "Add to cart"/);
+  assert.equal(filtered.split("\n").length, 3);
+});
+
+test("filterSnapshotContent match regex keeps matching lines", () => {
+  const filtered = filterSnapshotContent(SAMPLE_SNAPSHOT, {
+    match: /textbox|checkbox/i,
+  });
+  assert.match(filtered, /textbox "Search"/);
+  assert.match(filtered, /checkbox "Subscribe"/);
+  assert.doesNotMatch(filtered, /button "Add to cart"/);
+});
+
+test("filterSnapshotContent maxChars truncates with omission note", () => {
+  const filtered = filterSnapshotContent(SAMPLE_SNAPSHOT, { maxChars: 40 });
+  assert.ok(filtered.length > 40);
+  assert.match(filtered, /… truncated \(\d+ chars omitted for maxChars=40\)$/);
+});
+
+test("filterSnapshotContent returns content unchanged when no filters set", () => {
+  assert.equal(filterSnapshotContent(SAMPLE_SNAPSHOT), SAMPLE_SNAPSHOT);
+  assert.equal(filterSnapshotContent(""), "");
+});
+
+test("snapshot applies interactiveOnly filter to text output", async () => {
+  await withSnapshotEgo(SAMPLE_SNAPSHOT, async () => {
+    const text = await snapshot({ interactiveOnly: true });
+    assert.match(text, /button "Add to cart"/);
+    assert.doesNotMatch(text, /Static ad/);
+  });
+});
+
+test("snapshotRaw filters content but preserves refs", async () => {
+  await withSnapshotEgo(SAMPLE_SNAPSHOT, async () => {
+    const raw = await snapshotRaw({ roles: ["link"] });
+    assert.match(raw.content, /link "Home"/);
+    assert.doesNotMatch(raw.content, /button "Add to cart"/);
+    assert.equal(raw.refs.length, 4);
+  });
+});
+
+test("snapshot passes ego options without filter keys", async () => {
+  let receivedOptions;
+  const previous = globalThis.ego;
+  globalThis.ego = {
+    async snapshot(options) {
+      receivedOptions = options;
+      return {
+        content: "Page: Test\n  button [ref=1, loc=role:button]",
+        refs: [],
+      };
+    },
+  };
+  invalidateSession();
+  try {
+    await snapshot({
+      scope: "only_within_viewport",
+      includeActionMarks: false,
+      interactiveOnly: true,
+      maxChars: 100,
+    });
+    assert.deepEqual(receivedOptions, {
+      scope: "only_within_viewport",
+      includeActionMarks: false,
+      includeStableLocator: true,
+    });
+  } finally {
+    invalidateSession();
+    if (previous === undefined) {
+      delete globalThis.ego;
+    } else {
+      globalThis.ego = previous;
+    }
+  }
+});

--- a/package/ego-browser/src/driver/snapshot-filter.ts
+++ b/package/ego-browser/src/driver/snapshot-filter.ts
@@ -1,0 +1,147 @@
+export type SnapshotFilterOptions = {
+  interactiveOnly?: boolean;
+  roles?: string[];
+  match?: string | RegExp;
+  maxChars?: number;
+};
+
+const INTERACTIVE_ROLES = new Set([
+  "button",
+  "link",
+  "textbox",
+  "checkbox",
+  "radio",
+  "combobox",
+  "menuitem",
+  "tab",
+  "switch",
+  "searchbox",
+  "slider",
+  "spinbutton",
+  "option",
+]);
+
+const LANDMARK_ROLES = new Set([
+  "heading",
+  "banner",
+  "complementary",
+  "contentinfo",
+  "form",
+  "main",
+  "navigation",
+  "region",
+  "search",
+]);
+
+function lineRoleMatches(line: string, role: string): boolean {
+  const normalized = role.toLowerCase();
+  const rolePattern = new RegExp(`\\brole=${normalized}\\b`, "i");
+  const locPattern = new RegExp(
+    `loc=role:${normalized}(?:\\[|[,\\s\\]]|$)`,
+    "i",
+  );
+  return rolePattern.test(line) || locPattern.test(line);
+}
+
+function lineHasRef(line: string): boolean {
+  return /\[ref=|\bref=\d+/.test(line);
+}
+
+function lineMatchesPattern(line: string, match: string | RegExp): boolean {
+  if (typeof match === "string") {
+    return line.toLowerCase().includes(match.toLowerCase());
+  }
+  return match.test(line);
+}
+
+function lineMatchesInteractiveOnly(line: string): boolean {
+  for (const role of INTERACTIVE_ROLES) {
+    if (lineRoleMatches(line, role)) return true;
+  }
+  if (!lineHasRef(line)) return false;
+  for (const role of LANDMARK_ROLES) {
+    if (lineRoleMatches(line, role)) return true;
+  }
+  return false;
+}
+
+function isMetadataHeaderLine(line: string): boolean {
+  const trimmed = line.trim();
+  return /^(Page:|URL:|Title:|Snapshot:)/i.test(trimmed);
+}
+
+function splitHeaderLines(lines: string[]): {
+  header: string[];
+  body: string[];
+} {
+  const header: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "") {
+      if (header.length > 0) header.push(line);
+      continue;
+    }
+    if (isMetadataHeaderLine(line)) {
+      header.push(line);
+      continue;
+    }
+    return { header, body: lines.slice(i) };
+  }
+  return { header, body: [] };
+}
+
+function hasLineFilters(options: SnapshotFilterOptions): boolean {
+  return Boolean(
+    options.interactiveOnly ||
+    (options.roles && options.roles.length > 0) ||
+    options.match != null,
+  );
+}
+
+function shouldKeepLine(line: string, options: SnapshotFilterOptions): boolean {
+  if (options.interactiveOnly && !lineMatchesInteractiveOnly(line)) {
+    return false;
+  }
+  if (options.roles?.length) {
+    const matchesRole = options.roles.some((role) =>
+      lineRoleMatches(line, role),
+    );
+    if (!matchesRole) return false;
+  }
+  if (options.match != null && !lineMatchesPattern(line, options.match)) {
+    return false;
+  }
+  return true;
+}
+
+function truncateContent(content: string, maxChars: number): string {
+  if (content.length <= maxChars) return content;
+  const omitted = content.length - maxChars;
+  return `${content.slice(0, maxChars)}\n… truncated (${omitted} chars omitted for maxChars=${maxChars})`;
+}
+
+/**
+ * Post-process snapshot text to drop non-actionable lines and optionally cap size.
+ */
+export function filterSnapshotContent(
+  content: string,
+  options: SnapshotFilterOptions = {},
+): string {
+  if (!content) return content;
+  if (!hasLineFilters(options) && options.maxChars == null) {
+    return content;
+  }
+
+  let filtered = content;
+  if (hasLineFilters(options)) {
+    const lines = content.split("\n");
+    const { header, body } = splitHeaderLines(lines);
+    const keptBody = body.filter((line) => shouldKeepLine(line, options));
+    filtered = [...header, ...keptBody].join("\n");
+  }
+
+  if (options.maxChars != null) {
+    filtered = truncateContent(filtered, options.maxChars);
+  }
+  return filtered;
+}

--- a/package/ego-browser/src/format.ts
+++ b/package/ego-browser/src/format.ts
@@ -407,17 +407,24 @@ const FUNCTION_DOCS: Record<string, FunctionDoc> = {
       {
         name: "options",
         type: "object",
-        description: "Snapshot options such as scope.",
+        description:
+          "Snapshot options: scope, includeActionMarks, includeStableLocator, interactiveOnly, roles, match, maxChars.",
       },
     ],
     returns: "Promise<string>",
-    example: "console.log(await page.snapshot())",
+    example: "console.log(await page.snapshot({ interactiveOnly: true }))",
   },
   "page.snapshotRaw": {
     signature: "page.snapshotRaw(options?) => Promise<object>",
-    description: "Return the raw structured snapshot object.",
+    description:
+      "Return the raw structured snapshot object (content filtered when filter options are set; refs unchanged).",
     params: [
-      { name: "options", type: "object", description: "Snapshot options." },
+      {
+        name: "options",
+        type: "object",
+        description:
+          "Snapshot options: scope, includeActionMarks, includeStableLocator, interactiveOnly, roles, match, maxChars.",
+      },
     ],
     returns: "Promise<object>",
     example: "console.log(await page.snapshotRaw())",

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -198,6 +198,7 @@ These workflows can be combined. A task may take multiple heredoc rounds when th
 
 - `wait(...)` and `timeout` values are in **seconds**; only parameters whose names end in `Ms` are milliseconds.
 - `snapshotText()` defaults to `scope: 'full_page'`, covering the whole page. Use the default in almost every case; only pass `scope: 'only_within_viewport'` when the task needs only visible content.
+- Pass filter options to shrink noisy snapshots: `interactiveOnly: true` keeps buttons/links/form controls (plus heading/landmark lines with refs); `roles: ['button','link']` keeps matching roles; `match: 'checkout'` or a regex keeps matching lines; `maxChars` truncates with an omission note. Filters apply to snapshot text only — refs stay intact in the ref map.
 - `@N` refs are only valid for the most recent `snapshotText` call — every call rebuilds the refMap. Ref numbers come from the CDP `backendNodeId`, so the same element keeps the same number across calls; but to use `@N`, N must appear in the latest snapshotText output. An element scrolled out of the viewport, a DOM re-render, or a previous call with `scope:'only_within_viewport'` that didn't cover the element will all cause `Unknown ref`. For elements you need to reference long-term, use the `loc=...` value from snapshotText output as a stable selector, or write a CSS selector directly.
 - `js()` returns the evaluated result, not a JSON string — don't wrap it with `JSON.parse(...)`.
 - Inside a `js(...)` template string, regex backslashes must be doubled (e.g. `\\d`, `\\s`), or use `String.raw`.


### PR DESCRIPTION
## Summary
- Adds optional snapshot filters: `interactiveOnly`, `roles`, `match`, and `maxChars` to cut agent token use on large pages
- Pure post-processing on snapshot text — defaults unchanged; `snapshotRaw` filters `content` only and leaves `refs` intact
- Documents options in `help()` / SKILL.md with unit coverage for filter behavior

## Test plan
- [x] `cd package/ego-browser && npm test`
- [x] On a content-heavy site, compare `await page.snapshot()` vs `await page.snapshot({ interactiveOnly: true })` size
- [x] Verify `maxChars` truncation note appears and refs still work for kept lines