### PR TITLE
fix: align Codex plugin marketplace name

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "ego-lite",
+  "name": "browser-skills",
   "version": "1.2.5",
   "description": "Browser automation for AI agents through ego lite.",
   "author": {

--- a/package/ego-browser/test/plugin-package.test.js
+++ b/package/ego-browser/test/plugin-package.test.js
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const marketplaceUrl = new URL(
+  "../../../.claude-plugin/marketplace.json",
+  import.meta.url,
+);
+const manifestUrl = new URL(
+  "../../../.codex-plugin/plugin.json",
+  import.meta.url,
+);
+
+test("marketplace plugin name matches the Codex plugin manifest", () => {
+  const marketplace = JSON.parse(
+    readFileSync(fileURLToPath(marketplaceUrl), "utf8"),
+  );
+  const manifest = JSON.parse(
+    readFileSync(fileURLToPath(manifestUrl), "utf8"),
+  );
+
+  assert.equal(marketplace.plugins.length, 1);
+  assert.equal(marketplace.plugins[0].name, manifest.name);
+});


### PR DESCRIPTION
## Summary

Align the Codex plugin manifest name with the existing `browser-skills` marketplace identity so Codex can install the plugin without breaking Claude Code users’ current installation ID.

## Related issue

No linked issue. Codex currently rejects the package because `.codex-plugin/plugin.json` declares `ego-lite` while the marketplace entry declares `browser-skills`.

## Changes

- Preserve the existing `browser-skills@ego-agent-skills` marketplace identity.
- Update the Codex manifest name to `browser-skills`.
- Add a regression test that requires the marketplace and Codex manifest names to match.

## Verification

```text
npm test
# 312 tests passed

codex plugin marketplace add /path/to/ego-lite
codex plugin add browser-skills@ego-agent-skills
# installed successfully in an isolated CODEX_HOME
```

## Impact

- [x] Installation or update flow
- [ ] Public helper API or behavior
- [ ] Agent skill or instructions
- [ ] Site learning
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

No helper API, runtime behavior, skill instructions, or dependencies change.

## Checklist

- [x] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc and agent-facing documentation are unchanged because the helper surface does not change.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [ ] A release-note label is selected (`fix` requested after PR creation).