### PR TITLE
fix(evaluate): recognize regex literals in hasReturnStatement

### DIFF
--- a/package/ego-browser/src/cdp-eval.test.mjs
+++ b/package/ego-browser/src/cdp-eval.test.mjs
@@ -30,6 +30,28 @@ test("hasReturnStatement does not match return as part of an identifier", () => 
   assert.equal(hasReturnStatement("const returnCode = 1; returnCode"), false);
 });
 
+test("hasReturnStatement ignores return inside a regex literal", () => {
+  assert.equal(
+    hasReturnStatement("/return/i.test(document.body.innerText)"),
+    false,
+  );
+  assert.equal(
+    hasReturnStatement("/no return value/.test(document.title)"),
+    false,
+  );
+  assert.equal(hasReturnStatement("[/return/, /also return/].length"), false);
+  assert.equal(hasReturnStatement("/[/]return[/]/.source"), false);
+});
+
+test("hasReturnStatement finds a real return past a regex containing a quote", () => {
+  assert.equal(hasReturnStatement("if (/'/.test(s)) foo(); return s;"), true);
+});
+
+test("hasReturnStatement treats a slash after a value as division, not a regex", () => {
+  assert.equal(hasReturnStatement("const rate = total / count; rate"), false);
+  assert.equal(hasReturnStatement("a / b / c"), false);
+});
+
 /* ------------------------------------------------------------------ */
 /*  decodeUnserializableJsValue — special CDP value decoding          */
 /* ------------------------------------------------------------------ */
@@ -291,6 +313,29 @@ test("evaluate passes plain expressions without IIFE wrapping", async () => {
     const result = await evaluate("1 + 2");
     assert.equal(result, 3);
     assert.equal(capturedExpression, "1 + 2");
+  } finally {
+    restore();
+  }
+});
+
+test("evaluate does not wrap a regex-literal expression in an IIFE", async () => {
+  let capturedExpression;
+  const restore = setOverrides({
+    cdpOverride: async (method, params) => {
+      if (method === "Runtime.evaluate") {
+        capturedExpression = params.expression;
+        return { result: { type: "boolean", value: false } };
+      }
+      return {};
+    },
+  });
+  try {
+    const expr = "/return/i.test(document.body.innerText)";
+    const result = await evaluate(expr);
+    // Must be sent verbatim; wrapping it as (function(){ ... })() would swallow
+    // the value and return undefined because the IIFE has no return.
+    assert.equal(capturedExpression, expr);
+    assert.equal(result, false);
   } finally {
     restore();
   }

--- a/package/ego-browser/src/cdp-eval.ts
+++ b/package/ego-browser/src/cdp-eval.ts
@@ -158,10 +158,19 @@ export function hasReturnStatement(expression) {
   let i = 0;
   let stateName = "code";
   let quote = "";
+  let inCharClass = false;
+  // Whether the previous significant token ended a value/expression. A `/` after
+  // a value is division; otherwise it begins a regex literal. Without this, a
+  // regex such as /return/ or /'/ is scanned as code and misreported.
+  let prevIsValue = false;
   while (i < expression.length) {
     const ch = expression[i];
     const next = expression[i + 1] || "";
     if (stateName === "code") {
+      if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+        i += 1;
+        continue;
+      }
       if (ch === "'" || ch === '"' || ch === "`") {
         stateName = "string";
         quote = ch;
@@ -178,6 +187,12 @@ export function hasReturnStatement(expression) {
         i += 2;
         continue;
       }
+      if (ch === "/" && !prevIsValue) {
+        stateName = "regex";
+        inCharClass = false;
+        i += 1;
+        continue;
+      }
       if (expression.startsWith("return", i)) {
         const before = i > 0 ? expression[i - 1] : "";
         const after = expression[i + 6] || "";
@@ -185,6 +200,7 @@ export function hasReturnStatement(expression) {
           return true;
         }
       }
+      prevIsValue = /[A-Za-z0-9_$)\]]/.test(ch);
       i += 1;
       continue;
     }
@@ -212,8 +228,41 @@ export function hasReturnStatement(expression) {
       if (ch === quote) {
         stateName = "code";
         quote = "";
+        prevIsValue = true;
       }
       i += 1;
+      continue;
+    }
+    if (stateName === "regex") {
+      if (ch === "\\") {
+        i += 2;
+        continue;
+      }
+      if (ch === "[") {
+        inCharClass = true;
+        i += 1;
+        continue;
+      }
+      if (ch === "]") {
+        inCharClass = false;
+        i += 1;
+        continue;
+      }
+      if (ch === "\n") {
+        // Unterminated regex literal; resume scanning as code.
+        stateName = "code";
+        prevIsValue = false;
+        i += 1;
+        continue;
+      }
+      if (ch === "/" && !inCharClass) {
+        stateName = "code";
+        prevIsValue = true;
+        i += 1;
+        continue;
+      }
+      i += 1;
+      continue;
     }
   }
   return false;


### PR DESCRIPTION
## Summary

`page.evaluate("...")` with a string expression can return the wrong result, or throw on a valid script, when the expression contains a regex literal. `hasReturnStatement` decides whether to wrap the expression in an IIFE, and its hand-rolled tokenizer had no concept of a regex literal, so any `/.../ ` was scanned as ordinary code.

## Symptoms

```js
await page.evaluate("/return/i.test(document.body.innerText)")
// hasReturnStatement returns true -> wrapped as (function(){ /return/i.test(...) })()
// the IIFE has no return -> result is undefined instead of the boolean

await page.evaluate("if (/'/.test(s)) foo(); return s;")
// the quote inside /'/ flips the scanner into string state and swallows the real
// top-level return -> not wrapped -> Runtime.evaluate throws "Illegal return statement"
```

The first case is the more dangerous one: the agent gets `undefined` with no error and makes a wrong decision.

## Fix

Add a `regex` state to the tokenizer. A `/` begins a regex literal when it follows a non-value token (start of input, an operator, `(`, `,`, `[`, `=`, etc.) and division when it follows a value (identifier, number, `)`, `]`). The regex state consumes through the closing unescaped `/`, honoring `[...]` character classes and `\` escapes. This is additive: a `/` after a value is still treated as division, so existing expressions are unaffected.

## Verification

- `hasReturnStatement` unit tests for regex literals (including a character class `/[/]/` and a quote `/'/` in the pattern), and for division (`a / b / c`) staying unrecognized as a regex.
- End-to-end test asserting `evaluate` sends `/return/i.test(...)` to `Runtime.evaluate` verbatim, not wrapped in an IIFE.
- Full `npm test` passes; `tsc --noEmit` and `prettier --check` clean.

## Impact

- [x] Public helper API or behavior (string-form `page.evaluate` with a regex literal now returns the correct value)
- [x] No externally visible impact for expressions without regex literals
