### PR TITLE
fix(load): keep polling when the readyState probe throws mid-navigation

### DIFF
--- a/package/ego-browser/src/driver/load.test.mjs
+++ b/package/ego-browser/src/driver/load.test.mjs
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { setOverrides } from "../../dist/src/state.js";
+import { waitForDocumentLoad } from "../../dist/src/driver/load.js";
+
+function committedTree(url = "https://example.com/app") {
+  return { frameTree: { frame: { url } } };
+}
+
+test("waitForDocumentLoad keeps polling when Runtime.evaluate throws transiently", async () => {
+  let evalCalls = 0;
+  let t = 0;
+  const restore = setOverrides({
+    now: () => t,
+    sleep: async (ms) => {
+      t += ms;
+    },
+    cdpOverride: async (method) => {
+      if (method === "Page.getFrameTree") return committedTree();
+      if (method === "Runtime.evaluate") {
+        evalCalls += 1;
+        // The execution context is torn down while a navigation commits.
+        if (evalCalls === 1) {
+          throw new Error("Execution context was destroyed.");
+        }
+        return { result: { value: "complete" } };
+      }
+      return {};
+    },
+  });
+  try {
+    const settled = await waitForDocumentLoad({ timeout: 5000 });
+    assert.equal(settled, true, "must settle after the transient eval error");
+    assert.ok(evalCalls >= 2, "must retry past the transient error");
+  } finally {
+    restore();
+  }
+});
+
+test("waitForDocumentLoad times out to false (does not throw) when evaluate keeps failing", async () => {
+  let t = 0;
+  const restore = setOverrides({
+    now: () => t,
+    sleep: async (ms) => {
+      t += ms;
+    },
+    cdpOverride: async (method) => {
+      if (method === "Page.getFrameTree") return committedTree();
+      if (method === "Runtime.evaluate") {
+        throw new Error("Cannot find context with specified id");
+      }
+      return {};
+    },
+  });
+  try {
+    const settled = await waitForDocumentLoad({ timeout: 900 });
+    assert.equal(
+      settled,
+      false,
+      "a persistent eval failure must time out to false, not reject",
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("waitForDocumentLoad resolves true once the frame is committed and complete", async () => {
+  let t = 0;
+  const restore = setOverrides({
+    now: () => t,
+    sleep: async (ms) => {
+      t += ms;
+    },
+    cdpOverride: async (method) => {
+      if (method === "Page.getFrameTree") return committedTree();
+      if (method === "Runtime.evaluate")
+        return { result: { value: "complete" } };
+      return {};
+    },
+  });
+  try {
+    assert.equal(await waitForDocumentLoad({ timeout: 5000 }), true);
+  } finally {
+    restore();
+  }
+});

--- a/package/ego-browser/src/driver/load.ts
+++ b/package/ego-browser/src/driver/load.ts
@@ -22,7 +22,16 @@ export async function waitForDocumentLoad(options: WaitForLoadOptions = {}) {
     } catch {
       // Page.getFrameTree may not be supported in some sessions; fall back to readyState only.
     }
-    if (committed && ready.includes(await evaluate("document.readyState"))) {
+    let readyState = "";
+    try {
+      readyState = await evaluate("document.readyState");
+    } catch {
+      // Runtime.evaluate can reject while the page is committing a navigation
+      // ("Execution context was destroyed"). Like the getFrameTree call above,
+      // treat this as not-ready-yet and keep polling instead of rejecting the
+      // whole wait.
+    }
+    if (committed && ready.includes(readyState)) {
       return true;
     }
     await state.sleep(300);


### PR DESCRIPTION
## Summary

`waitForDocumentLoad` rejects the whole navigation wait when its `document.readyState` probe throws, even though the loop is designed to poll until the page settles or the deadline elapses. During a navigation commit, `Runtime.evaluate` routinely rejects with "Execution context was destroyed." / "Cannot find context with specified id", so a normal navigation can surface as a spurious hard error.

## Root cause

`package/ego-browser/src/driver/load.ts` deliberately tolerates one CDP call failing on a transitioning page, but not the adjacent one:

```ts
try {
  const tree = await cdp("Page.getFrameTree");
  ...
} catch {
  // Page.getFrameTree may not be supported in some sessions; fall back to readyState only.
}
if (committed && ready.includes(await evaluate("document.readyState"))) {  // unguarded
  return true;
}
```

The `evaluate("document.readyState")` call issues `Runtime.evaluate`, which is exactly the call that fails mid-commit. Any rejection there escapes the loop and rejects the function, which is documented to return a boolean (`true` settled / `false` timed out), never to throw.

This wait backs `page.goto` (`nav.ts:65`), `browser.openOrReuseTab` (`nav.ts:192` / `202`), and `page.waitForLoadState` (`waits.ts:165`).

## Fix

Guard the `readyState` probe the same way `getFrameTree` is guarded: treat a rejection as not-ready-yet and keep polling.

```ts
let readyState = "";
try {
  readyState = await evaluate("document.readyState");
} catch {
  // Execution context can be torn down mid-navigation; retry on the next tick.
}
if (committed && ready.includes(readyState)) {
  return true;
}
```

## Verification

New `load.test.mjs` (deterministic, mock CDP via `setOverrides`):

- A one-time `Runtime.evaluate` rejection is tolerated: the wait keeps polling and returns `true` once the page reports `complete`. Fails before this change (the call rejects on the first eval error), passes after.
- A persistent eval failure times out to `false` rather than rejecting.
- The committed-and-complete happy path returns `true`.

Full `npm test`, `tsc --noEmit`, and `prettier --check` are clean.

## Impact

- [x] Public helper API or behavior (navigation waits no longer throw on a transient mid-navigation eval failure)
- [x] No externally visible impact when the readyState probe succeeds
