### PR TITLE
fix(ego-browser): resolve selectOption matches before clearing the selection

### DIFF
--- a/package/ego-browser/scripts/real-browser-e2e/cases/index.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/cases/index.mjs
@@ -12,6 +12,7 @@ import {
 } from "./pointer.mjs";
 import { keyboardCase } from "./keyboard.mjs";
 import { keyboardRegressionCase } from "./keyboard-regression.mjs";
+import { selectOptionAtomicCases } from "./select-option-atomic.mjs";
 import { macosInputRegressionCase } from "./macos-input-regression.mjs";
 import {
   cdpJsHelpCase,
@@ -59,6 +60,7 @@ export const e2eCases = [
   { name: "runtime regression", body: runtimeRegressionCase },
   { name: "screencast recording", body: videoRecordingCase },
   { name: "concert ticket rush", body: damaiRushCase },
+  ...selectOptionAtomicCases,
   ...adversarialCases,
   ...workflowCases,
   ...downloadCases,

--- a/package/ego-browser/scripts/real-browser-e2e/cases/select-option-atomic.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/cases/select-option-atomic.mjs
@@ -1,0 +1,72 @@
+import { homeCase } from "./shared.mjs";
+
+export const selectOptionAtomicCases = [
+  {
+    name: "selectOption keeps the current selection when no option matches",
+    body: homeCase(`
+      await page.locator("#dropdown").selectOption("gamma");
+      assertEqual(await page.locator("#dropdown").inputValue(), "gamma", "selectOption selects a later option");
+      assertEqual(await page.evaluate("window.__fixtureState.dropdownValue"), "gamma", "the page records the selection");
+
+      const misses = [
+        ["delta", "an unknown value"],
+        [{ label: "Delta" }, "an unknown label"],
+        [{ index: 7 }, "an out-of-range index"],
+      ];
+      for (const [wanted, label] of misses) {
+        await assertRejects(
+          () => page.locator("#dropdown").selectOption(wanted),
+          "could not find option",
+          "selectOption rejects " + label
+        );
+        assertEqual(
+          await page.locator("#dropdown").inputValue(),
+          "gamma",
+          "selectOption keeps the selected value after " + label
+        );
+        assertEqual(
+          await page.evaluate("window.__fixtureState.dropdownValue"),
+          "gamma",
+          "the page state still matches the DOM after " + label
+        );
+      }
+
+      await page.evaluate(\`(() => {
+        const select = document.createElement("select");
+        select.id = "multi-dropdown";
+        select.multiple = true;
+        for (const value of ["one", "two", "three"]) {
+          const option = document.createElement("option");
+          option.value = value;
+          option.textContent = value;
+          select.append(option);
+        }
+        document.body.append(select);
+        return true;
+      })()\`);
+
+      const multiValues = () =>
+        page.locator("#multi-dropdown").evaluate((el) =>
+          Array.from(el.selectedOptions).map((option) => option.value).join(",")
+        );
+
+      await page.locator("#multi-dropdown").selectOption(["one", "three"]);
+      assertEqual(await multiValues(), "one,three", "selectOption selects several options in a multiple select");
+      await assertRejects(
+        () => page.locator("#multi-dropdown").selectOption(["two", "four"]),
+        "could not find option",
+        "selectOption rejects a partly matching multiple selection"
+      );
+      assertEqual(await multiValues(), "one,three", "selectOption keeps every selected option after a partial miss");
+
+      /* A single select stops after the first requested value, so a trailing
+         unknown one is never looked up. */
+      assertEqual(
+        (await page.locator("#dropdown").selectOption(["beta", "delta"])).join(","),
+        "beta",
+        "a single select applies the first requested value and ignores the rest"
+      );
+      assertEqual(await page.locator("#dropdown").inputValue(), "beta", "the first requested value reaches the DOM");
+    `),
+  },
+];

--- a/package/ego-browser/src/driver/keyboard.test.mjs
+++ b/package/ego-browser/src/driver/keyboard.test.mjs
@@ -462,6 +462,120 @@ test("selectOption returns selected values", async () => {
   assert.match(call.params.functionDeclaration, /HTMLSelectElement/);
 });
 
+// Stand-in for the <select> that selectOption's page-side body runs against.
+// The body is applied to an instance of this class so the suite can read back
+// the selection and the events it left behind.
+class SelectStub {
+  constructor(values, selectedIndex, multiple = false) {
+    this.multiple = multiple;
+    this.options = values.map((value, index) => ({
+      value,
+      label: value.toUpperCase(),
+      text: value.toUpperCase(),
+      selected: index === selectedIndex,
+    }));
+    this.events = [];
+  }
+
+  dispatchEvent(event) {
+    this.events.push(event.type);
+    return true;
+  }
+
+  get selectedValues() {
+    return this.options
+      .filter((option) => option.selected)
+      .map((option) => option.value);
+  }
+}
+
+function selectStubHarness(stub) {
+  return setOverrides({
+    cdpOverride(method, params) {
+      if (method === "Runtime.evaluate") {
+        return { result: { objectId: "object-1" } };
+      }
+      if (method === "Runtime.callFunctionOn") {
+        const pageFunction = new Function(
+          "HTMLSelectElement",
+          `return (${params.functionDeclaration});`,
+        )(SelectStub);
+        try {
+          const value = pageFunction.apply(
+            stub,
+            params.arguments.map((argument) => argument.value),
+          );
+          return { result: { value } };
+        } catch (error) {
+          return {
+            result: { subtype: "error", description: String(error) },
+          };
+        }
+      }
+      return {};
+    },
+  });
+}
+
+test("selectOption leaves the selection alone when no option matches", async () => {
+  for (const wanted of ["delta", { label: "DELTA" }, { index: 7 }]) {
+    const stub = new SelectStub(["alpha", "beta", "gamma"], 2);
+    const restore = selectStubHarness(stub);
+    try {
+      await assert.rejects(
+        () => selectOption("#choice", wanted),
+        /could not find option/,
+      );
+    } finally {
+      restore();
+    }
+
+    assert.deepEqual(stub.selectedValues, ["gamma"]);
+    assert.deepEqual(stub.events, []);
+  }
+});
+
+test("selectOption keeps every selection in a multiple select on a partial miss", async () => {
+  const stub = new SelectStub(["one", "two", "three"], 0, true);
+  const selecting = selectStubHarness(stub);
+  try {
+    assert.deepEqual(await selectOption("#choice", ["one", "three"]), [
+      "one",
+      "three",
+    ]);
+  } finally {
+    selecting();
+  }
+
+  const restore = selectStubHarness(stub);
+  try {
+    await assert.rejects(
+      () => selectOption("#choice", ["two", "four"]),
+      /could not find option/,
+    );
+  } finally {
+    restore();
+  }
+
+  assert.deepEqual(stub.selectedValues, ["one", "three"]);
+  assert.deepEqual(stub.events, ["input", "change"]);
+});
+
+test("selectOption on a single select applies the first value and ignores the rest", async () => {
+  const stub = new SelectStub(["alpha", "beta", "gamma"], 2);
+  const restore = selectStubHarness(stub);
+  try {
+    assert.deepEqual(await selectOption("#choice", ["beta", "delta"]), [
+      "beta",
+    ]);
+  } finally {
+    restore();
+  }
+
+  assert.deepEqual(stub.selectedValues, ["beta"]);
+  assert.deepEqual(stub.events, ["input", "change"]);
+});
+
 test("setChecked rejects page-side validation errors", async () => {
   const restore = setOverrides({
     cdpOverride(method) {

--- a/package/ego-browser/src/driver/keyboard.ts
+++ b/package/ego-browser/src/driver/keyboard.ts
@@ -451,8 +451,7 @@ export async function selectOption(
         throw new Error("selectOption target must be a select element");
       }
       const wanted = Array.isArray(values) ? values : [values];
-      const selected = [];
-      for (const option of this.options) option.selected = false;
+      const matches = [];
       for (const wantedOption of wanted) {
         let match;
         if (typeof wantedOption === "object" && wantedOption !== null) {
@@ -467,9 +466,14 @@ export async function selectOption(
           match = [...this.options].find((option) => option.value === String(wantedOption));
         }
         if (!match) throw new Error("selectOption could not find option " + JSON.stringify(wantedOption));
+        matches.push(match);
+        if (!this.multiple) break;
+      }
+      const selected = [];
+      for (const option of this.options) option.selected = false;
+      for (const match of matches) {
         match.selected = true;
         selected.push(match.value);
-        if (!this.multiple) break;
       }
       this.dispatchEvent(new Event("input", { bubbles: true }));
       this.dispatchEvent(new Event("change", { bubbles: true }));


### PR DESCRIPTION
## Summary

`selectOption()` clears the whole option list before it looks for a match, so a call
naming an option the page does not have both throws *and* silently moves the selection.
The throw happens before the `input`/`change` dispatch, so the page is never told.

```js
await page.evaluate(`document.body.innerHTML =
  '<select id="qty"><option value="1">1<option value="2">2<option value="5" selected>5</select>'`)

await page.locator('#qty').selectOption('10')
// throws: ...selectOption could not find option "10"   <- correct
await page.locator('#qty').inputValue()              // "1"  <- was "5"
```

Measured at real Chromium `149.0.7827.55` (Playwright build 1228, headful) driving
`dist/src` through `installEgoSdk()`, with a `change` listener mirroring the value into
`window.__appQty`. Starting state is `DOM=5, app=5, changes=0` in every row:

| `values` | DOM value | app state | `change` events | result |
|---|---|---|---|---|
| `"10"` | 5 → **1** | 5 | 0 | throws |
| `{ label: "Ten" }` | 5 → **1** | 5 | 0 | throws |
| `{ index: 9 }` | 5 → **1** | 5 | 0 | throws |
| `"2"` | 5 → 2 | 2 | 1 | ok |
| `["2", "10"]` | 5 → 2 | 2 | 1 | ok |

The last two rows are unaffected and are included because they pin behaviour this change
deliberately preserves — see *Fix* below.

The failure is silent in both directions: the DOM now holds a value nobody asked for, and
no `input` or `change` fires, so the page's own `change`-derived state still holds the old
one. Any later read of that element — by the agent or by the page's own submit handler —
returns the wrong one.

## Related issue

No issue. Filing directly as it is a self-contained page-side ordering bug with a
real-browser reproduction and a regression case.

## Changes

- `src/driver/keyboard.ts` — `selectOption()`'s page-side body resolves every wanted value
  into a match list first and throws there; only after the loop completes does it clear
  `option.selected` and apply the matches. 10 lines, no other behaviour touched.
- `scripts/real-browser-e2e/cases/select-option-atomic.mjs` (new) + one registration in
  `cases/index.mjs` — real-browser case.
- `src/driver/keyboard.test.mjs` — three unit tests.

**Cause.** The body clears `option.selected` across the whole list, then resolves the
wanted values one at a time inside the same loop and throws from the middle of it. Because
a non-`multiple` select cannot have an empty selection, HTML's "ask for a reset" step then
selects its first option — which is why the DOM lands on `1` rather than on nothing.

**Fix.** Resolve first, mutate second. The resolution loop is moved verbatim, including its
existing `if (!this.multiple) break;`, so a single select still stops after the first
requested value and never looks up the ones behind it: `selectOption(["beta", "delta"])`
on a single select succeeds today and still succeeds, returning `["beta"]`. The returned
value order, the deselect-all-then-apply sequence, the error message and the
`input`/`change` dispatch are all unchanged. The only thing that moves is *when* the
mutation happens relative to the throw.

## Verification

Run from `package/ego-browser`.

```text
npm test                     314 pass / 0 fail   (311 on dev, +3 new)
npm run typecheck            clean
npm run validate:site-skills site skills ok
npx prettier --check <the four touched files>   All matched files use Prettier code style!
npm audit --audit-level=moderate                found 0 vulnerabilities
```

`npm run e2e` itself was **not** run: it shells out to the native `ego-browser` binary,
which is not installed here. The new case was instead executed against real Chromium by
booting the project's own `startFixtureServer()`, installing the SDK over CDP, and running
the exported case body — the same path the runner takes, minus the app binary.

Both tests were verified to fail without the fix, by reverting **only**
`src/driver/keyboard.ts` to `dev`, rebuilding, and re-running:

| | `dev` source | with the fix |
|---|---|---|
| e2e case `selectOption keeps the current selection when no option matches` | **FAIL** — `selectOption keeps the selected value after an unknown value: expected "gamma", got "alpha"` (3 of 16 assertions reached) | **PASS**, 16 assertions |
| `npm test` | 312 pass / **2 fail** | 314 pass / 0 fail |

The two failing unit tests are `selectOption leaves the selection alone when no option
matches` and `selectOption keeps every selection in a multiple select on a partial miss`.
The third new unit test, `selectOption on a single select applies the first value and
ignores the rest`, passes both before and after by design — it exists to pin the `break`
semantics the fix must not widen.

One honest caveat on the unit tests: they apply the page-side body to a stand-in select
object, so they observe the selection being *emptied* (`[]`), not reset to option 0 — the
"ask for a reset" step is the browser's, and only the e2e case sees it. The e2e case is
the load-bearing evidence; the unit tests are the fast guard.

The e2e case covers a missed value, a missed label and an out-of-range index against the
fixture `#dropdown` (asserting both the DOM value and `window.__fixtureState.dropdownValue`
stay in step), a partial miss on an injected `multiple` select, and the single-select
`break`.

## Impact

- [x] Public helper API or behavior
- [ ] Agent skill or instructions
- [ ] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

Compatibility: a `selectOption()` call that already succeeds is unaffected — same return
value, same events, same resulting selection. The change is only observable on a call that
throws, where the selection is now left as it was instead of being reset. Code relying on
a failed `selectOption()` clearing the select would change behaviour, but that is the
defect being fixed.

## Alternative considered

Snapshot `selectedIndex` / the selected set up front and restore it in a `catch` before
rethrowing. That keeps the current single-pass loop, but it fires no events either and
leaves a window where the select is momentarily cleared, so a `MutationObserver` or a
focus-driven handler could still observe the wrong state. Resolving first avoids the
window entirely. Happy to switch if you prefer the smaller textual diff.

## Checklist

- [x] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained above.
- [x] Relevant tests and validation commands pass locally.
- [ ] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes. — not applicable; the JSDoc for `selectOption()` is unchanged and still accurate.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [ ] A release-note label is selected (`feat`, `fix`, `docs`, `chore`, `ci`, or `refactor`). — `fix`; label application is silently dropped for non-collaborators, so please apply it.
