### PR TITLE
fix(ego-browser): probe the installed skill location for the agent workspace

### DIFF
--- a/package/ego-browser/src/env.test.mjs
+++ b/package/ego-browser/src/env.test.mjs
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+
+import { agentWorkspace, REPO_ROOT, SRC_DIR } from "../dist/src/env.js";
+
+const BUNDLED_SKILL = resolve(SRC_DIR, "ego-browser");
+const REPO_SKILL = resolve(REPO_ROOT, "..", "..", "skills", "ego-browser");
+const HOME = resolve("/home/agent");
+const INSTALL_ROOT = resolve(HOME, ".local", "share", "ego", "ego-skills");
+
+function existsIn(paths) {
+  return (path) => paths.includes(path);
+}
+
+test("agentWorkspace prefers the EGO_BROWSER_AGENT_WORKSPACE override", () => {
+  const override = resolve("/workspaces/custom");
+  const result = agentWorkspace({
+    env: { EGO_BROWSER_AGENT_WORKSPACE: override },
+    exists: () => true,
+  });
+  assert.equal(result, override);
+});
+
+test("agentWorkspace uses the skill bundled next to the build output", () => {
+  const result = agentWorkspace({ env: {}, exists: existsIn([BUNDLED_SKILL]) });
+  assert.equal(result, BUNDLED_SKILL);
+});
+
+test("agentWorkspace uses the repo-layout skill when it exists", () => {
+  const result = agentWorkspace({ env: {}, exists: existsIn([REPO_SKILL]) });
+  assert.equal(result, REPO_SKILL);
+});
+
+test("agentWorkspace falls back to the installed skill registered by onboarding", () => {
+  const result = agentWorkspace({
+    env: { HOME },
+    exists: existsIn([resolve(INSTALL_ROOT, "learnings")]),
+  });
+  assert.equal(result, INSTALL_ROOT);
+});
+
+test("agentWorkspace prefers an ego-browser subdirectory inside the install root", () => {
+  const result = agentWorkspace({
+    env: { HOME },
+    exists: existsIn([
+      resolve(INSTALL_ROOT, "ego-browser", "learnings"),
+      resolve(INSTALL_ROOT, "learnings"),
+    ]),
+  });
+  assert.equal(result, resolve(INSTALL_ROOT, "ego-browser"));
+});
+
+test("agentWorkspace ignores an installed directory without learnings", () => {
+  const result = agentWorkspace({
+    env: { HOME },
+    exists: existsIn([INSTALL_ROOT]),
+  });
+  assert.equal(result, REPO_SKILL);
+});
+
+test("agentWorkspace resolves the home directory from USERPROFILE", () => {
+  const result = agentWorkspace({
+    env: { USERPROFILE: HOME },
+    exists: existsIn([resolve(INSTALL_ROOT, "learnings")]),
+  });
+  assert.equal(result, INSTALL_ROOT);
+});
+
+test("agentWorkspace keeps the repo-layout path when nothing exists", () => {
+  const result = agentWorkspace({ env: {}, exists: () => false });
+  assert.equal(result, REPO_SKILL);
+});

--- a/package/ego-browser/src/env.ts
+++ b/package/ego-browser/src/env.ts
@@ -5,22 +5,57 @@ import { fileURLToPath } from "node:url";
 export const SRC_DIR = dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = resolve(SRC_DIR, "..");
 
