### PR TITLE
fix(observe): recover the ref map under the same scope used to mint refs

### DIFF
--- a/package/ego-browser/src/driver/observe.test.mjs
+++ b/package/ego-browser/src/driver/observe.test.mjs
@@ -9,6 +9,7 @@ import {
   invalidateSession,
 } from "../../dist/src/browser-runtime.js";
 import { drainEvents, screenshot } from "../../dist/src/driver/observe.js";
+import { browserRefMap, ensureRefMapForRef } from "../../dist/src/ref-state.js";
 import { setOverrides } from "../../dist/src/state.js";
 
 function withCdpRuntime(fn) {
@@ -114,4 +115,36 @@ test("screenshot creates a missing parent directory", async () => {
 
 test("drainEvents returns the current event array synchronously", () => {
   assert.ok(Array.isArray(drainEvents()));
+});
+
+test("ref-map recovery snapshots with the same scope agents use to mint refs", async () => {
+  const previous = globalThis.ego;
+  let recoveryOptions;
+  globalThis.ego = {
+    async snapshot(options) {
+      recoveryOptions = options;
+      return {
+        content: "",
+        refs: [{ backendNodeId: 500, role: "button", name: "Off screen" }],
+      };
+    },
+  };
+  browserRefMap.clear();
+  try {
+    // Empty ref map + an @ref triggers the recovery snapshot (new-heredoc path).
+    await ensureRefMapForRef("@500");
+  } finally {
+    if (previous === undefined) {
+      delete globalThis.ego;
+    } else {
+      globalThis.ego = previous;
+    }
+    browserRefMap.clear();
+  }
+
+  assert.equal(
+    recoveryOptions?.scope,
+    "full_page",
+    "recovery must snapshot full_page, matching snapshot() defaults",
+  );
 });

--- a/package/ego-browser/src/driver/observe.ts
+++ b/package/ego-browser/src/driver/observe.ts
@@ -62,7 +62,11 @@ export async function snapshotRaw(options: SnapshotOptions = {}) {
   return result;
 }
 
-registerSnapshotForRefRefresh(() => snapshotRaw());
+// Rebuild an empty ref map (new heredoc / process) under the same scope agents
+// use to mint refs via snapshot() below. Using the bridge's default scope here
+// would only re-register refs for in-viewport elements, so an @ref for an
+// off-viewport element could never be recovered.
+registerSnapshotForRefRefresh(() => snapshotRaw({ scope: "full_page" }));
 
 /**
  * Return snapshot content with agent-friendly defaults. The text surface most


### PR DESCRIPTION
## Summary

The snapshot that rebuilds an empty ref map uses a different scope than the snapshot agents use to obtain refs, so an `@ref` for an off-viewport element can fail to resolve in a fresh heredoc.

## Details

`browserRefMap` is per-process module state, so it starts empty in every heredoc. The common agent pattern is: call `browser.snapshot()` in one heredoc to read the page and collect `@refs`, then act on a `@ref` (click/hover/read) in a later heredoc. That later call finds an empty map and rebuilds it via `ensureRefMapForRef` -> the registered recovery snapshot.

The agent-facing `snapshot()` mints refs with `scope: "full_page"` (observe.ts):

```ts
const result = await snapshotRaw({
  scope: options.scope ?? "full_page",
  includeActionMarks: options.includeActionMarks ?? true,
  includeStableLocator: options.includeStableLocator ?? true,
});
```

But the recovery callback snapshotted with no options, i.e. the bridge's default scope:

```ts
registerSnapshotForRefRefresh(() => snapshotRaw());
```

So refs are minted under `full_page` but recovered under the bridge default. If the bridge default is viewport-only, an `@ref` to an element outside the viewport is not re-registered and resolves to `Unknown ref`.

## Fix

Recover under the same scope agents mint refs with:

```ts
registerSnapshotForRefRefresh(() => snapshotRaw({ scope: "full_page" }));
```

(Recovery only consumes `result.refs`, so it does not need the action-mark / stable-locator annotations, only the full-page element coverage.)

## Verification

Deterministic unit test in `observe.test.mjs`: with an empty ref map, resolving an `@ref` triggers the recovery snapshot, and the options passed to the bridge now carry `scope: "full_page"`. The test fails before this change (scope is `undefined`) and passes after. Full `npm test`, `tsc --noEmit`, and `prettier --check` are clean.

## Caveat

The unit test proves the harness now recovers with the same scope it mints with. Whether the old behavior produced a hard `Unknown ref` additionally depends on the bridge's default snapshot scope, which is not in this repo. If the bridge already defaults to full_page this change is a harmless explicit alignment; if it is viewport-scoped (the reason `snapshot()` overrides it), it fixes off-viewport ref recovery. Either way the recovery path should not silently use a narrower scope than the mint path.

## Impact

- [x] Public helper API or behavior (ref recovery for off-viewport elements)
- [x] No externally visible impact when the mint and recovery scopes already agreed
