### PR TITLE
fix(ego-browser): complete the implicit input role table

### DIFF
--- a/package/ego-browser/src/locator-query.test.mjs
+++ b/package/ego-browser/src/locator-query.test.mjs
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { queryAllExpression } from "../dist/src/locator-query.js";
+
+// Implicit roles per ARIA in HTML. An empty role means the input type has no
+// corresponding role and must not match any role locator.
+const INPUT_ROLES = [
+  [null, "textbox"],
+  ["text", "textbox"],
+  ["email", "textbox"],
+  ["tel", "textbox"],
+  ["url", "textbox"],
+  ["unknown-type", "textbox"],
+  ["search", "searchbox"],
+  ["number", "spinbutton"],
+  ["range", "slider"],
+  ["checkbox", "checkbox"],
+  ["radio", "radio"],
+  ["button", "button"],
+  ["submit", "button"],
+  ["reset", "button"],
+  ["image", "button"],
+  ["color", ""],
+  ["date", ""],
+  ["datetime-local", ""],
+  ["file", ""],
+  ["hidden", ""],
+  ["month", ""],
+  ["password", ""],
+  ["time", ""],
+  ["week", ""],
+];
+
+const NO_ROLE_TYPES = INPUT_ROLES.filter(([, role]) => !role).map(
+  ([type]) => type,
+);
+
+function fakeInput(type) {
+  const attributes = type === null ? {} : { type };
+  return {
+    tagName: "INPUT",
+    label: type === null ? "<input>" : `<input type="${type}">`,
+    getAttribute: (name) =>
+      Object.prototype.hasOwnProperty.call(attributes, name)
+        ? attributes[name]
+        : null,
+    hasAttribute: (name) =>
+      Object.prototype.hasOwnProperty.call(attributes, name),
+    setAttribute: (name, value) => {
+      attributes[name] = value;
+    },
+  };
+}
+
+function fakeDocument(inputs) {
+  const form = { querySelectorAll: () => inputs };
+  return {
+    querySelectorAll: (selector) => (selector === "form" ? [form] : inputs),
+    getElementById: () => null,
+  };
+}
+
+// Chained locators (page.locator("form").getByRole(...)) keep the injected-JS
+// DOM path, so this is the code path the implicit-role table actually serves.
+function matchingInputs(role, inputs) {
+  const selector = `internal:scope:${encodeURIComponent(
+    JSON.stringify({ base: "form", child: `loc=role:${role}` }),
+  )}`;
+  const evaluate = new Function(
+    "document",
+    `return ${queryAllExpression(selector)};`,
+  );
+  return evaluate(fakeDocument(inputs)).map((element) => element.label);
+}
+
+test("chained role locators map input types to their implicit ARIA roles", () => {
+  const inputs = INPUT_ROLES.map(([type]) => fakeInput(type));
+  const roles = new Set(INPUT_ROLES.map(([, role]) => role));
+  roles.delete("");
+  for (const role of roles) {
+    const expected = inputs
+      .filter((_, index) => INPUT_ROLES[index][1] === role)
+      .map((element) => element.label);
+    assert.deepEqual(matchingInputs(role, inputs), expected, `role:${role}`);
+  }
+});
+
+test("chained role locators skip input types with no implicit role", () => {
+  const inputs = NO_ROLE_TYPES.map((type) => fakeInput(type));
+  for (const role of ["textbox", "searchbox", "spinbutton", "button"]) {
+    assert.deepEqual(matchingInputs(role, inputs), [], `role:${role}`);
+  }
+});
+
+test("chained role locators treat a datalist-backed input as a combobox", () => {
+  const inputs = ["text", "search"].map((type) => {
+    const input = fakeInput(type);
+    input.setAttribute("list", "suggestions");
+    return input;
+  });
+  assert.deepEqual(matchingInputs("combobox", inputs), [
+    '<input type="text">',
+    '<input type="search">',
+  ]);
+  assert.deepEqual(matchingInputs("textbox", inputs), []);
+  assert.deepEqual(matchingInputs("searchbox", inputs), []);
+});

