### PR TITLE
fix(ego-browser): clip screenshots to the current scroll offset

### DIFF
--- a/package/ego-browser/src/driver/observe.test.mjs
+++ b/package/ego-browser/src/driver/observe.test.mjs
@@ -11,7 +11,7 @@ import {
 import { drainEvents, screenshot } from "../../dist/src/driver/observe.js";
 import { setOverrides } from "../../dist/src/state.js";
 
-function withCdpRuntime(fn) {
+function withCdpRuntime(fn, { evaluate } = {}) {
   const previous = globalThis.ego;
   const sent = [];
   const runtime = {
@@ -36,7 +36,9 @@ function withCdpRuntime(fn) {
       } else if (request.method === "Page.captureScreenshot") {
         result = { data: Buffer.from("png").toString("base64") };
       } else if (request.method === "Runtime.evaluate") {
-        result = { result: { value: "1" } };
+        result = {
+          result: { value: evaluate?.(request.params.expression) ?? "1" },
+        };
       }
       queueMicrotask(() =>
         runtime.onCDPMessage(JSON.stringify({ id: request.id, result })),
@@ -61,6 +63,80 @@ function withCdpRuntime(fn) {
       }
     });
 }
+
+// A scrolled page: the viewport sits 1500px down the document, so a clip pinned
+// to 0,0 would ask for content the compositor has not rasterized.
+const scrolledPageInfo = {
+  url: "https://example.com/",
+  title: "Example",
+  w: 800,
+  h: 600,
+  sx: 40,
+  sy: 1500,
+  pw: 800,
+  ph: 3000,
+};
+
+function scrolledPageMetrics(expression) {
+  return expression.includes("devicePixelRatio")
+    ? "1"
+    : JSON.stringify(scrolledPageInfo);
+}
+
+test("screenshot clips the viewport to the current scroll offset", async () => {
+  const restore = setOverrides({ async writeFile() {} });
+  try {
+    await withCdpRuntime(
+      async ({ sent }) => {
+        await screenshot({ path: "/tmp/ego-browser-scrolled-shot.png" });
+
+        const shot = sent.find(
+          (request) => request.method === "Page.captureScreenshot",
+        );
+        assert.equal(shot.params.captureBeyondViewport, false);
+        assert.deepEqual(shot.params.clip, {
+          x: scrolledPageInfo.sx,
+          y: scrolledPageInfo.sy,
+          width: scrolledPageInfo.w,
+          height: scrolledPageInfo.h,
+          scale: 1,
+        });
+      },
+      { evaluate: scrolledPageMetrics },
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("screenshot keeps fullPage captures anchored to the document origin", async () => {
+  const restore = setOverrides({ async writeFile() {} });
+  try {
+    await withCdpRuntime(
+      async ({ sent }) => {
+        await screenshot({
+          path: "/tmp/ego-browser-fullpage-shot.png",
+          fullPage: true,
+        });
+
+        const shot = sent.find(
+          (request) => request.method === "Page.captureScreenshot",
+        );
+        assert.equal(shot.params.captureBeyondViewport, true);
+        assert.deepEqual(shot.params.clip, {
+          x: 0,
+          y: 0,
+          width: scrolledPageInfo.pw,
+          height: scrolledPageInfo.ph,
+          scale: 1,
+        });
+      },
+      { evaluate: scrolledPageMetrics },
+    );
+  } finally {
+    restore();
+  }
+});
 
 test("screenshot skips page metric JavaScript while a native dialog is pending", async () => {
   const writes = [];

--- a/package/ego-browser/src/driver/observe.ts
+++ b/package/ego-browser/src/driver/observe.ts
@@ -122,9 +122,15 @@ export async function screenshot(options: ScreenshotOptions = {}) {
         if ("dialog" in info) {
           return screenshot({ ...options, path, raw: true });
         }
+        // Page.captureScreenshot clips in document coordinates. With
+        // captureBeyondViewport false the compositor only has the current
+        // viewport rasterized, so pinning the origin to 0,0 asks for the top of
+        // the document and comes back blank whenever the page is scrolled. Anchor
+        // the viewport clip to the scroll offset; fullPage rasterizes the whole
+        // document, where 0,0 is the right origin.
         params.clip = {
-          x: 0,
-          y: 0,
+          x: full ? 0 : info.sx,
+          y: full ? 0 : info.sy,
           width: full ? info.pw : info.w,
           height: full ? info.ph : info.h,
           scale: cssScale,


### PR DESCRIPTION
## What

Anchor the viewport screenshot clip to the page's current scroll offset, so `captureScreenshot()` stops returning a blank frame whenever `window.scrollY != 0`.

## Why

Fixes #163.

`Page.captureScreenshot` interprets `clip` in **document** coordinates. `screenshot()` built its clip with the origin pinned to `x: 0, y: 0` while `captureBeyondViewport` was `false` (`src/driver/observe.ts`). With the compositor holding only the current viewport rasterized, asking for the top of the document returns an empty frame once the page is scrolled — and it fails **silently**, resolving to a valid PNG path. An agent can report a visual verification it never actually performed.

`pageInfo()` already returns `sx` / `sy`, so the correct origin was on hand; at `scrollY = 0` the old clip merely happened to coincide with the viewport, which is why the bug went unnoticed.

## How to verify

A 5-band page, 600px each (3000px document). Run before and after the patch:

```js
await goto("file:///tmp/bands.html")
await waitForLoadState()

for (const y of [0, 1500, 0]) {
  await evaluate(`window.scrollTo(0, ${y})`)
  await waitForTimeout(1200)
  const info = await pageInfo()
  await screenshot({ path: `/tmp/shot-${y}-${Date.now()}.png` })
  console.log(info.sy, await evaluate(
    `(document.elementFromPoint(innerWidth/2, innerHeight/2)||{}).id || ''`))
}
```

Real browser (ego lite 0.4.5.5, macOS), same page state, old clip vs patched helper:

| scroll | probe at viewport centre | before | after |
| --- | --- | --- | --- |
| `sy = 0` | `b0` | 19 814 B — BAND 0 / 1 | 19 814 B — **byte-identical** |
| `sy = 1500` | `b3` | 7 680 B — **blank white** | 17 683 B — BAND 2 / 3 / 4 |
| `sy = 0` again | `b0` | 19 814 B | 19 814 B — **byte-identical** |

Both `sy = 0` captures are unchanged down to the SHA, so unscrolled behaviour does not move. `fullPage: true` taken *while* scrolled to 1500 still returns the whole document (BAND 0 → 4), confirming that branch is intact.

Regression coverage added in `src/driver/observe.test.mjs`:

- `screenshot clips the viewport to the current scroll offset` — asserts the `clip` handed to `Page.captureScreenshot` matches `pageInfo()`'s `sx` / `sy`. Fails on `main`/`dev` without this patch (`x: 0, y: 0` vs expected `x: 40, y: 1500`).
- `screenshot keeps fullPage captures anchored to the document origin` — guards the `fullPage` branch at `0,0`.

```
npm ci && npm test    # 313 pass / 0 fail (build + typecheck included)
npx prettier --check src/driver/observe.ts src/driver/observe.test.mjs   # clean
npm run e2e           # real-browser suite: see note below
```

`npm run e2e` reports one failure on my machine — `screencast recording: FFmpeg executable was not found` — which is environmental, not a regression: the embedded runtime is launched by macOS with a bare `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, so a Homebrew `ffmpeg` in `/opt/homebrew/bin` is unreachable and `EGO_BROWSER_FFMPEG_PATH` from the shell does not propagate into it. It reproduces identically on an unpatched `dev` checkout, and it exercises `video-recorder.ts`, which this PR does not touch.

## Impact

- **No helper surface change.** `screenshot()` keeps its name, options, and return type, so `SKILL.md` needs no update and nothing is required on the agent side.
- **Agents get a behaviour fix, not a contract change**: calls that silently produced blank PNGs now produce the viewport. Anything that captured at `scrollY = 0` is byte-for-byte unaffected.
- **The explicit `options.clip` path is deliberately untouched.** A caller passing `clip` is specifying document coordinates on purpose — that is the existing contract, and re-anchoring it to the scroll offset would silently shift their requested region.
- `raw: true` is likewise untouched.
- No runtime dependencies added.

---

_Release-note label: I do not have permission to apply labels on this repo. This should be categorised under **Fixes** — the repo has no `fix` label, but `bug` maps to that section in `.github/release.yml`. Could a maintainer add it?_
