### PR TITLE
fix(helpers): treat a nullish getByRole name / filter value as no filter

### DIFF
--- a/package/ego-browser/src/helpers.test.mjs
+++ b/package/ego-browser/src/helpers.test.mjs
@@ -224,6 +224,35 @@ test("helper surface exposes Playwright-style object facades", () => {
   assert.equal("elementEval" in context, false);
 });
 
+test("getByRole treats a nullish name as no name filter", () => {
+  const page = helperContext().page;
+  // A computed name that came out undefined/null must match all elements of the
+  // role (Playwright semantics), not the literal string "undefined"/"null".
+  assert.equal(
+    page.getByRole("button", { name: undefined }).selector,
+    "loc=role:button",
+  );
+  assert.equal(
+    page.getByRole("button", { name: null }).selector,
+    "loc=role:button",
+  );
+  // A real name still filters.
+  assert.equal(
+    page.getByRole("button", { name: "Save" }).selector,
+    'loc=role:button[name="Save"]',
+  );
+});
+
+test("filter treats a nullish hasText as no filter", () => {
+  const filter = helperContext()
+    .page.locator("#target")
+    .filter({ hasText: undefined }).selector;
+  assert.deepEqual(
+    JSON.parse(decodeURIComponent(filter.slice("internal:filter:".length))),
+    { base: "#target" },
+  );
+});
+
 test("page.url reads the current URL asynchronously", async () => {
   const restore = setOverrides({
     cdpOverride: async (method) => {

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -639,8 +639,12 @@ function textSelector(prefix, text, options: any = {}) {
 }
 
 function roleSelector(role, options: any = {}) {
+  // A nullish name (e.g. getByRole("button", { name: label }) with an undefined
+  // label) means "no name filter", matching all elements of the role, as in
+  // Playwright. Gating on key presence would instead filter on the literal
+  // string "undefined"/"null" and match nothing.
   const name =
-    options && Object.prototype.hasOwnProperty.call(options, "name")
+    options && options.name != null
       ? `[name=${JSON.stringify(roleNameMatcher(options.name))}]`
       : "";
   return `loc=role:${role}${name}`;
@@ -651,17 +655,20 @@ function testIdSelector(testId) {
 }
 
 function filterSelector(base, options: any = {}) {
+  // Gate every filter on the value being present, not just the key, so a nullish
+  // option (a computed value that came out undefined) is treated as "no filter"
+  // instead of matching the literal string "undefined"/"null".
   const data: any = { base };
-  if (Object.prototype.hasOwnProperty.call(options, "hasText")) {
+  if (options.hasText != null) {
     data.hasText = textMatcher(options.hasText);
   }
-  if (Object.prototype.hasOwnProperty.call(options, "hasNotText")) {
+  if (options.hasNotText != null) {
     data.hasNotText = textMatcher(options.hasNotText);
   }
-  if (options.has !== undefined) {
+  if (options.has != null) {
     data.has = locatorSelector(options.has);
   }
-  if (options.hasNot !== undefined) {
+  if (options.hasNot != null) {
     data.hasNot = locatorSelector(options.hasNot);
   }
   return internalSelector("filter", data);


### PR DESCRIPTION
## Summary

`page.getByRole(role, { name })` (and `locator.filter({ hasText })`) treat an explicitly nullish value as an active filter on the literal string `"undefined"` / `"null"`, instead of "no filter". So `getByRole("button", { name: undefined })` matches only buttons whose accessible name is literally the word "undefined" (practically none) and then auto-waits to a timeout, rather than matching all buttons as Playwright does.

## Root cause

`package/ego-browser/src/helpers.ts` gates these filters on the key being present rather than the value being defined:

```ts
// roleSelector
const name =
  options && Object.prototype.hasOwnProperty.call(options, "name")
    ? `[name=${JSON.stringify(roleNameMatcher(options.name))}]`
    : "";
```

`{ name: undefined }` has the key, so the branch runs; `JSON.stringify(roleNameMatcher(undefined))` interpolates as the text `undefined`, producing `loc=role:button[name=undefined]`, which `locator-query.ts` compiles to `accessibleName(el) === "undefined"`.

Verified against the built runtime:

| call | actual selector | expected |
|---|---|---|
| `getByRole("button", { name: undefined })` | `loc=role:button[name=undefined]` | `loc=role:button` |
| `getByRole("button", { name: null })` | `loc=role:button[name=null]` | `loc=role:button` |
| `getByRole("button", { name: "Save" })` | `loc=role:button[name="Save"]` | unchanged |

The inconsistency is the tell: in the same `filterSelector`, `has` / `hasNot` already gate on `!== undefined`, while `name` / `hasText` / `hasNotText` used `hasOwnProperty`.

Agents commonly pass a computed value, `getByRole("button", { name: label })`; when `label` is `undefined` Playwright degrades to "any button", but this facade silently breaks to "button named 'undefined'".

## Fix

Gate every filter on the value being non-nullish (`!= null`), so both `undefined` and `null` mean "no filter", in `roleSelector` and all four `filterSelector` options.

## Verification

- New tests: `getByRole("button", { name: undefined | null })` now yields `loc=role:button`; a real name still filters; `filter({ hasText: undefined })` yields no `hasText` in the compiled selector.
- Full `npm test`, `tsc --noEmit`, and `prettier --check` are clean.

## Impact

- [x] Public helper API or behavior (nullish name / hasText now match Playwright's "omit the filter" semantics)
- [x] No externally visible impact for present filter values
