### PR TITLE
feat(ego-browser): add page console and error drain helpers

### DIFF
--- a/package/ego-browser/src/browser-runtime.test.mjs
+++ b/package/ego-browser/src/browser-runtime.test.mjs
@@ -4,6 +4,9 @@ import assert from "node:assert/strict";
 import {
   browserCdp,
   drainBrowserEvents,
+  drainConsoleMessages,
+  pendingConsoleMessages,
+  waitForConsole,
   invalidateSession,
   isBrowserRuntime,
   pendingDialog,
@@ -80,6 +83,7 @@ function cleanup() {
   invalidateSession();
   clearPreferredTarget();
   drainBrowserEvents();
+  drainConsoleMessages();
   state.cdpOverride = null;
   state.sessionInflight = null;
 }
@@ -649,6 +653,12 @@ test("ensureSession selects the preferred tab when available", async () => {
     const pageEnable = calls.find((c) => c.method === "Page.enable");
     assert.ok(pageEnable, "Page.enable was called for the attached session");
     assert.equal(pageEnable.sessionId, `auto-sess-${attach.id}`);
+    const runtimeEnable = calls.find((c) => c.method === "Runtime.enable");
+    assert.ok(
+      runtimeEnable,
+      "Runtime.enable was called for the attached session",
+    );
+    assert.equal(runtimeEnable.sessionId, `auto-sess-${attach.id}`);
   } finally {
     cleanup();
   }
@@ -816,4 +826,186 @@ test("browserSnapshotRefsToRefMap skips null, non-object, and missing backendNod
   ]);
   assert.equal(refMap._data.size, 1, "only the valid ref is added");
   assert.ok(refMap._data.has("7"));
+});
+
+/* ------------------------------------------------------------------ */
+/*  Console message buffer                                            */
+/* ------------------------------------------------------------------ */
+
+test("drainConsoleMessages collects structured console events and clears the buffer", async () => {
+  const calls = installManualEgo();
+  try {
+    const p = browserCdp("Target.getVersion", {}, undefined, 5000);
+    globalThis.ego.onCDPMessage(
+      JSON.stringify({ id: calls[0].id, result: {} }),
+    );
+    await p;
+
+    fireEvent("Runtime.consoleAPICalled", {
+      type: "warning",
+      timestamp: 100,
+      args: [{ type: "string", value: "be careful" }],
+    });
+    fireEvent("Runtime.exceptionThrown", {
+      timestamp: 200,
+      exceptionDetails: {
+        text: "Uncaught Error: boom",
+        exception: { description: "Error: boom" },
+      },
+    });
+
+    const first = drainConsoleMessages();
+    assert.equal(first.length, 2);
+    assert.deepEqual(first[0], {
+      type: "warning",
+      text: "be careful",
+      timestamp: 100,
+      args: ["be careful"],
+    });
+    assert.deepEqual(first[1], {
+      type: "pageerror",
+      text: "Uncaught Error: boom",
+      timestamp: 200,
+    });
+
+    assert.equal(
+      drainConsoleMessages().length,
+      0,
+      "second drain returns empty",
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("pendingConsoleMessages peeks without clearing the buffer", async () => {
+  const calls = installManualEgo();
+  try {
+    const p = browserCdp("Target.getVersion", {}, undefined, 5000);
+    globalThis.ego.onCDPMessage(
+      JSON.stringify({ id: calls[0].id, result: {} }),
+    );
+    await p;
+
+    fireEvent("Runtime.consoleAPICalled", {
+      type: "log",
+      args: [{ type: "string", value: "hello" }],
+    });
+
+    const peeked = pendingConsoleMessages();
+    assert.equal(peeked.length, 1);
+    assert.equal(peeked[0].text, "hello");
+    assert.equal(pendingConsoleMessages().length, 1, "peek does not drain");
+    assert.equal(
+      drainConsoleMessages().length,
+      1,
+      "drain still works after peek",
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("waitForConsole resolves matching buffered and future messages", async () => {
+  const calls = installManualEgo();
+  try {
+    const p = browserCdp("Target.getVersion", {}, undefined, 5000);
+    globalThis.ego.onCDPMessage(
+      JSON.stringify({ id: calls[0].id, result: {} }),
+    );
+    await p;
+
+    fireEvent("Runtime.consoleAPICalled", {
+      type: "log",
+      args: [{ type: "string", value: "already here" }],
+    });
+    const buffered = await waitForConsole("already");
+    assert.equal(buffered.text, "already here");
+
+    const pending = waitForConsole(/future-msg/, { timeout: 500 });
+    fireEvent("Runtime.consoleAPICalled", {
+      type: "error",
+      args: [{ type: "string", value: "future-msg arrived" }],
+    });
+    const future = await pending;
+    assert.equal(future.type, "error");
+    assert.match(future.text, /future-msg/);
+  } finally {
+    cleanup();
+  }
+});
+
+test("waitForConsole supports type filtering", async () => {
+  const calls = installManualEgo();
+  try {
+    const p = browserCdp("Target.getVersion", {}, undefined, 5000);
+    globalThis.ego.onCDPMessage(
+      JSON.stringify({ id: calls[0].id, result: {} }),
+    );
+    await p;
+
+    fireEvent("Runtime.consoleAPICalled", {
+      type: "log",
+      args: [{ type: "string", value: "same text" }],
+    });
+
+    const promise = waitForConsole("same text", {
+      type: "pageerror",
+      timeout: 100,
+    });
+    await assert.rejects(promise, /waitForConsole timed out/);
+  } finally {
+    cleanup();
+  }
+});
+
+test("drainConsoleMessages caps at MAX_BUFFERED_CONSOLE_MESSAGES (1000)", async () => {
+  const calls = installManualEgo();
+  try {
+    const p = browserCdp("Target.getVersion", {}, undefined, 5000);
+    globalThis.ego.onCDPMessage(
+      JSON.stringify({ id: calls[0].id, result: {} }),
+    );
+    await p;
+
+    for (let i = 0; i < 1005; i++) {
+      fireEvent("Runtime.consoleAPICalled", {
+        type: "log",
+        args: [{ type: "string", value: `msg-${i}` }],
+      });
+    }
+    const messages = drainConsoleMessages();
+    assert.equal(
+      messages.length,
+      1000,
+      "console buffer capped at 1000 messages",
+    );
+    assert.equal(messages[0].text, "msg-5", "oldest console messages dropped");
+    assert.equal(messages[messages.length - 1].text, "msg-1004");
+  } finally {
+    cleanup();
+  }
+});
+
+test("console messages still appear in raw drainBrowserEvents", async () => {
+  const calls = installManualEgo();
+  try {
+    const p = browserCdp("Target.getVersion", {}, undefined, 5000);
+    globalThis.ego.onCDPMessage(
+      JSON.stringify({ id: calls[0].id, result: {} }),
+    );
+    await p;
+
+    fireEvent("Runtime.consoleAPICalled", {
+      type: "log",
+      args: [{ type: "string", value: "dual-write" }],
+    });
+
+    assert.equal(drainConsoleMessages().length, 1);
+    const raw = drainBrowserEvents();
+    assert.equal(raw.length, 1);
+    assert.equal(raw[0].method, "Runtime.consoleAPICalled");
+  } finally {
+    cleanup();
+  }
 });

--- a/package/ego-browser/src/browser-runtime.ts
+++ b/package/ego-browser/src/browser-runtime.ts
@@ -6,6 +6,19 @@ const SESSION_TTL_MS = 2000;
 // Upper bound for buffered CDP events. The runtime can be long-lived (installEgoSdk
 // inside the browser); without a cap, undrained events grow without bound.
 const MAX_BUFFERED_EVENTS = 10000;
+const MAX_BUFFERED_CONSOLE_MESSAGES = 1000;
+export type ConsoleMessage = {
+  type: string;
+  text: string;
+  timestamp?: number;
+  args?: string[];
+};
+type ConsoleWaiter = {
+  matches: (message: ConsoleMessage) => boolean;
+  resolve: (message: ConsoleMessage) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
 const SESSION_LOST =
   /Session (?:with given id )?not found|Target closed|No session/i;
 const BROWSER_LEVEL = (method) =>
@@ -19,6 +32,8 @@ let nextMessageId = 1;
 const pending = new Map();
 const events = [];
 const eventWaiters = [];
+const consoleMessages: ConsoleMessage[] = [];
+const consoleWaiters: ConsoleWaiter[] = [];
 const eventSubscribers = new Set<BrowserEventSubscriber>();
 const pageEnabledSessions = new Set();
 const pendingDialogs = new Map();
@@ -166,6 +181,57 @@ export function drainBrowserEvents() {
   return out;
 }
 
+export function drainConsoleMessages() {
+  return consoleMessages.splice(0, consoleMessages.length);
+}
+
+export function pendingConsoleMessages() {
+  return consoleMessages.slice();
+}
+
+export function waitForConsole(
+  matcher?: string | RegExp | ((message: ConsoleMessage) => boolean),
+  options: { timeout?: number; type?: string } = {},
+) {
+  const timeout = options.timeout ?? state.defaultTimeout;
+  const typeFilter = options.type;
+
+  function matches(message: ConsoleMessage) {
+    if (typeFilter && message.type !== typeFilter) {
+      return false;
+    }
+    if (matcher === undefined) {
+      return true;
+    }
+    if (typeof matcher === "string") {
+      return message.text.includes(matcher);
+    }
+    if (matcher instanceof RegExp) {
+      return matcher.test(message.text);
+    }
+    return matcher(message);
+  }
+
+  const existing = consoleMessages.find(matches);
+  if (existing) {
+    return Promise.resolve(existing);
+  }
+
+  return new Promise<ConsoleMessage>((resolve, reject) => {
+    const waiter: ConsoleWaiter = {
+      matches,
+      resolve,
+      reject,
+      timer: setTimeout(() => {
+        const index = consoleWaiters.indexOf(waiter);
+        if (index >= 0) consoleWaiters.splice(index, 1);
+        reject(new Error("waitForConsole timed out"));
+      }, timeout),
+    };
+    consoleWaiters.push(waiter);
+  });
+}
+
 export function waitForBrowserEvent(
   predicate,
   timeoutMs = state.defaultTimeout,
@@ -212,6 +278,72 @@ async function enablePageEvents(sessionId) {
   } catch {
     // Dialog tracking is best-effort. Do not make all helpers fail on targets
     // that reject Page.enable, such as unusual internal pages.
+  }
+  try {
+    await rawCdp("Runtime.enable", {}, sessionId);
+  } catch {
+    // Console capture is best-effort for the same unusual targets.
+  }
+}
+
+function remoteObjectText(obj: any) {
+  if (!obj || typeof obj !== "object") {
+    return "";
+  }
+  if (obj.value !== undefined) {
+    if (typeof obj.value === "string") {
+      return obj.value;
+    }
+    try {
+      return JSON.stringify(obj.value);
+    } catch {
+      return String(obj.value);
+    }
+  }
+  if (typeof obj.description === "string") {
+    return obj.description;
+  }
+  if (typeof obj.preview?.description === "string") {
+    return obj.preview.description;
+  }
+  return obj.type || "";
+}
+
+function formatConsoleAPICalled(params: any = {}): ConsoleMessage {
+  const args = (params.args || []).map(remoteObjectText);
+  return {
+    type: params.type || "log",
+    text: args.join(" "),
+    timestamp: params.timestamp,
+    args,
+  };
+}
+
+function formatExceptionThrown(params: any = {}): ConsoleMessage {
+  const details = params.exceptionDetails || {};
+  return {
+    type: "pageerror",
+    text:
+      details.text || details.exception?.description || "Uncaught exception",
+    timestamp: params.timestamp ?? details.timestamp,
+  };
+}
+
+function pushConsoleMessage(message: ConsoleMessage) {
+  consoleMessages.push(message);
+  if (consoleMessages.length > MAX_BUFFERED_CONSOLE_MESSAGES) {
+    consoleMessages.splice(
+      0,
+      consoleMessages.length - MAX_BUFFERED_CONSOLE_MESSAGES,
+    );
+  }
+  for (const waiter of [...consoleWaiters]) {
+    if (!waiter.matches(message)) {
+      continue;
+    }
+    clearTimeout(waiter.timer);
+    consoleWaiters.splice(consoleWaiters.indexOf(waiter), 1);
+    waiter.resolve(message);
   }
 }
 
@@ -273,6 +405,10 @@ function handleMessage(message) {
     if (sessionId) {
       pendingDialogs.delete(sessionId);
     }
+  } else if (data.method === "Runtime.consoleAPICalled") {
+    pushConsoleMessage(formatConsoleAPICalled(data.params));
+  } else if (data.method === "Runtime.exceptionThrown") {
+    pushConsoleMessage(formatExceptionThrown(data.params));
   }
   let deliveredToSubscriber = false;
   for (const subscriber of eventSubscribers) {

--- a/package/ego-browser/src/driver/console.test.mjs
+++ b/package/ego-browser/src/driver/console.test.mjs
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { drainConsole, waitForConsole } from "../../dist/src/driver/console.js";
+import {
+  drainConsoleMessages,
+  invalidateSession,
+} from "../../dist/src/browser-runtime.js";
+
+function installManualEgo() {
+  globalThis.ego = {
+    async listTabs() {
+      return { tabs: [{ targetId: "tab-1", active: true }] };
+    },
+    sendCDPMessage(payload) {},
+  };
+}
+
+function fireEvent(method, params = {}) {
+  globalThis.ego.onCDPMessage(JSON.stringify({ method, params }));
+}
+
+function cleanup() {
+  delete globalThis.ego;
+  invalidateSession();
+  drainConsoleMessages();
+}
+
+test("page facade drainConsole and waitForConsole delegate to browser runtime", async () => {
+  const { browserCdp } = await import("../../dist/src/browser-runtime.js");
+  installManualEgo();
+  try {
+    const promise = browserCdp("Target.getVersion", {}, undefined, 5000);
+    globalThis.ego.sendCDPMessage = (payload) => {
+      const parsed = JSON.parse(payload);
+      globalThis.ego.onCDPMessage(
+        JSON.stringify({ id: parsed.id, result: {} }),
+      );
+    };
+    globalThis.ego.sendCDPMessage(
+      JSON.stringify({ id: 1, method: "Target.getVersion" }),
+    );
+    await promise;
+
+    fireEvent("Runtime.consoleAPICalled", {
+      type: "log",
+      args: [{ type: "string", value: "via facade" }],
+    });
+
+    const drained = drainConsole();
+    assert.equal(drained.length, 1);
+    assert.equal(drained[0].text, "via facade");
+
+    const pending = waitForConsole("next", { timeout: 500 });
+    fireEvent("Runtime.consoleAPICalled", {
+      type: "log",
+      args: [{ type: "string", value: "next message" }],
+    });
+    const matched = await pending;
+    assert.equal(matched.text, "next message");
+  } finally {
+    cleanup();
+  }
+});

--- a/package/ego-browser/src/driver/console.ts
+++ b/package/ego-browser/src/driver/console.ts
@@ -1,0 +1,16 @@
+import {
+  drainConsoleMessages,
+  waitForConsole as waitForConsoleMessage,
+  type ConsoleMessage,
+} from "../browser-runtime.js";
+
+export function drainConsole() {
+  return drainConsoleMessages();
+}
+
+export function waitForConsole(
+  matcher?: string | RegExp | ((message: ConsoleMessage) => boolean),
+  options?: { timeout?: number; type?: string },
+) {
+  return waitForConsoleMessage(matcher, options);
+}

--- a/package/ego-browser/src/driver/nav.test.mjs
+++ b/package/ego-browser/src/driver/nav.test.mjs
@@ -456,9 +456,15 @@ test("browser runtime enables Page events and tracks pending native dialogs", as
 
     assert.deepEqual(
       sent.map((request) => request.method),
-      ["Target.attachToTarget", "Page.enable", "Runtime.evaluate"],
+      [
+        "Target.attachToTarget",
+        "Page.enable",
+        "Runtime.enable",
+        "Runtime.evaluate",
+      ],
     );
     assert.equal(sent[1].sessionId, "session-1");
+    assert.equal(sent[2].sessionId, "session-1");
 
     runtime.emit("Page.javascriptDialogOpening", {
       type: "alert",

--- a/package/ego-browser/src/format.ts
+++ b/package/ego-browser/src/format.ts
@@ -442,6 +442,33 @@ const FUNCTION_DOCS: Record<string, FunctionDoc> = {
     returns: "Promise<object[]>",
     example: "console.log(await page.drainEvents())",
   },
+  "page.drainConsole": {
+    signature: "page.drainConsole() => ConsoleMessage[]",
+    description:
+      "Drain structured console.log/warn/error and uncaught page errors captured from the page.",
+    returns: "ConsoleMessage[]",
+    example: "console.log(await page.drainConsole())",
+  },
+  "page.waitForConsole": {
+    signature:
+      "page.waitForConsole(matcher?, options?) => Promise<ConsoleMessage>",
+    description:
+      "Wait for a console or page-error message. matcher may be a substring, RegExp, predicate, or omitted to match any message.",
+    params: [
+      {
+        name: "matcher",
+        type: "string | RegExp | function",
+        description: "Optional text/predicate matcher.",
+      },
+      {
+        name: "options",
+        type: "{ timeout?: number, type?: string }",
+        description: "Timeout in ms and optional message type filter.",
+      },
+    ],
+    returns: "Promise<ConsoleMessage>",
+    example: "await page.waitForConsole('ready', { timeout: 5000 })",
+  },
   "page.keyboard.press": {
     signature: "page.keyboard.press(key, options?) => Promise<void>",
     description: "Press a keyboard key or shortcut.",

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -11,6 +11,7 @@ import * as keyboard from "./driver/keyboard.js";
 import * as locator from "./driver/locator.js";
 import * as nav from "./driver/nav.js";
 import * as observe from "./driver/observe.js";
+import * as console from "./driver/console.js";
 import * as waits from "./driver/waits.js";
 import * as files from "./driver/files.js";
 import * as downloads from "./driver/downloads.js";
@@ -87,6 +88,7 @@ export {
   elementCenter,
   drainEvents,
 } from "./driver/observe.js";
+export { drainConsole, waitForConsole } from "./driver/console.js";
 export {
   waitForTimeout,
   waitForLoadState,
@@ -734,6 +736,8 @@ function createPageFacade() {
     snapshotRaw: observe.snapshotRaw,
     elementCenter: observe.elementCenter,
     drainEvents: observe.drainEvents,
+    drainConsole: console.drainConsole,
+    waitForConsole: console.waitForConsole,
     screencast: {
       start: screencast.startScreencast,
       stop: screencast.stopScreencast,
@@ -807,7 +811,7 @@ function createSiteFacade() {
 }
 
 const FACADE_HELP: Record<string, string> = {
-  page: 'page: Playwright-style page facade. page.url() asynchronously returns the current URL; always call await page.url() before using the string. Use page.goto(url), page.locator(selector), page.getByText(text), page.getByLabel(text), page.getByPlaceholder(text), page.getByTestId(testId), page.setDefaultTimeout(ms), page.waitForEvent("download"), page.waitForLoadState(state, options), page.waitForURL(url, options), page.waitForRequest(urlOrPredicate, options), page.waitForResponse(urlOrPredicate, options), page.evaluate(expression), page.screenshot(options), page.screencast.start({ path, size, quality }), page.screencast.stop(), page.keyboard.press(key), page.keyboard.type(text), and page.mouse.click(x, y). waitForURL predicates receive URL objects and waitUntil defaults to load.',
+  page: 'page: Playwright-style page facade. page.url() asynchronously returns the current URL; always call await page.url() before using the string. Use page.goto(url), page.locator(selector), page.getByText(text), page.getByLabel(text), page.getByPlaceholder(text), page.getByTestId(testId), page.setDefaultTimeout(ms), page.waitForEvent("download"), page.waitForLoadState(state, options), page.waitForURL(url, options), page.waitForRequest(urlOrPredicate, options), page.waitForResponse(urlOrPredicate, options), page.drainConsole(), page.waitForConsole(matcher, options), page.evaluate(expression), page.screenshot(options), page.screencast.start({ path, size, quality }), page.screencast.stop(), page.keyboard.press(key), page.keyboard.type(text), and page.mouse.click(x, y). waitForURL predicates receive URL objects and waitUntil defaults to load.',
   locator:
     "page.locator(selector): returns a strict, auto-waiting locator facade with locator(), getByRole(), getByText(), filter(), first(), nth(index), last(), click(), hover(), dragTo(target), scrollIntoViewIfNeeded(), fill(value), clear(), press(key), check(), selectOption(value), textContent(), innerText(), innerHTML(), isVisible(), isEnabled(), getAttribute(name), screenshot(), count(), evaluate(fn, arg), evaluateAll(fn, arg), and waitFor(options). Narrow multiple matches; use first()/nth() only for confirmed legitimate duplicates.",
   browser:

--- a/package/ego-browser/src/index.ts
+++ b/package/ego-browser/src/index.ts
@@ -111,6 +111,8 @@ const LEGACY_GLOBAL_HELPERS = [
   "screenshot",
   "elementCenter",
   "drainEvents",
+  "drainConsole",
+  "waitForConsole",
   "waitForTimeout",
   "waitForLoadState",
   "waitForSelector",

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -35,7 +35,7 @@ The heredoc body runs as a Node.js script that controls the selected ego-browser
 
 - Task spaces: `listTaskSpaces`, `useOrCreateTaskSpace`, `claimTaskSpace`, `handOffTaskSpace`, `takeOverTaskSpace`, `waitForAgentControl`, `completeTaskSpace`
 - Navigation / state: `listTabs`, `openOrReuseTab`, `closeTab`, `gotoAndWait`, `currentTab`, `switchTab`, `gotoUrl`, `pageInfo`, `ensureRealTab`
-- Observation: `snapshotText`, `captureScreenshot`, `drainEvents`
+- Observation: `snapshotText`, `captureScreenshot`, `drainEvents`, `drainConsole`, `waitForConsole`
 - Scroll / mouse: `scrollBy`, `scrollToBottomUntil`, `scroll`, `click`, `doubleClick`, `hover`, `dragMouse`
 - Keyboard & input: `typeText`, `fillInput`, `pressKey`, `dispatchKey`
 - File: `uploadFile`
@@ -51,6 +51,8 @@ Notes:
 - `await ensureRealTab()` — switches to an existing non-internal page tab if needed and resolves to it; resolves to `null` when none exists. It does not create a tab — use `await openOrReuseTab(...)` for that.
 - `await closeTab(target?)` — closes the given target id / tab object, or the current tab when omitted.
 - `await drainEvents()` — consumes and returns the async event queue produced by the page (navigation events, network events, etc.).
+- `await drainConsole()` — consumes and returns structured console and page-error messages (`{ type, text, timestamp, args? }`).
+- `await waitForConsole(matcher?, { timeout?, type? })` — waits for a matching console or page-error message.
 - `await serverFetch(url, options)` — issues a request from Node and returns the response body.
 - `await browserFetch(url, options)` — issues a request from the current browser page context and returns the response body.
 - `help(name)` — prints usage for a given helper, e.g. `cliLog(help('click'))`.


### PR DESCRIPTION
## Summary
- Adds a dedicated console/pageerror buffer (alongside raw CDP events) with `Runtime.enable`
- Exposes `page.drainConsole()` and `page.waitForConsole()` for structured log/error inspection
- Leaves `page.drainEvents()` unchanged for raw CDP consumers

## Test plan
- [x] `cd package/ego-browser && npm test`
- [x] Live page that `console.error`s / throws: confirm `drainConsole()` returns structured messages and clears the buffer
- [x] Confirm `waitForConsole(/boom/)` resolves and `drainEvents()` still returns raw CDP events