--- a/package/ego-browser/src/locator-query.ts
+++ b/package/ego-browser/src/locator-query.ts
@@ -389,10 +389,16 @@ function roleElementsExpression(locator, rootExpression = "document") {
         if (tag === 'img' && el.hasAttribute('alt')) return 'img';
         if (/^h[1-6]$/.test(tag)) return 'heading';
         if (tag === 'input') {
-          if (type === 'button' || type === 'submit' || type === 'reset') return 'button';
+          if (type === 'button' || type === 'submit' || type === 'reset' || type === 'image') return 'button';
           if (type === 'checkbox') return 'checkbox';
           if (type === 'radio') return 'radio';
           if (type === 'range') return 'slider';
+          if (type === 'number') return 'spinbutton';
+          // No corresponding ARIA role: these must not fall through to textbox.
+          if (['color', 'date', 'datetime-local', 'file', 'hidden', 'month', 'password', 'time', 'week'].includes(type)) return '';
+          if (el.hasAttribute('list')) return 'combobox';
+          if (type === 'search') return 'searchbox';
+          // text/email/tel/url, plus a missing or unknown type, which the browser renders as text.
           return 'textbox';
         }
         return '';


### PR DESCRIPTION
## Summary

Chained and filtered role locators (`internal:scope:` / `internal:filter:`) keep the injected-JS DOM path, and its implicit-role table mapped every `input` type it did not explicitly handle to `textbox`. So `role:textbox` matched inputs that have no accessible role at all — including `hidden` and `password` — while `role:spinbutton` and `role:searchbox` could never match anything.

#97 made the AX tree the single source of truth for root `role:` locators and deliberately left chained/filtered forms on the DOM path, describing what it kept there as "a partial implicit-role table". This completes that table. It does not change any routing.

## Related issue

None open. Found while reading the two match-set implementations after #97, so it is a self-contained correctness gap rather than a reported failure — I verified it directly against the generated expression instead (see Verification).

## Changes

- `src/locator-query.ts` — finish the implicit `input` role mapping per [ARIA in HTML](https://www.w3.org/TR/html-aria/#docconformance):
  - `number` → `spinbutton`, `search` → `searchbox`, `image` → `button`
  - `color`, `date`, `datetime-local`, `file`, `hidden`, `month`, `password`, `time`, `week` → no role (all were `textbox`)
  - a `list` attribute makes a text- or search-typed input a `combobox`
  - a missing or unknown `type` still resolves to `textbox`, matching how the browser renders it
- `src/locator-query.test.mjs` (new) — behaviour tests that evaluate the generated expression against a stubbed DOM and assert the whole match set per role. Colocated per `AGENTS.md`.

`select`'s `multiple` / `size` split (`combobox` vs `listbox`) is the adjacent gap in the same table. I left it out to keep this to one concern; happy to follow up.

## Verification

Run from `package/ego-browser`:

```text
npm test                                              # 314/314 pass (311 before, +3 new)
npm run typecheck                                     # clean
npm run validate:site-skills                          # site skills ok
npm audit --audit-level=moderate                      # 0 vulnerabilities
prettier --check src/locator-query.ts src/locator-query.test.mjs   # clean
```

The new tests fail against the unpatched table and pass with it, so they pin behaviour rather than restate the implementation:

```text
# reverting only src/locator-query.ts, keeping the new tests
not ok 255 - chained role locators map input types to their implicit ARIA roles
not ok 256 - chained role locators skip input types with no implicit role
not ok 257 - chained role locators treat a datalist-backed input as a combobox
# tests 314 | pass 311 | fail 3
```

Match sets from the expression generated for `page.locator("form").getByRole(...)`:

| locator | before | after |
| --- | --- | --- |
| `role:textbox` | also matched `hidden`, `number`, `search`, `image`, `file`, `color`, `date` | `text`, `email`, `tel`, `url`, untyped |
| `role:spinbutton` | matched nothing | `number` |
| `role:searchbox` | matched nothing | `search` |
| `role:button` | missed `image` | `button`, `submit`, `reset`, `image` |

`npm run e2e` was **not** run: it needs the macOS ego lite app to provide the `ego-browser` command and I am on Linux. This change only alters a generated DOM expression, and neither `ci.yml` nor `quality-gates.yml` runs e2e.

## Impact

- [x] Public helper API or behavior
- [ ] Agent skill or instructions
- [ ] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

A deliberate behaviour change, scoped to chained/filtered `role:` locators. Root `role:` locators are untouched — they resolve through the AX tree. A script that relied on `role:textbox` reaching a `hidden`, `password` or date-family input will now match fewer elements; that match was never reachable through the AX path, so the two paths agree more closely after this change than before.

## Checklist

- [x] The PR targets the correct base branch (`dev`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes.
- [x] Relevant tests and validation commands pass locally (e2e excepted, see above).
- [ ] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes — not applicable: no helper name or signature changed, and `SKILL.md` does not enumerate implicit roles.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [ ] A release-note label is selected — `fix` requested; I do not have write access to set labels.