-export function agentWorkspace() {
-  if (process.env.EGO_BROWSER_AGENT_WORKSPACE) {
-    return resolvePath(process.env.EGO_BROWSER_AGENT_WORKSPACE);
+export function agentWorkspace({
+  env = process.env,
+  exists = existsSync,
+} = {}) {
+  if (env.EGO_BROWSER_AGENT_WORKSPACE) {
+    return resolvePath(env.EGO_BROWSER_AGENT_WORKSPACE);
   }
 
   const bundledSkill = resolve(SRC_DIR, "ego-browser");
-  if (existsSync(bundledSkill)) {
+  if (exists(bundledSkill)) {
     return bundledSkill;
   }
 
-  return resolve(REPO_ROOT, "..", "..", "skills", "ego-browser");
+  const repoSkill = resolve(REPO_ROOT, "..", "..", "skills", "ego-browser");
+  if (exists(repoSkill)) {
+    return repoSkill;
+  }
+
+  // In the app-bundled runtime neither module-relative candidate exists on
+  // disk (the skill payload ships elsewhere in the bundle), so the repo-layout
+  // path resolves to a directory that is not there. Onboarding registers the
+  // shipped skill at a user-level location; accept it only when it actually
+  // holds learnings, so a stale leftover directory cannot claim the workspace.
+  for (const installedSkill of installedSkillCandidates(env)) {
+    if (exists(resolve(installedSkill, "learnings"))) {
+      return installedSkill;
+    }
+  }
+
+  return repoSkill;
+}
+
+// Onboarding links the shipped skill payload to ~/.local/share/ego/ego-skills;
+// depending on the link target that path is the skill directory itself or a
+// directory holding an ego-browser/ subdirectory. Resolved against the home
+// directory directly so behavior is identical on POSIX and Windows.
+function installedSkillCandidates(env) {
+  const home = env.HOME || env.USERPROFILE;
+  if (!home) {
+    return [];
+  }
+  const installRoot = resolve(home, ".local", "share", "ego", "ego-skills");
+  return [resolve(installRoot, "ego-browser"), installRoot];
 }
 
 export function resolvePath(path) {
   if (path.startsWith("~")) {
-    return resolve(process.env.HOME || process.env.USERPROFILE || ".", path.slice(1));
+    return resolve(
+      process.env.HOME || process.env.USERPROFILE || ".",
+      path.slice(1),
+    );
   }
   return resolve(path);
 }
@@ -36,7 +71,10 @@ export function loadEnvFile(path) {
     }
     const index = line.indexOf("=");
     const key = line.slice(0, index).trim();
-    const value = line.slice(index + 1).trim().replace(/^['"]|['"]$/g, "");
+    const value = line
+      .slice(index + 1)
+      .trim()
+      .replace(/^['"]|['"]$/g, "");
     if (key && process.env[key] === undefined) {
       process.env[key] = value;
     }


### PR DESCRIPTION
## Summary

In the app-bundled CLI the agent-workspace fallback resolves to a path that does not exist (from a root cwd, literally `/skills/ego-browser`), so the entire site-learnings subsystem is unreachable even though the learning packs ship with the app and are present on disk. This PR keeps the existing resolution precedence and adds one narrow step: when neither module-relative candidate exists on disk, probe the user-level location onboarding registers, accepting it only when it actually holds `learnings/`.

## Related issue

Fixes the runtime-side root cause reported in #215. Note the reporter self-closed that issue (before this PR opened) after finding the in-process `process.env.EGO_BROWSER_AGENT_WORKSPACE = ...` workaround — the resolution defect itself is still present on `dev`, and this PR makes the workaround unnecessary for the CLI half. The app-side half (caller env not forwarded into the embedded runtime) remains out of this repo's reach.

## Changes

- `src/env.ts` — `agentWorkspace()` keeps the current precedence (env override → skill bundled next to the build output → repo layout). New behavior only starts where the old chain returned a nonexistent path: when neither module-relative candidate exists, it probes `~/.local/share/ego/ego-skills` (the location onboarding links, per the report in #215) both as the skill directory itself and as a parent of `ego-browser/`. A candidate is accepted only when it holds `learnings/`, so a stale leftover directory cannot claim the workspace. When nothing exists anywhere, the returned value is byte-identical to today's (the repo-layout path).
- The home directory is resolved from `HOME` / `USERPROFILE` directly rather than through `resolvePath("~...")`, deliberately: the `~`-expansion defect in `resolvePath` is already being fixed by #146 and #148, and this PR must not collide with either.
- `agentWorkspace()` gains an injectable `{ env, exists }` seam (defaulting to `process.env` / `existsSync`) so the bundled-runtime layout is testable without touching the real filesystem — same injectable-seam pattern as `update-notice.ts`. All call sites are unchanged (`agentWorkspace()`).
- `src/env.test.mjs` — 8 regression tests covering the full decision table: override precedence, bundled candidate, repo-layout candidate, installed-root fallback, `ego-browser/` subdirectory priority, rejection of an installed directory without `learnings/`, `USERPROFILE` resolution, and the nothing-exists default.

Note: prettier normalized two pre-existing unformatted blocks in `env.ts` (`resolvePath`, `loadEnvFile`) because the changed-file style gate checks whole files. Same situation #148 documented.

## Verification

Run from `package/ego-browser` (Windows 11, Node 24; suite is platform-neutral):

```text
npm test                      -> 319 pass, 0 fail (311 existing + 8 new)
npm run typecheck             -> ok
npm run validate:site-skills  -> site skills ok
npm audit --audit-level=moderate -> 0 vulnerabilities
prettier --check src/env.ts src/env.test.mjs -> ok
```

The new tests fail without the fix: reverting the `src/env.ts` change makes "falls back to the installed skill registered by onboarding", "prefers an ego-browser subdirectory inside the install root", and "resolves the home directory from USERPROFILE" fail (the old chain returns the repo-layout path).

I don't have a macOS install to run the shipped app against; the repro and paths come from the detailed report in #215. Behavior for repo checkouts is covered by the tests and unchanged.

## Impact

- [x] Public helper API or behavior
- [ ] Agent skill or instructions
- [ ] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

Behavior change is strictly additive: the fallback only fires where the previous result was a nonexistent directory, so `learnContext()` / `runSiteTool` / `runSiteBrowserTool` start working in the app-bundled CLI without `EGO_BROWSER_AGENT_WORKSPACE`. Repo checkouts, the env override, and the SDK path resolve exactly as before. Composes cleanly with #146/#148 (different functions in the same file; no shared hunks beyond formatting).

## Checklist

- [x] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained above.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [x] A release-note label is selected (`fix`).
