### PR TITLE
fix(ego-browser): extract sessionId from params in cdp() to prevent silent misrouting

### DIFF
--- a/package/ego-browser/src/cdp-eval.test.mjs
+++ b/package/ego-browser/src/cdp-eval.test.mjs
@@ -252,6 +252,73 @@ test("cdp tracks Network domain state on enable", async () => {
   }
 });
 
+test("cdp extracts sessionId from params when not passed as third argument", async () => {
+  const calls = [];
+  const restore = setOverrides({
+    cdpOverride: async (method, params, sessionId) => {
+      calls.push([method, params, sessionId]);
+      return { value: "ok" };
+    },
+  });
+  try {
+    await cdp("Runtime.evaluate", {
+      expression: "1",
+      returnByValue: true,
+      sessionId: "sess-from-params",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][0], "Runtime.evaluate");
+    assert.equal(calls[0][2], "sess-from-params");
+  } finally {
+    restore();
+  }
+});
+
+test("cdp strips sessionId from params when extracted", async () => {
+  const calls = [];
+  const restore = setOverrides({
+    cdpOverride: async (method, params, sessionId) => {
+      calls.push([method, params, sessionId]);
+      return { value: "ok" };
+    },
+  });
+  try {
+    await cdp("Runtime.evaluate", {
+      expression: "1",
+      sessionId: "sess-456",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal("sessionId" in calls[0][1], false);
+    assert.equal(calls[0][1].expression, "1");
+    assert.equal(calls[0][2], "sess-456");
+  } finally {
+    restore();
+  }
+});
+
+test("cdp prefers explicit third-arg sessionId over params.sessionId", async () => {
+  const calls = [];
+  const restore = setOverrides({
+    cdpOverride: async (method, params, sessionId) => {
+      calls.push([method, params, sessionId]);
+      return { value: "ok" };
+    },
+  });
+  try {
+    await cdp(
+      "Runtime.evaluate",
+      { expression: "1", sessionId: "from-params" },
+      "explicit-sess",
+    );
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][2], "explicit-sess");
+    // params.sessionId is left alone when explicit sessionId is provided
+    assert.equal(calls[0][1].sessionId, "from-params");
+  } finally {
+    restore();
+  }
+});
+
 /* ------------------------------------------------------------------ */
 /*  evaluate() — Playwright-style pageFunction evaluation              */
 /* ------------------------------------------------------------------ */

--- a/package/ego-browser/src/cdp-eval.ts
+++ b/package/ego-browser/src/cdp-eval.ts
@@ -10,6 +10,19 @@ class TimeoutError extends Error {}
  * @returns {Promise<object>} CDP result object.
  */
 export async function cdp(method, params: any = {}, sessionId = undefined) {
+  // If sessionId is not passed as the third argument but sits inside params,
+  // extract it so the command routes to the intended target instead of
+  // silently falling back to the page session (issue #199).
+  if (
+    sessionId === undefined &&
+    params &&
+    typeof params === "object" &&
+    "sessionId" in params
+  ) {
+    sessionId = params.sessionId;
+    const { sessionId: _, ...rest } = params;
+    params = rest;
+  }
   const result = state.cdpOverride
     ? await state.cdpOverride(method, params, sessionId)
     : (await send({ method, params, session_id: sessionId })).result || {};


### PR DESCRIPTION
## Summary

Fix a bug where `cdp(method, params)` silently routes to the page session when `sessionId` is passed inside the `params` object instead of as the third argument. The fix extracts `sessionId` from `params` when it is not explicitly provided as the third argument, strips it from params, and routes the command to the correct target session.

## Issue

Fixes #199

## Changes

- **`src/cdp-eval.ts`**: Added extraction logic in `cdp()` — when `sessionId` is `undefined` (third arg) but exists in `params`, extract and use it. Strips it from `params` to prevent it being sent inside the CDP params object. An explicit third-arg `sessionId` still takes precedence.
- **`src/cdp-eval.test.mjs`**: Added 3 regression tests covering:
  1. Extracting `sessionId` from params when not passed as third arg
  2. Stripping `sessionId` from params after extraction
  3. Preferring the explicit third-arg `sessionId` over one in params

## How to verify

```bash
cd package/ego-browser
npm test
```

All 314 tests pass (0 failures). The 3 new tests validate:
- `cdp("Runtime.evaluate", { expression: "1", sessionId: "sess-from-params" })` → routes to `"sess-from-params"`
- The extracted `sessionId` is stripped from params before forwarding
- `cdp(m, { sessionId: "from-params" }, "explicit-sess")` → uses `"explicit-sess"`

## Impact

- **Helper surface**: No change — `cdp()` signature is unchanged, JSDoc is unchanged
- **Backward compatibility**: Fully backward-compatible. Calls using the correct third-argument form or with no sessionId are unaffected
- **Agent side**: No updates needed

## Additional Notes

The fix is a minimal surgical edit (13 lines in production code) following the project's four design principles. The approach honors the sessionId inside params rather than rejecting, which matches the principle of least surprise — if the caller put `sessionId` in params, they clearly intended to target that session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)