### PR TITLE
fix(keyboard): type astral-plane characters (emoji) instead of dropping them

### DIFF
--- a/package/ego-browser/src/driver/keyboard.test.mjs
+++ b/package/ego-browser/src/driver/keyboard.test.mjs
@@ -553,6 +553,30 @@ test("typeText presses text without focusing a selector", async () => {
   );
 });
 
+test("typeText types an astral-plane character (emoji) instead of dropping it", async () => {
+  const texts = [];
+  const restore = setOverrides({
+    cdpOverride(method, params) {
+      if (method === "Input.dispatchKeyEvent" && params.type === "keyDown") {
+        texts.push(params.text);
+      }
+      return {};
+    },
+  });
+  try {
+    await typeText("a😀b");
+  } finally {
+    restore();
+  }
+
+  // The emoji is a surrogate pair; it must still be typed as one character.
+  assert.equal(
+    texts.filter(Boolean).join(""),
+    "a😀b",
+    "emoji must be typed, not dropped",
+  );
+});
+
 test("pressOnSelector focuses a selector then presses a key", async () => {
   const calls = [];
   const restore = setOverrides({

--- a/package/ego-browser/src/driver/keyboard.ts
+++ b/package/ego-browser/src/driver/keyboard.ts
@@ -52,7 +52,11 @@ function keyDefinition(key) {
   if (special) {
     return special;
   }
-  if (key.length !== 1) {
+  // Count code points, not UTF-16 code units: an astral-plane character such as
+  // an emoji is a surrogate pair (key.length === 2) but a single printable
+  // character. Using key.length here would misclassify it as a named key and
+  // type nothing (text: "").
+  if ([...key].length !== 1) {
     return { vk: 0, key, code: key, text: "" };
   }
   const vk = key.toUpperCase().codePointAt(0);


### PR DESCRIPTION
## Summary

Typing a string that contains an astral-plane character (an emoji, and some CJK-Ext / mathematical symbols) through the keyboard API silently drops that character. `typeText("a😀b")` types `ab`. The surrounding characters type normally and no error is raised, so the field ends up with corrupted input the agent believes it entered correctly.

## Root cause

`keyDefinition` in `package/ego-browser/src/driver/keyboard.ts` classifies a key as a named special key vs a printable character with:

```ts
if (key.length !== 1) {
  return { vk: 0, key, code: key, text: "" };   // named key: nothing is typed
}
```

`key.length` is the UTF-16 code-unit count. An emoji such as `😀` is a surrogate pair with `key.length === 2`, so it is misclassified as a named key and assigned `text: ""`. `press()` then omits `text` from the `keyDown` event, so no character is inserted.

`fill()` is not affected (it uses `Input.insertText` with the whole value), which is why the same value fills correctly but types wrong, making the discrepancy easy to miss. The typing paths that are affected are `typeText` (keyboard.type), `pressSequentially`, and `pressOnSelector`.

## Fix

Count code points, not code units, so a single-code-point character (including an emoji) is treated as printable and carries its `text`:

```ts
if ([...key].length !== 1) {
```

## Verification

- New test: `typeText("a😀b")` now emits `keyDown` text `a`, `😀`, `b` (joined `a😀b`). It fails before the change (`ab`) and passes after.
- Full `npm test` passes; `tsc --noEmit` and `prettier --check` clean.

## Impact

- [x] Public helper API or behavior (emoji and other astral-plane characters now type correctly)
- [x] No externally visible impact for BMP text (single code unit is unchanged)
