### PR TITLE
feat(ego-browser): add retryOnTransient and soft expect helpers

### DIFF
--- a/package/ego-browser/src/driver/expect.test.mjs
+++ b/package/ego-browser/src/driver/expect.test.mjs
@@ -1,0 +1,350 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  browserCdp,
+  invalidateSession,
+} from "../../dist/src/browser-runtime.js";
+import { ElementResolutionError } from "../../dist/src/element-resolver.js";
+import { setOverrides } from "../../dist/src/state.js";
+import { helperContext } from "../../dist/src/helpers.js";
+import {
+  expectHidden,
+  expectText,
+  expectUrl,
+  expectValue,
+  expectVisible,
+  isTransientError,
+  retryOnTransient,
+} from "../../dist/src/driver/expect.js";
+
+function withCdpRuntime(fn) {
+  const previous = globalThis.ego;
+  const runtime = {
+    async listTabs() {
+      return {
+        tabs: [
+          {
+            targetId: "target-1",
+            active: true,
+            title: "Example",
+            url: "https://example.com/",
+          },
+        ],
+      };
+    },
+    sendCDPMessage(payload) {
+      const request = JSON.parse(payload);
+      let result = {};
+      if (request.method === "Target.attachToTarget") {
+        result = { sessionId: "session-1" };
+      } else if (request.method === "Runtime.evaluate") {
+        result = {
+          result: {
+            value: JSON.stringify({
+              url: "https://example.com/",
+              title: "Example",
+              w: 800,
+              h: 600,
+              sx: 0,
+              sy: 0,
+              pw: 800,
+              ph: 1200,
+            }),
+          },
+        };
+      }
+      queueMicrotask(() =>
+        runtime.onCDPMessage(JSON.stringify({ id: request.id, result })),
+      );
+    },
+    emit(method, params) {
+      runtime.onCDPMessage(
+        JSON.stringify({ sessionId: "session-1", method, params }),
+      );
+    },
+  };
+  globalThis.ego = runtime;
+  invalidateSession();
+  return Promise.resolve()
+    .then(() => fn({ runtime }))
+    .finally(() => {
+      invalidateSession();
+      if (previous === undefined) {
+        delete globalThis.ego;
+      } else {
+        globalThis.ego = previous;
+      }
+    });
+}
+
+test("isTransientError classifies ElementResolutionError and message patterns", () => {
+  assert.equal(
+    isTransientError(
+      new ElementResolutionError("Unknown ref: 12", "transient"),
+    ),
+    true,
+  );
+  assert.equal(
+    isTransientError(
+      new ElementResolutionError("matched 2 elements", "permanent"),
+    ),
+    false,
+  );
+  assert.equal(
+    isTransientError(new Error("Locator foo matched 0 elements")),
+    true,
+  );
+  assert.equal(isTransientError(new Error("Element not ready yet")), true);
+  assert.equal(isTransientError(new Error("Invalid selector")), false);
+  assert.equal(isTransientError("not an error"), false);
+});
+
+test("retryOnTransient retries transient errors then succeeds", async () => {
+  let attempts = 0;
+  const sleeps = [];
+  const restore = setOverrides({
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+  });
+  try {
+    const result = await retryOnTransient(
+      () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new ElementResolutionError("Unknown ref: 5", "transient");
+        }
+        return "done";
+      },
+      { attempts: 5, interval: 0.2 },
+    );
+    assert.equal(result, "done");
+    assert.equal(attempts, 3);
+    assert.deepEqual(sleeps, [200, 200]);
+  } finally {
+    restore();
+  }
+});
+
+test("retryOnTransient rethrows permanent errors immediately", async () => {
+  let attempts = 0;
+  const restore = setOverrides({
+    sleep: async () => {
+      throw new Error("sleep should not run");
+    },
+  });
+  try {
+    await assert.rejects(
+      () =>
+        retryOnTransient(() => {
+          attempts += 1;
+          throw new ElementResolutionError("matched 2 elements", "permanent");
+        }),
+      (error) => {
+        assert.ok(error instanceof ElementResolutionError);
+        assert.equal(error.kind, "permanent");
+        return true;
+      },
+    );
+    assert.equal(attempts, 1);
+  } finally {
+    restore();
+  }
+});
+
+test("retryOnTransient exhausts attempts and rethrows last transient error", async () => {
+  const restore = setOverrides({
+    sleep: async () => {},
+  });
+  try {
+    await assert.rejects(
+      () =>
+        retryOnTransient(
+          () => {
+            throw new Error("matched 0 elements");
+          },
+          { attempts: 2, interval: 0.1 },
+        ),
+      /matched 0 elements/,
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("expectVisible returns ok:true when element is visible", async () => {
+  const restore = setOverrides({
+    cdpOverride(method) {
+      if (method === "Runtime.evaluate") {
+        return { result: { objectId: "node-1" } };
+      }
+      if (method === "Runtime.callFunctionOn") {
+        return { result: { value: true } };
+      }
+      return {};
+    },
+  });
+  try {
+    assert.deepEqual(await expectVisible("#banner"), { ok: true });
+  } finally {
+    restore();
+  }
+});
+
+test("expectVisible returns ok:false when element is not visible", async () => {
+  const restore = setOverrides({
+    cdpOverride(method) {
+      if (method === "Runtime.evaluate") {
+        return { result: { objectId: "node-1" } };
+      }
+      if (method === "Runtime.callFunctionOn") {
+        return { result: { value: false } };
+      }
+      return {};
+    },
+  });
+  try {
+    const result = await expectVisible("#banner");
+    assert.equal(result.ok, false);
+    assert.match(result.detail, /not visible/);
+    assert.equal(result.actual, false);
+    assert.equal(result.expected, true);
+  } finally {
+    restore();
+  }
+});
+
+test("expectHidden returns ok:false on permanent resolution failure without throwing", async () => {
+  const restore = setOverrides({
+    cdpOverride(method) {
+      if (method === "Runtime.evaluate") {
+        return {
+          exceptionDetails: {
+            exception: {
+              description: "Error: Locator #dup matched 2 elements",
+            },
+          },
+        };
+      }
+      return {};
+    },
+  });
+  try {
+    const result = await expectHidden("#dup");
+    assert.equal(result.ok, false);
+    assert.match(result.detail, /expectHidden failed/);
+  } finally {
+    restore();
+  }
+});
+
+test("expectText returns mismatch details", async () => {
+  const restore = setOverrides({
+    cdpOverride(method) {
+      if (method === "Runtime.evaluate") {
+        return { result: { objectId: "node-1" } };
+      }
+      if (method === "Runtime.callFunctionOn") {
+        return { result: { value: "Hello" } };
+      }
+      return {};
+    },
+  });
+  try {
+    const result = await expectText("h1", "Goodbye");
+    assert.equal(result.ok, false);
+    assert.equal(result.actual, "Hello");
+    assert.equal(result.expected, "Goodbye");
+    assert.match(result.detail, /text mismatch/);
+  } finally {
+    restore();
+  }
+});
+
+test("expectUrl returns ok:false when pageInfo reports a dialog", async () => {
+  await withCdpRuntime(async ({ runtime }) => {
+    await browserCdp("Runtime.evaluate", { expression: "document.title" });
+    runtime.emit("Page.javascriptDialogOpening", {
+      type: "alert",
+      message: "Blocked",
+      url: "https://example.com/",
+    });
+
+    const result = await expectUrl(/example/);
+    assert.equal(result.ok, false);
+    assert.match(result.detail, /JavaScript dialog/);
+    assert.deepEqual(result.expected, /example/);
+  });
+});
+
+test("expectUrl matches string and RegExp URLs", async () => {
+  const pagePayload = {
+    url: "https://example.com/checkout?x=1",
+    title: "Checkout",
+    w: 100,
+    h: 100,
+    sx: 0,
+    sy: 0,
+    pw: 100,
+    ph: 100,
+  };
+  const restore = setOverrides({
+    cdpOverride(method, params) {
+      if (method === "Runtime.evaluate") {
+        return {
+          result: {
+            value: JSON.stringify(pagePayload),
+          },
+        };
+      }
+      return {};
+    },
+  });
+  try {
+    assert.deepEqual(await expectUrl("https://example.com/checkout?x=1"), {
+      ok: true,
+      actual: "https://example.com/checkout?x=1",
+      expected: "https://example.com/checkout?x=1",
+    });
+    assert.equal((await expectUrl(/\/checkout/)).ok, true);
+    const mismatch = await expectUrl("https://other.test");
+    assert.equal(mismatch.ok, false);
+    assert.match(mismatch.detail, /URL mismatch/);
+  } finally {
+    restore();
+  }
+});
+
+test("expectValue returns ok:true on match", async () => {
+  const restore = setOverrides({
+    cdpOverride(method) {
+      if (method === "Runtime.evaluate") {
+        return { result: { objectId: "node-1" } };
+      }
+      if (method === "Runtime.callFunctionOn") {
+        return { result: { value: "agent@example.com" } };
+      }
+      return {};
+    },
+  });
+  try {
+    assert.deepEqual(await expectValue("#email", "agent@example.com"), {
+      ok: true,
+      actual: "agent@example.com",
+      expected: "agent@example.com",
+    });
+  } finally {
+    restore();
+  }
+});
+
+test("page facade exposes retry and soft expect helpers", () => {
+  const { page } = helperContext();
+  assert.equal(typeof page.retryOnTransient, "function");
+  assert.equal(typeof page.expectVisible, "function");
+  assert.equal(typeof page.expectHidden, "function");
+  assert.equal(typeof page.expectText, "function");
+  assert.equal(typeof page.expectUrl, "function");
+  assert.equal(typeof page.expectValue, "function");
+});

--- a/package/ego-browser/src/driver/expect.ts
+++ b/package/ego-browser/src/driver/expect.ts
@@ -1,0 +1,216 @@
+import { ElementResolutionError } from "../element-resolver.js";
+import { state } from "../state.js";
+import * as locator from "./locator.js";
+import { pageInfo } from "./nav.js";
+
+export type SoftExpectResult = {
+  ok: boolean;
+  detail?: string;
+  actual?: unknown;
+  expected?: unknown;
+};
+
+export type RetryOnTransientOptions = {
+  attempts?: number;
+  interval?: number;
+};
+
+const TRANSIENT_MESSAGE = /Unknown ref|not ready|matched 0 elements/i;
+
+/**
+ * Whether an error is retryable by retryOnTransient.
+ * @param {unknown} error Thrown error.
+ * @returns {boolean}
+ */
+export function isTransientError(error: unknown): boolean {
+  if (error instanceof ElementResolutionError) {
+    return error.kind === "transient";
+  }
+  if (error instanceof Error) {
+    return TRANSIENT_MESSAGE.test(error.message);
+  }
+  return false;
+}
+
+/**
+ * Retry an async action when element resolution is transiently unavailable.
+ * @param {Function} fn Action to run.
+ * @param {{ attempts?: number, interval?: number }} [options] attempts default 5; interval in seconds, default 0.4.
+ * @returns {Promise<any>} fn result on success.
+ */
+export async function retryOnTransient<T>(
+  fn: () => T | Promise<T>,
+  options: RetryOnTransientOptions = {},
+): Promise<T> {
+  const attempts = options.attempts ?? 5;
+  const intervalMs = (options.interval ?? 0.4) * 1000;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (!isTransientError(error)) {
+        throw error;
+      }
+      lastError = error;
+      if (attempt < attempts) {
+        await state.sleep(intervalMs);
+      }
+    }
+  }
+  throw lastError;
+}
+
+function matchStringOrRegExp(
+  actual: string,
+  expected: string | RegExp,
+): boolean {
+  if (expected instanceof RegExp) {
+    return expected.test(actual);
+  }
+  return actual === expected;
+}
+
+function softCatch(error: unknown, prefix: string, expected?: unknown) {
+  const detail =
+    error instanceof Error ? `${prefix}: ${error.message}` : prefix;
+  return {
+    ok: false as const,
+    detail,
+    ...(expected !== undefined ? { expected } : {}),
+  };
+}
+
+/**
+ * Soft assertion: element is visible. Returns { ok } instead of throwing.
+ * @param {string} selector CSS selector / @ref / loc= / xpath= for the element.
+ * @returns {Promise<{ ok: boolean, detail?: string, actual?: unknown, expected?: unknown }>}
+ */
+export async function expectVisible(
+  selector: string,
+): Promise<SoftExpectResult> {
+  try {
+    const visible = await locator.isVisible(selector);
+    if (visible) {
+      return { ok: true };
+    }
+    return {
+      ok: false,
+      detail: "element is not visible",
+      actual: visible,
+      expected: true,
+    };
+  } catch (error) {
+    return softCatch(error, "expectVisible failed");
+  }
+}
+
+/**
+ * Soft assertion: element is hidden. Returns { ok } instead of throwing.
+ * @param {string} selector CSS selector / @ref / loc= / xpath= for the element.
+ * @returns {Promise<{ ok: boolean, detail?: string, actual?: unknown, expected?: unknown }>}
+ */
+export async function expectHidden(
+  selector: string,
+): Promise<SoftExpectResult> {
+  try {
+    const hidden = await locator.isHidden(selector);
+    if (hidden) {
+      return { ok: true };
+    }
+    return {
+      ok: false,
+      detail: "element is not hidden",
+      actual: !hidden,
+      expected: false,
+    };
+  } catch (error) {
+    return softCatch(error, "expectHidden failed");
+  }
+}
+
+/**
+ * Soft assertion: element text matches. Uses innerText. Returns { ok } instead of throwing.
+ * @param {string} selector CSS selector / @ref / loc= / xpath= for the element.
+ * @param {string|RegExp} expected Expected text.
+ * @returns {Promise<{ ok: boolean, detail?: string, actual?: unknown, expected?: unknown }>}
+ */
+export async function expectText(
+  selector: string,
+  expected: string | RegExp,
+): Promise<SoftExpectResult> {
+  try {
+    const actual = await locator.innerText(selector);
+    if (matchStringOrRegExp(actual, expected)) {
+      return { ok: true, actual, expected };
+    }
+    return {
+      ok: false,
+      detail: "text mismatch",
+      actual,
+      expected,
+    };
+  } catch (error) {
+    return softCatch(error, "expectText failed", expected);
+  }
+}
+
+/**
+ * Soft assertion: current URL matches. Returns { ok } instead of throwing.
+ * @param {string|RegExp} expected Expected URL or pattern.
+ * @returns {Promise<{ ok: boolean, detail?: string, actual?: unknown, expected?: unknown }>}
+ */
+export async function expectUrl(
+  expected: string | RegExp,
+): Promise<SoftExpectResult> {
+  try {
+    const info = await pageInfo();
+    if ("dialog" in info && info.dialog) {
+      return {
+        ok: false,
+        detail:
+          "page has an open JavaScript dialog; URL is unavailable until the dialog is handled",
+        expected,
+      };
+    }
+    const actual = info.url;
+    if (matchStringOrRegExp(actual, expected)) {
+      return { ok: true, actual, expected };
+    }
+    return {
+      ok: false,
+      detail: "URL mismatch",
+      actual,
+      expected,
+    };
+  } catch (error) {
+    return softCatch(error, "expectUrl failed", expected);
+  }
+}
+
+/**
+ * Soft assertion: input value matches. Returns { ok } instead of throwing.
+ * @param {string} selector CSS selector / @ref / loc= / xpath= for the form control.
+ * @param {string|RegExp} expected Expected value.
+ * @returns {Promise<{ ok: boolean, detail?: string, actual?: unknown, expected?: unknown }>}
+ */
+export async function expectValue(
+  selector: string,
+  expected: string | RegExp,
+): Promise<SoftExpectResult> {
+  try {
+    const actual = await locator.inputValue(selector);
+    if (matchStringOrRegExp(actual, expected)) {
+      return { ok: true, actual, expected };
+    }
+    return {
+      ok: false,
+      detail: "value mismatch",
+      actual,
+      expected,
+    };
+  } catch (error) {
+    return softCatch(error, "expectValue failed", expected);
+  }
+}

--- a/package/ego-browser/src/format.ts
+++ b/package/ego-browser/src/format.ts
@@ -442,6 +442,126 @@ const FUNCTION_DOCS: Record<string, FunctionDoc> = {
     returns: "Promise<object[]>",
     example: "console.log(await page.drainEvents())",
   },
+  "page.retryOnTransient": {
+    signature: "page.retryOnTransient(fn, options?) => Promise<any>",
+    description:
+      "Retry an async action when element resolution fails transiently (unknown ref, not ready, zero matches). Re-throws permanent or other errors immediately.",
+    params: [
+      {
+        name: "fn",
+        type: "Function",
+        required: true,
+        description: "Async action to run.",
+      },
+      {
+        name: "options",
+        type: "{ attempts?: number, interval?: number }",
+        description:
+          "Retry count (default 5) and interval in seconds between attempts (default 0.4).",
+      },
+    ],
+    returns: "Promise<any>",
+    example:
+      "await page.retryOnTransient(() => page.locator('@12').click(), { attempts: 3 })",
+  },
+  "page.expectVisible": {
+    signature:
+      "page.expectVisible(selector) => Promise<{ ok, detail?, actual?, expected? }>",
+    description:
+      "Soft assertion that an element is visible. Returns { ok: false } on failure instead of throwing.",
+    params: [
+      {
+        name: "selector",
+        type: "string",
+        required: true,
+        description: "CSS, XPath, loc=..., text, or @ref selector.",
+      },
+    ],
+    returns:
+      "Promise<{ ok: boolean, detail?: string, actual?: unknown, expected?: unknown }>",
+    example:
+      "const result = await page.expectVisible('button.submit'); if (!result.ok) cliLog(result)",
+  },
+  "page.expectHidden": {
+    signature:
+      "page.expectHidden(selector) => Promise<{ ok, detail?, actual?, expected? }>",
+    description:
+      "Soft assertion that an element is hidden. Returns { ok: false } on failure instead of throwing.",
+    params: [
+      {
+        name: "selector",
+        type: "string",
+        required: true,
+        description: "CSS, XPath, loc=..., text, or @ref selector.",
+      },
+    ],
+    returns:
+      "Promise<{ ok: boolean, detail?: string, actual?: unknown, expected?: unknown }>",
+    example: "cliLog(await page.expectHidden('.loading-spinner'))",
+  },
+  "page.expectText": {
+    signature:
+      "page.expectText(selector, expected) => Promise<{ ok, detail?, actual?, expected? }>",
+    description:
+      "Soft assertion that element innerText matches a string or RegExp.",
+    params: [
+      {
+        name: "selector",
+        type: "string",
+        required: true,
+        description: "CSS, XPath, loc=..., text, or @ref selector.",
+      },
+      {
+        name: "expected",
+        type: "string | RegExp",
+        required: true,
+        description: "Expected text.",
+      },
+    ],
+    returns:
+      "Promise<{ ok: boolean, detail?: string, actual?: unknown, expected?: unknown }>",
+    example: "cliLog(await page.expectText('h1', /Welcome/))",
+  },
+  "page.expectUrl": {
+    signature:
+      "page.expectUrl(expected) => Promise<{ ok, detail?, actual?, expected? }>",
+    description:
+      "Soft assertion that the current URL matches a string or RegExp. Returns ok:false when a native dialog blocks pageInfo().",
+    params: [
+      {
+        name: "expected",
+        type: "string | RegExp",
+        required: true,
+        description: "Expected URL or pattern.",
+      },
+    ],
+    returns:
+      "Promise<{ ok: boolean, detail?: string, actual?: unknown, expected?: unknown }>",
+    example: "cliLog(await page.expectUrl(/\\/checkout/))",
+  },
+  "page.expectValue": {
+    signature:
+      "page.expectValue(selector, expected) => Promise<{ ok, detail?, actual?, expected? }>",
+    description:
+      "Soft assertion that an input, textarea, or select value matches a string or RegExp.",
+    params: [
+      {
+        name: "selector",
+        type: "string",
+        required: true,
+        description: "CSS, XPath, loc=..., text, or @ref selector.",
+      },
+      {
+        name: "expected",
+        type: "string | RegExp",
+        required: true,
+        description: "Expected value.",
+      },
+    ],
+    returns:
+      "Promise<{ ok: boolean, detail?: string, actual?: unknown, expected?: unknown }>",
+    example: "cliLog(await page.expectValue('#email', 'me@example.com'))",
+  },
   "page.keyboard.press": {
     signature: "page.keyboard.press(key, options?) => Promise<void>",
     description: "Press a keyboard key or shortcut.",

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -15,6 +15,7 @@ import * as waits from "./driver/waits.js";
 import * as files from "./driver/files.js";
 import * as downloads from "./driver/downloads.js";
 import * as screencast from "./driver/screencast.js";
+import * as expect from "./driver/expect.js";
 import { browserFetch, serverFetch } from "./http.js";
 import {
   loadBrowserToolSource,
@@ -98,6 +99,14 @@ export {
 } from "./driver/waits.js";
 export { setInputFiles } from "./driver/files.js";
 export { startScreencast, stopScreencast } from "./driver/screencast.js";
+export {
+  retryOnTransient,
+  expectVisible,
+  expectHidden,
+  expectText,
+  expectUrl,
+  expectValue,
+} from "./driver/expect.js";
 export { browserFetch, serverFetch } from "./http.js";
 
 /**
@@ -745,6 +754,12 @@ function createPageFacade() {
       insertText: keyboard.insertText,
       type: keyboard.typeText,
     },
+    retryOnTransient: expect.retryOnTransient,
+    expectVisible: expect.expectVisible,
+    expectHidden: expect.expectHidden,
+    expectText: expect.expectText,
+    expectUrl: expect.expectUrl,
+    expectValue: expect.expectValue,
     mouse: {
       click: (x, y, options = {}) => {
         const [target, effectiveOptions] = mousePointArgs(x, y, options);
@@ -807,7 +822,7 @@ function createSiteFacade() {
 }
 
 const FACADE_HELP: Record<string, string> = {
-  page: 'page: Playwright-style page facade. page.url() asynchronously returns the current URL; always call await page.url() before using the string. Use page.goto(url), page.locator(selector), page.getByText(text), page.getByLabel(text), page.getByPlaceholder(text), page.getByTestId(testId), page.setDefaultTimeout(ms), page.waitForEvent("download"), page.waitForLoadState(state, options), page.waitForURL(url, options), page.waitForRequest(urlOrPredicate, options), page.waitForResponse(urlOrPredicate, options), page.evaluate(expression), page.screenshot(options), page.screencast.start({ path, size, quality }), page.screencast.stop(), page.keyboard.press(key), page.keyboard.type(text), and page.mouse.click(x, y). waitForURL predicates receive URL objects and waitUntil defaults to load.',
+  page: 'page: Playwright-style page facade. page.url() asynchronously returns the current URL; always call await page.url() before using the string. Use page.goto(url), page.locator(selector), page.getByText(text), page.getByLabel(text), page.getByPlaceholder(text), page.getByTestId(testId), page.setDefaultTimeout(ms), page.waitForEvent("download"), page.waitForLoadState(state, options), page.waitForURL(url, options), page.waitForRequest(urlOrPredicate, options), page.waitForResponse(urlOrPredicate, options), page.evaluate(expression), page.screenshot(options), page.screencast.start({ path, size, quality }), page.screencast.stop(), page.keyboard.press(key), page.keyboard.type(text), and page.mouse.click(x, y). Soft checks: page.retryOnTransient(fn, options), page.expectVisible(selector), page.expectHidden(selector), page.expectText(selector, expected), page.expectUrl(expected), page.expectValue(selector, expected) return { ok } instead of throwing. waitForURL predicates receive URL objects and waitUntil defaults to load.',
   locator:
     "page.locator(selector): returns a strict, auto-waiting locator facade with locator(), getByRole(), getByText(), filter(), first(), nth(index), last(), click(), hover(), dragTo(target), scrollIntoViewIfNeeded(), fill(value), clear(), press(key), check(), selectOption(value), textContent(), innerText(), innerHTML(), isVisible(), isEnabled(), getAttribute(name), screenshot(), count(), evaluate(fn, arg), evaluateAll(fn, arg), and waitFor(options). Narrow multiple matches; use first()/nth() only for confirmed legitimate duplicates.",
   browser:

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -40,6 +40,7 @@ The heredoc body runs as a Node.js script that controls the selected ego-browser
 - Keyboard & input: `typeText`, `fillInput`, `pressKey`, `dispatchKey`
 - File: `uploadFile`
 - Wait: `wait`, `waitForLoad`, `waitForElement`, `waitForNetworkIdle`
+- Soft expects (via `page` facade): `page.retryOnTransient(fn, { attempts, interval })`, `page.expectVisible(selector)`, `page.expectHidden(selector)`, `page.expectText(selector, expected)`, `page.expectUrl(expected)`, `page.expectValue(selector, expected)` — return `{ ok, detail?, actual?, expected? }` instead of throwing
 - Fetch: `serverFetch`, `browserFetch`
 - CDP / evaluate: `js`, `cdp`
 - Output: `cliLog`, `help`


### PR DESCRIPTION
## Summary
- Adds `page.retryOnTransient()` that retries only on transient `ElementResolutionError`s (and common not-ready messages)
- Adds soft expects (`expectVisible`, `expectHidden`, `expectText`, `expectUrl`, `expectValue`) that return `{ ok, detail? }` instead of throwing
- Helps agents avoid burning full heredoc rounds on flaky element timing

## Test plan
- [x] `cd package/ego-browser && npm test`
- [x] Live: click a delayed element via `retryOnTransient(() => page.locator(...).click())`
- [x] Live: soft-fail `expectUrl` / `expectVisible` and confirm scripts continue after `{ ok: false }`