### PR TITLE
docs(ego-browser): clarify taskSpaces.takeOver resolves no value

### DIFF
--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -171,6 +171,14 @@ A "user is controlling", "inactive", or "not assigned" error is a hard stop for 
 
 For login, captcha, or another manual step, finish all safe preparation in the current Bash invocation, call `taskSpaces.handOff([nameOrId])`, check its `done` result, and tell the user exactly what to do. Resume only after explicit confirmation: use `taskSpaces.takeOver(nameOrId)` for a space the agent handed off, or `taskSpaces.claim(id)` for an existing user-owned/inactive space.
 
+`taskSpaces.takeOver(nameOrId)` only restores agent control and resolves no value; `taskSpaces.claim(id)` resolves the task space. Do not assign the result of `takeOver` or read `task.id` from it. Keep the id returned by `useOrCreate` and reuse it when resuming:
+
+```js
+const taskId = 3
+await taskSpaces.takeOver(taskId)
+console.log(JSON.stringify({ taskSpaceId: taskId, url: (await page.info()).url }))
+```
+
 `taskSpaces.waitForAgentControl(nameOrId)` only polls; it never takes control. Use it only when the same script initiated the handoff and intentionally remains alive; after it resolves, continue the remaining work in that script.
 
 ## Choose the interaction path


### PR DESCRIPTION
Closes #171

Supersedes #172, which targeted `main` against the legacy task-space wording. This version is rebased onto `dev` and matches the current `taskSpaces.*` facade.

## What

Document that `taskSpaces.takeOver(nameOrId)` only restores agent control and resolves no value.

## Why

The Control handoff section tells agents to resume with `taskSpaces.takeOver(...)` but never stated its return contract. That makes it natural to write `const task = await taskSpaces.takeOver(3)` and read `task.id`, which throws `TypeError: Cannot read properties of undefined (reading 'id')` at runtime. `takeOverTaskSpace` in `package/ego-browser/src/helpers.ts` is typed `Promise<void>`; `claimTaskSpace` is the one that resolves a task space.

## How to verify

- `npm run validate:agent-style --prefix package/ego-browser` — passed (31 files)
- `npm run validate:site-skills --prefix package/ego-browser` — passed
- `git diff --check` — clean
- lefthook pre-commit — all 7 checks green

## Impact

Documentation only. No helper surface change. Single hunk in `skills/ego-browser/SKILL.md`; the example uses the existing `page.info()` / `console.log(JSON.stringify(...))` house style.

Please add the `docs` release-note label — I do not have triage permission on this repo.