### PR TITLE
fix(runtime): scope page event waiters to their session to ignore cross-session events

### DIFF
--- a/package/ego-browser/src/browser-runtime.test.mjs
+++ b/package/ego-browser/src/browser-runtime.test.mjs
@@ -396,6 +396,87 @@ test("waitForBrowserEvent ignores events that happened before waiting", async ()
   }
 });
 
+test("waitForBrowserEvent ignores matching events from another session (issue #204)", async () => {
+  installAutoEgo();
+  try {
+    // Prime ego.onCDPMessage (set by rawCdp) so fireEvent can deliver events.
+    await browserCdp("Runtime.evaluate", { expression: "1" });
+    state.sessionId = "sess-active";
+    let resolved = false;
+    const promise = waitForBrowserEvent(
+      (event) => event.method === "Page.downloadWillBegin",
+      500,
+    ).then((event) => {
+      resolved = true;
+      return event;
+    });
+
+    // An event from a different page session must not resolve the waiter.
+    fireEvent("Page.downloadWillBegin", { guid: "other-session" }, "sess-b");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(
+      resolved,
+      false,
+      "waiter must ignore an event from another session",
+    );
+
+    // The active session's event resolves it.
+    fireEvent("Page.downloadWillBegin", { guid: "my-session" }, "sess-active");
+    const event = await promise;
+    assert.equal(event.params.guid, "my-session");
+  } finally {
+    cleanup();
+  }
+});
+
+test("waitForBrowserEvent honors an explicit sessionId scope", async () => {
+  installAutoEgo();
+  try {
+    // Prime ego.onCDPMessage (set by rawCdp) so fireEvent can deliver events.
+    await browserCdp("Runtime.evaluate", { expression: "1" });
+    state.sessionId = "sess-active";
+    let resolved = false;
+    const promise = waitForBrowserEvent(
+      (event) => event.method === "Page.downloadWillBegin",
+      500,
+      "sess-explicit",
+    ).then((event) => {
+      resolved = true;
+      return event;
+    });
+
+    // Even the active session's event is ignored when a different scope is set.
+    fireEvent("Page.downloadWillBegin", { guid: "active" }, "sess-active");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(resolved, false, "explicit scope must exclude other sessions");
+
+    fireEvent("Page.downloadWillBegin", { guid: "scoped" }, "sess-explicit");
+    const event = await promise;
+    assert.equal(event.params.guid, "scoped");
+  } finally {
+    cleanup();
+  }
+});
+
+test("waitForBrowserEvent still delivers events that carry no sessionId", async () => {
+  installAutoEgo();
+  try {
+    // Prime ego.onCDPMessage (set by rawCdp) so fireEvent can deliver events.
+    await browserCdp("Runtime.evaluate", { expression: "1" });
+    state.sessionId = "sess-active";
+    const promise = waitForBrowserEvent(
+      (event) => event.method === "Page.downloadWillBegin",
+      500,
+    );
+    // Browser-level / untagged events (no sessionId) stay unfiltered.
+    fireEvent("Page.downloadWillBegin", { guid: "untagged" });
+    const event = await promise;
+    assert.equal(event.params.guid, "untagged");
+  } finally {
+    cleanup();
+  }
+});
+
 test("drainBrowserEvents caps at MAX_BUFFERED_EVENTS (10000)", async () => {
   const calls = installManualEgo();
   try {

--- a/package/ego-browser/src/browser-runtime.ts
+++ b/package/ego-browser/src/browser-runtime.ts
@@ -169,10 +169,12 @@ export function drainBrowserEvents() {
 export function waitForBrowserEvent(
   predicate,
   timeoutMs = state.defaultTimeout,
+  sessionId = undefined,
 ) {
   return new Promise((resolve, reject) => {
     const waiter = {
       predicate,
+      sessionId,
       resolve,
       reject,
       timer: setTimeout(() => {
@@ -294,6 +296,20 @@ function handleMessage(message) {
     }
   }
   for (const waiter of [...eventWaiters]) {
+    // Page/network events carry the originating page session id. A waiter is
+    // scoped to a single session (its explicit sessionId, else the active page
+    // session), so ignore events from other sessions; otherwise a waiter on
+    // session A could resolve from a background target's event (issue #204).
+    // Events without a sessionId (browser-level, or bridges that omit it) are
+    // left unfiltered so existing behavior is preserved.
+    const expectedSession = waiter.sessionId ?? state.sessionId;
+    if (
+      data.sessionId &&
+      expectedSession &&
+      data.sessionId !== expectedSession
+    ) {
+      continue;
+    }
     let matched = false;
     try {
       matched = waiter.predicate(data);

--- a/package/ego-browser/src/driver/downloads.test.mjs
+++ b/package/ego-browser/src/driver/downloads.test.mjs
@@ -6,6 +6,7 @@ import {
   drainBrowserEvents,
   invalidateSession,
 } from "../../dist/src/browser-runtime.js";
+import { state } from "../../dist/src/state.js";
 import { waitForEvent } from "../../dist/src/driver/downloads.js";
 
 function installAutoEgo(options = {}) {
@@ -43,7 +44,10 @@ function installAutoEgo(options = {}) {
   return calls;
 }
 
-function fireEvent(method, params = {}, sessionId = "sess-1") {
+// Fire on the active page session by default. Download events arrive on the
+// session ego-browser attached to; the waiters are now scoped to that session
+// (issue #204), so events must carry the same sessionId ego-browser resolved.
+function fireEvent(method, params = {}, sessionId = state.sessionId) {
   globalThis.ego.onCDPMessage(JSON.stringify({ method, params, sessionId }));
 }
 


### PR DESCRIPTION
## Summary

`page.waitForEvent("download")`, `waitForRequest()`, and `waitForResponse()` can resolve from an event that belongs to a different CDP page session. The event predicates only match on method/payload and never check the originating session, so a waiter registered on session A can be completed by a matching event from another target (for example a background page or service worker emitting `Page.downloadWillBegin` or `Network.requestWillBeSent`).

## Related issue

Fixes #204

## Root cause

`waitForBrowserEvent` (`package/ego-browser/src/browser-runtime.ts`) stores a predicate-only waiter, and `handleMessage` runs every waiter's predicate against every event regardless of `data.sessionId`:

```ts
for (const waiter of [...eventWaiters]) {
  matched = waiter.predicate(data);   // no session check
  ...
}
```

The sibling subscriber path already filters by session (`if (subscriber.sessionId && subscriber.sessionId !== data.sessionId) continue;`). The waiter path was missing the equivalent guard.

## Fix

Scope each waiter to a session and skip events from other sessions, mirroring the subscriber design:

- `waitForBrowserEvent(predicate, timeoutMs, sessionId?)` now accepts an optional session id and stores it on the waiter.
- In `handleMessage`, the expected session is the waiter's explicit `sessionId` if given, otherwise the active page session (`state.sessionId`). Events whose `sessionId` differs are skipped.
- Events without a `sessionId` (browser-level events, or bridges that omit it) are left unfiltered, so existing behavior is preserved. The existing call sites (`downloads.ts`, `waits.ts`) need no change: they operate on the active page session and pick up the `state.sessionId` default at match time.

## Verification

- New regression tests in `browser-runtime.test.mjs`:
  - a waiter ignores a matching event from another session and then resolves from the active session's event;
  - an explicit `sessionId` scope excludes even the active session's event;
  - an event with no `sessionId` is still delivered (backward compatibility).
- Full `browser-runtime.test.mjs` suite: 42 passing. `tsc --noEmit` clean. `prettier --check` clean on both files.

To confirm the tests guard the bug, revert the `handleMessage` hunk: the cross-session test then resolves from the wrong session's event and fails.

## Impact

- [x] Public helper API or behavior (waiters are now session-scoped; `waitForBrowserEvent` gains an optional `sessionId` argument, default preserves current behavior)
- [x] No externally visible impact for single-session flows