### PR TITLE
fix(ego-browser): avoid mutating runMain argv

### DIFF
--- a/package/ego-browser/src/run-cli.test.mjs
+++ b/package/ego-browser/src/run-cli.test.mjs
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runMain } from "../dist/src/run.js";
+
+function captureStream() {
+  const chunks = [];
+  return {
+    write(chunk) {
+      chunks.push(String(chunk));
+    },
+    text() {
+      return chunks.join("");
+    },
+  };
+}
+
+test("runMain does not mutate caller-owned argv arrays", async () => {
+  const argv = ["--debug-clicks"];
+  const env = {};
+  const stdout = captureStream();
+  const stderr = captureStream();
+
+  const exitCode = await runMain({
+    argv,
+    env,
+    stdinText: 'console.log("ready")',
+    stdout,
+    stderr,
+    services: { printUpdateBanner() {} },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.deepEqual(argv, ["--debug-clicks"]);
+  assert.equal(env.EGO_BROWSER_DEBUG_CLICKS, "1");
+  assert.equal(stdout.text(), "ready\n");
+  assert.equal(stderr.text(), "");
+});

--- a/package/ego-browser/src/run.ts
+++ b/package/ego-browser/src/run.ts
@@ -60,7 +60,7 @@ export const USAGE = `Usage:
 `;
 
 export async function runMain(options: RunMainOptions = {}) {
-  const argv = options.argv || process.argv.slice(2);
+  const argv = [...(options.argv || process.argv.slice(2))];
   const stdout = options.stdout || processStdout;
   const stderr = options.stderr || processStderr;
   const env = options.env || process.env;


### PR DESCRIPTION
## What

Copy `runMain` argv input before parsing CLI flags so caller-owned arrays are not mutated by flag handling.

## Why

`--debug-clicks` currently shifts from the `argv` array passed through `RunMainOptions`, which can surprise tests, embedders, or other programmatic callers that reuse the same array.

## How to verify

- `cd package/ego-browser && npm test`
- `cd package/ego-browser && npm run validate:site-skills`

## Impact

No helper surface changes. This only makes CLI option parsing non-mutating while preserving the existing `--debug-clicks` behavior.

## Note

The local pre-commit real-browser e2e hook could not run because this environment does not have the `ego-browser` command installed; the unit/integration suite and site-skill validation both pass.