### PR TITLE
docs: use browser automation wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="docs/assets/banner.png" alt="ego lite" width="100%" />
 
-**The fastest browser for AI agents to run web automation**
+**The fastest browser for AI agents to run browser automation**
 
 <a href="https://trendshift.io/repositories/42334?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-42334" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/42334" alt="citrolabs%2Fego-lite | Trendshift" width="250" height="55"/></a>
 


### PR DESCRIPTION
## Summary

- replace the README tagline wording from "web automation" to "browser automation"
- align the tagline with the terminology used throughout the README

## Testing

- not run (documentation-only change)
- `git diff --check`