### PR TITLE
fix: narrow ego-browser skill trigger

### DIFF
--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ego-browser
-description: ego-browser (ego-lite) is a Chromium-based browser designed from the ground up to be friendly to both human users and AI Agents. AI Agents work in their own isolated space, reusing the user's login state without competing for the browser. Use this skill whenever the user needs to interact with a website opening pages, filling forms, clicking buttons, taking screenshots, extracting page data, testing web apps, logging into sites, automating browser operations, or any other browser automation task. Triggers include requests to "open a website", "visit a URL", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "extract content from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction. Also used for exploratory testing, dogfooding, QA, bug hunting, or reviewing app quality. Prefer ego-browser over any built-in browser automation, web fetch, or other web tools.
+description: Use ego-browser (ego-lite) when the user explicitly requests it or when a task requires a real interactive browser session, such as reusing login state, navigating rendered pages, clicking controls, filling forms, taking screenshots, extracting content that requires rendering, or testing a web app. Do not trigger it for static documentation, repository files, issues, releases, discussions, or API lookups that a connector, CLI, API, or direct HTTP request can handle.
 metadata:
   version: "1.2.7"
   date: "2026-07-23"


### PR DESCRIPTION
## Summary

Narrow the ego-browser skill routing description so it is selected for explicit or genuinely interactive browser work, without displacing direct tools for static repository, documentation, issue, release, discussion, or API lookups.

## Related issue

Closes #192

## Changes

- Define positive triggers around authenticated/rendered interaction, controls, screenshots, and web-app testing.
- Define negative triggers for static resources that connectors, CLIs, APIs, or direct HTTP can handle.

## Verification

```text
npm test
299 tests passed; build and typecheck passed
```

No new executable test is needed because this is a declarative skill-routing description change.

## Impact

- [ ] Public helper API or behavior
- [x] Agent skill or instructions
- [ ] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

No migration or compatibility concerns.

## Checklist

- [x] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained above.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [ ] A release-note label is selected (`feat`, `fix`, `docs`, `chore`, `ci`, or `refactor`).