### PR TITLE
fix(locator): await promises in locator.evaluate and evaluateAll(@ref)

### DIFF
--- a/package/ego-browser/src/driver/element-ops.ts
+++ b/package/ego-browser/src/driver/element-ops.ts
@@ -58,12 +58,15 @@ export async function withHandle(selectorOrRef, fn) {
  * @param {string} selectorOrRef Selector or ref string.
  * @param {string} functionDeclaration Function source whose `this` is the element.
  * @param {Array<unknown>} [args=[]] Arguments passed by value.
+ * @param {boolean} [awaitPromise=false] When true, resolve a promise returned by
+ *   the function before serializing (needed for async `evaluate` callbacks).
  * @returns {Promise<{result: any, objectId: string, sessionId?: string}>}
  */
 export async function resolveAndCall(
   selectorOrRef,
   functionDeclaration,
   args = [],
+  awaitPromise = false,
 ) {
   return withHandle(selectorOrRef, async ({ objectId, sessionId }) => {
     const result = await cdp(
@@ -73,7 +76,7 @@ export async function resolveAndCall(
         objectId,
         arguments: args.map((value) => ({ value })),
         returnByValue: true,
-        awaitPromise: false,
+        awaitPromise,
       },
       sessionId,
     );

--- a/package/ego-browser/src/driver/locator.test.mjs
+++ b/package/ego-browser/src/driver/locator.test.mjs
@@ -444,6 +444,84 @@ test("evaluateLocator runs a page function with one resolved element and an argu
   assert.equal(calls.at(-1).method, "Runtime.releaseObject");
 });
 
+test("evaluateLocator awaits a promise returned by an async page function", async () => {
+  const restore = setOverrides({
+    cdpOverride(method, params) {
+      if (method === "Runtime.evaluate") {
+        return { result: { objectId: "node-1" } };
+      }
+      if (method === "Runtime.callFunctionOn") {
+        assert.equal(
+          params.awaitPromise,
+          true,
+          "async locator.evaluate must ask CDP to await the returned promise",
+        );
+        // Simulate Chromium: the resolved value is only returned when awaitPromise
+        // is set; otherwise an unresolved promise serializes to {}.
+        return params.awaitPromise
+          ? { result: { value: "resolved" } }
+          : { result: { value: {} } };
+      }
+      return {};
+    },
+  });
+  try {
+    const value = await evaluateLocator(".item", async () => "resolved");
+    assert.equal(value, "resolved");
+  } finally {
+    restore();
+  }
+});
+
+test("evaluateAll awaits a promise for a ref selector", async () => {
+  browserRefMap.clear();
+  browserRefMap.add("1", 123, "button", "Submit");
+  const restore = setOverrides({
+    cdpOverride(method, params) {
+      if (method === "DOM.resolveNode") {
+        return { object: { objectId: "node-1" } };
+      }
+      if (method === "Runtime.callFunctionOn") {
+        assert.equal(params.awaitPromise, true);
+        return params.awaitPromise
+          ? { result: { value: 42 } }
+          : { result: { value: {} } };
+      }
+      return {};
+    },
+  });
+  try {
+    assert.equal(await evaluateAll("@1", async () => 42), 42);
+  } finally {
+    browserRefMap.clear();
+    restore();
+  }
+});
+
+test("plain element reads do not await promises (unchanged)", async () => {
+  const restore = setOverrides({
+    cdpOverride(method, params) {
+      if (method === "Runtime.evaluate") {
+        return { result: { objectId: "node-1" } };
+      }
+      if (method === "Runtime.callFunctionOn") {
+        assert.notEqual(
+          params.awaitPromise,
+          true,
+          "synchronous reads must not opt into promise awaiting",
+        );
+        return { result: { value: "hello" } };
+      }
+      return {};
+    },
+  });
+  try {
+    assert.equal(await textContent(".item"), "hello");
+  } finally {
+    restore();
+  }
+});
+
 test("evaluateAll supports refs as a single-element array", async () => {
   const calls = [];
   browserRefMap.clear();

--- a/package/ego-browser/src/driver/locator.ts
+++ b/package/ego-browser/src/driver/locator.ts
@@ -272,6 +272,7 @@ export async function evaluateLocator(selector, pageFunction, arg = undefined) {
       return pageFunction(this, arg);
     }`,
     [functionSource, arg],
+    true,
   );
 }
 
@@ -292,6 +293,7 @@ export async function evaluateAll(selector, pageFunction, arg = undefined) {
         return pageFunction([this], arg);
       }`,
       [functionSource, arg],
+      true,
     );
   }
   const backendNodeIds = await queryRoleBackendNodeIds(selector);
@@ -301,11 +303,21 @@ export async function evaluateAll(selector, pageFunction, arg = undefined) {
   return evaluateQueryAll(selector, functionSource, arg);
 }
 
-async function readElement(selector, functionDeclaration, args = []) {
+async function readElement(
+  selector,
+  functionDeclaration,
+  args = [],
+  awaitPromise = false,
+) {
   const deadline = state.now() + state.defaultTimeout;
   while (true) {
     try {
-      return await readElementOnce(selector, functionDeclaration, args);
+      return await readElementOnce(
+        selector,
+        functionDeclaration,
+        args,
+        awaitPromise,
+      );
     } catch (error) {
       if (
         !(error instanceof ElementResolutionError) ||
@@ -319,8 +331,18 @@ async function readElement(selector, functionDeclaration, args = []) {
   }
 }
 
-async function readElementOnce(selector, functionDeclaration, args = []) {
-  const { result } = await resolveAndCall(selector, functionDeclaration, args);
+async function readElementOnce(
+  selector,
+  functionDeclaration,
+  args = [],
+  awaitPromise = false,
+) {
+  const { result } = await resolveAndCall(
+    selector,
+    functionDeclaration,
+    args,
+    awaitPromise,
+  );
   return runtimeValue(result, functionDeclaration);
 }
 


### PR DESCRIPTION
## Summary

`locator.evaluate()` and `evaluateAll()` with an `@ref` selector do not await a promise returned by the page function, so an async callback resolves to `{}` / `null` instead of its value. The same call on a CSS or role selector works correctly. The result of the public API therefore depends on the selector form.

## Root cause

`evaluateAll` for a CSS selector uses `evaluateQueryAll`, and for a role selector uses `evaluateRoleBackendNodes(..., true)`; both issue the CDP call with `awaitPromise: true` (`locator.ts:299`, `locator.ts:441`).

But `evaluateLocator` (single-element `locator.evaluate`) and the `@ref` branch of `evaluateAll` route through `readElement` -> `readElementOnce` -> `resolveAndCall`, which called `Runtime.callFunctionOn` with a hardcoded `awaitPromise: false` (`element-ops.ts`). CDP then serializes the still-unresolved promise, which returns by value as `{}` / `null`.

Concretely:

```js
await page.locator('#x').evaluate(async el => el.textContent)         // -> null   (single element)
await page.locator('#x').evaluate(el => Promise.resolve(el.tagName))  // -> {}     (single element)
await evaluateAll('css=.item', async els => els.length)              // -> correct (query path)
```

## Fix

Thread an opt-in `awaitPromise` flag through `resolveAndCall` -> `readElement` -> `readElementOnce`, defaulting to `false`. Every existing caller (synchronous element reads like `textContent`/`getAttribute`, and the `keyboard`/`pointer` helpers) keeps `awaitPromise: false` unchanged. Only the two evaluate paths (`evaluateLocator` and the `evaluateAll` `@ref` branch) opt into `true`, matching the query path and Playwright semantics.

## Verification

New tests in `locator.test.mjs` simulate Chromium's `awaitPromise` behavior in the CDP mock (the resolved value is only returned when `awaitPromise` is set):

- `evaluateLocator awaits a promise returned by an async page function`: fails before this change (returns `{}`), passes after.
- `evaluateAll awaits a promise for a ref selector`: same, for the `@ref` path.
- `plain element reads do not await promises (unchanged)`: guards that synchronous reads keep `awaitPromise` unset.

Full `locator` / `keyboard` / `pointer` suites: 49 passing. `tsc --noEmit` clean. `prettier --check` clean.

## Impact

- [x] Public helper API or behavior (async `evaluate` callbacks now return their resolved value; synchronous behavior unchanged)
- [x] No externally visible impact for non-promise evaluate callbacks