### PR TITLE
fix(ego-browser): name downloads by guid and confine the reported path

### DIFF
--- a/package/ego-browser/src/driver/downloads.test.mjs
+++ b/package/ego-browser/src/driver/downloads.test.mjs
@@ -71,10 +71,15 @@ test("waitForEvent('download') returns a Playwright-style download facade", asyn
     const download = await promise;
     assert.equal(download.suggestedFilename(), "file.png");
     assert.equal(download.url(), "https://example.com/file.png");
-    assert.match(await download.path(), /file\.png$/);
-    assert.ok(
-      calls.some((call) => call.method === "Browser.setDownloadBehavior"),
-      "enables browser download behavior",
+    assert.match(await download.path(), /download-1$/);
+    const behaviorCall = calls.find(
+      (call) => call.method === "Browser.setDownloadBehavior",
+    );
+    assert.ok(behaviorCall, "enables browser download behavior");
+    assert.equal(
+      behaviorCall.params.behavior,
+      "allowAndName",
+      "names the file on disk by its download guid",
     );
   } finally {
     cleanup();
@@ -113,11 +118,61 @@ test("waitForEvent('download') falls back to Page.setDownloadBehavior", async ()
       guid: "download-1",
       state: "completed",
     });
-    await promise;
+    const download = await promise;
+    const behaviorCall = calls.find(
+      (call) => call.method === "Page.setDownloadBehavior",
+    );
     assert.ok(
-      calls.some((call) => call.method === "Page.setDownloadBehavior"),
+      behaviorCall,
       "uses page-level download behavior when browser-level command is missing",
     );
+    assert.equal(
+      behaviorCall.params.behavior,
+      "allow",
+      "Page.setDownloadBehavior does not support allowAndName",
+    );
+    assert.match(
+      await download.path(),
+      /file\.png$/,
+      "derives the path from suggestedFilename when the browser names the file",
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("waitForEvent('download') derives the path from suggestedFilename when the guid is missing", async () => {
+  installAutoEgo();
+  try {
+    const promise = waitForEvent("download", { timeout: 1000 });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    fireEvent("Page.downloadWillBegin", {
+      url: "https://example.com/file.png",
+      suggestedFilename: "file.png",
+    });
+    fireEvent("Page.downloadProgress", { state: "completed" });
+    const download = await promise;
+    assert.equal(download.suggestedFilename(), "file.png");
+    assert.match(await download.path(), /file\.png$/);
+  } finally {
+    cleanup();
+  }
+});
+
+test("waitForEvent('download') rejects a path that escapes the download directory", async () => {
+  installAutoEgo({ browserSetDownloadBehaviorError: true });
+  try {
+    const promise = waitForEvent("download", { timeout: 1000 });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    fireEvent("Page.downloadWillBegin", {
+      guid: "download-1",
+      suggestedFilename: "../escaped.png",
+    });
+    fireEvent("Page.downloadProgress", {
+      guid: "download-1",
+      state: "completed",
+    });
+    await assert.rejects(promise, /escapes the download directory/);
   } finally {
     cleanup();
   }

--- a/package/ego-browser/src/driver/downloads.ts
+++ b/package/ego-browser/src/driver/downloads.ts
@@ -1,6 +1,6 @@
 import { mkdirSync } from "node:fs";
 import { copyFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve, sep } from "node:path";
 import { tmpdir } from "node:os";
 
 import { cdp } from "../cdp-eval.js";
@@ -68,7 +68,7 @@ async function waitForDownload(options: WaitForEventOptions = {}) {
         event?.params?.state === "canceled"),
     timeout,
   ) as Promise<DownloadProgress>;
-  await Promise.all([sessionPromise, behaviorPromise]);
+  const [, naming] = await Promise.all([sessionPromise, behaviorPromise]);
   const willBegin = await willBeginPromise;
   const guid = willBegin.params?.guid;
   downloadGuid = guid;
@@ -78,7 +78,13 @@ async function waitForDownload(options: WaitForEventOptions = {}) {
   if (progress.params?.state === "canceled") {
     throw new Error(`Download canceled: ${suggestedFilename}`);
   }
-  const downloadedPath = join(downloadDir, suggestedFilename);
+  // Under "allowAndName" the browser writes the file as its download guid, so
+  // the reported path cannot drift from the on-disk name. Under plain "allow"
+  // (the Page-level fallback) the browser chooses the name itself — it
+  // sanitizes suggestedFilename per platform and deduplicates collisions with
+  // " (1)" suffixes — so suggestedFilename is the best available guess there.
+  const fileName = naming === "guid" && guid ? guid : suggestedFilename;
+  const downloadedPath = confinePath(downloadDir, fileName);
   return {
     suggestedFilename: () => suggestedFilename,
     url: () => willBegin.params?.url || "",
@@ -90,13 +96,19 @@ async function waitForDownload(options: WaitForEventOptions = {}) {
   };
 }
 
+// Prefer Playwright's naming scheme: "allowAndName" saves the file as its
+// download guid inside downloadDir. Page.setDownloadBehavior (the fallback
+// for runtimes without the Browser-level command) only supports "allow", so
+// in that mode the on-disk name stays browser-chosen and the caller derives
+// the path from suggestedFilename instead.
 async function setDownloadBehavior(downloadDir) {
   try {
     await cdp("Browser.setDownloadBehavior", {
-      behavior: "allow",
+      behavior: "allowAndName",
       downloadPath: downloadDir,
       eventsEnabled: true,
     });
+    return "guid";
   } catch (error) {
     if (
       !/Browser\.setDownloadBehavior.*wasn't found|wasn't found/i.test(
@@ -109,5 +121,20 @@ async function setDownloadBehavior(downloadDir) {
       behavior: "allow",
       downloadPath: downloadDir,
     });
+    return "name";
   }
+}
+
+// Refuse a composed path that escapes downloadDir. Chromium sanitizes path
+// separators out of suggestedFilename before emitting the download events, so
+// a well-behaved runtime never trips this; it guards the boundary against an
+// event source that does not sanitize.
+function confinePath(downloadDir, fileName) {
+  const composed = resolve(downloadDir, fileName);
+  if (!composed.startsWith(downloadDir + sep)) {
+    throw new Error(
+      `download path escapes the download directory: ${JSON.stringify(fileName)}`,
+    );
+  }
+  return composed;
 }


### PR DESCRIPTION
## Summary

`page.waitForEvent("download")` reports `join(downloadDir, suggestedFilename)` as the download path, but under `behavior: "allow"` the browser chooses the on-disk name itself: it sanitizes `suggestedFilename` per platform (path separators everywhere; `:?"<>|*`, reserved device names, and trailing dots/spaces on Windows) and deduplicates collisions with " (1)" suffixes. Whenever any of that fires, `download.path()` points at a file that was never written and `saveAs()` fails with ENOENT. This PR switches the primary path to Chromium's `allowAndName` behavior — the same scheme Playwright uses — so the on-disk name is the download guid and the reported path can no longer drift from it.

## Related issue

No open issue. When closing #130/#132, @WUXM5 noted that Playwright "uses GUID-based naming together with path containment checks" and that additional boundary hardening might be addressed separately — this implements exactly that design. The user-visible defect it fixes (path drift under sanitization/deduplication) is distinct from the traversal claim that #130 investigated and rejected.

## Changes

- `src/driver/downloads.ts` — `Browser.setDownloadBehavior` now requests `behavior: "allowAndName"`, so the browser writes the file as its download guid inside the per-download temp dir; `download.path()` returns that guid path. `suggestedFilename()` is unchanged and still reports the server-suggested name; `saveAs(target)` still copies to the caller's chosen name.
- The `Page.setDownloadBehavior` fallback (runtimes without the Browser-level command) keeps `behavior: "allow"` — the Page-level command does not support `allowAndName` — and continues deriving the path from `suggestedFilename` there, as does the primary path if an event ever arrives without a guid.
- Every reported path now passes a containment check against the download directory before it is returned. Chromium sanitizes separators out of `suggestedFilename` before emitting the events, so a well-behaved runtime never trips it; it hardens the boundary against an event source that does not sanitize (the defense-in-depth gap acknowledged in #130).
- `src/driver/downloads.test.mjs` — updated facade/fallback assertions plus two new tests: missing-guid derivation, and rejection of an escaping composed path.

## Verification

Run from `package/ego-browser` (Windows 11, Node 24; suite is platform-neutral):

```text
npm test                      -> 313 pass, 0 fail (3 download tests before, 5 after)
npm run typecheck             -> ok
npm run validate:site-skills  -> site skills ok
npm audit --audit-level=moderate -> 0 vulnerabilities
```

Revert-check: with `src/driver/downloads.ts` reverted and the new tests kept, "returns a Playwright-style download facade" (guid naming) and "rejects a path that escapes the download directory" both fail; with the fix they pass.

Real-browser check I could not run here (no macOS install): a download whose `Content-Disposition` filename contains a character the platform sanitizes (for example `report:v2.pdf` on macOS via a colon on Windows-style checks, or any name that collides with an existing file so the browser writes `file (1).png`) — before this change `download.path()` names the unsanitized/original variant, after it names the guid file the browser actually wrote. The existing `scripts/real-browser-e2e/cases/downloads.mjs` case covers the happy path end-to-end and is worth a run on macOS before merge.

## Impact

- [x] Public helper API or behavior
- [ ] Agent skill or instructions
- [ ] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

`download.path()` now returns a guid-named file instead of a `suggestedFilename`-named file. That matches Playwright's contract (agents are told to use `suggestedFilename()` for the display name and `saveAs()` for a stable destination, both unchanged), so scripts written against Playwright semantics keep working; only code that assumed the temp-path basename equals the suggested name would notice — and that assumption is exactly what breaks today under sanitization or dedup.

## Checklist

- [x] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained above.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [x] A release-note label is selected (`fix`).
