### PR TITLE
feat(ego-windows-host): run the ego-browser runtime on stock Edge/Chrome (Windows preview)

### DIFF
--- a/.github/workflows/windows-host.yml
+++ b/.github/workflows/windows-host.yml
@@ -1,0 +1,41 @@
+name: Windows Host
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/windows-host.yml"
+      - "package/ego-windows-host/**"
+  push:
+    branches:
+      - dev
+      - main
+    paths:
+      - ".github/workflows/windows-host.yml"
+      - "package/ego-windows-host/**"
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # --ignore-scripts: installing the file:../ego-browser dependency would
+      # otherwise run ego-browser's prepare script (lefthook install), which is
+      # unnecessary in CI and not yet Windows-safe (see #148).
+      - name: Install dependencies
+        working-directory: package/ego-windows-host
+        run: npm ci --ignore-scripts
+
+      - name: Run tests
+        working-directory: package/ego-windows-host
+        run: npm test

--- a/package/ego-windows-host/.gitignore
+++ b/package/ego-windows-host/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/package/ego-windows-host/README.md
+++ b/package/ego-windows-host/README.md
@@ -1,0 +1,105 @@
+# ego-windows-host
+
+Run the `ego-browser` agent runtime against stock Microsoft Edge or Google
+Chrome on Windows — a preview for Windows users while native ego lite Windows
+support (#203) is under evaluation.
+
+The [ego lite app](https://lite.ego.app/) is macOS-only today. This package
+implements the same `globalThis.ego` contract the app's native bridge provides,
+backed by any CDP-capable Chromium already installed on the machine, and then
+delegates execution to the unmodified `ego-browser` runtime. Everything the
+runtime offers — `page`, `page.locator(...)`, `browser`, `taskSpaces`,
+snapshots, screenshots, waits — runs as-is.
+
+The host model follows the Linux host prior art in #134 / #202 (shared profile,
+task spaces as tracked tab sets with ownership), rebuilt for Windows: Edge
+detection, `%LOCALAPPDATA%` state, no POSIX daemon — the detached browser
+itself is the persistent process, so there is nothing extra to manage.
+
+```
+agent script ──> ego-browser runtime (unmodified)
+                     │  globalThis.ego
+                     ▼
+             ego-windows-host bridge
+                     │  two CDP websockets (loopback)
+                     ▼
+          stock Edge / Chrome (detached, dedicated profile)
+```
+
+## Quick start
+
+```powershell
+cd package/ego-browser; npm ci; npm run build
+cd ../ego-windows-host; npm ci; npm run build
+
+node bin/ego-windows-host.mjs -e "
+const task = await taskSpaces.useOrCreate('demo')
+await browser.openOrReuseTab('https://example.com', { wait: true })
+console.log(await page.snapshot())
+"
+```
+
+The first call launches the browser detached with a dedicated profile; it stays
+running, so later calls (and later agent heredocs) reattach to the same tabs and
+task spaces. Input forms: a script file (`ego-windows-host task.js`), inline
+`-e <code>`, or stdin. A leading `nodejs` argument is accepted so agent
+instructions written for `ego-browser nodejs` carry over.
+
+`--doctor` reports the detected browser, endpoint state, and task spaces.
+
+## Environment
+
+| Variable                | Purpose                                                                     |
+| ----------------------- | --------------------------------------------------------------------------- |
+| `EGO_HOST_BROWSER_PATH` | Full path to `msedge.exe` / `chrome.exe` (default: auto-detect, Edge first) |
+| `EGO_HOST_DEBUG_PORT`   | CDP port for the hosted browser (default `9522`)                            |
+| `EGO_HOST_STATE_DIR`    | State root (default `%LOCALAPPDATA%\ego-windows-host`)                      |
+| `EGO_HOST_HEADLESS`     | `1` to launch the browser headless                                          |
+
+## How task spaces are emulated
+
+A task space is a named, persisted set of tabs plus an ownership state
+(`agent` / `agentDelegatedToUser` / `user`), exactly the surface the runtime's
+`taskSpaces` helpers expect:
+
+- `useOrCreate` / `switch` / `claim` select a space; a fresh space opens one
+  blank tab so the runtime always has a session target.
+- `handOff` pauses agent commands: every CDP send and snapshot fails with the
+  stable `EGO_TASK_SPACE_USER_IN_CONTROL` code until `takeOver`, so the
+  runtime's hard-stop guidance and `waitForAgentControl` behave like they do
+  against the real app.
+- `complete(..., { keep: true })` leaves the tabs open and hands the space to
+  the user; `{ keep: false }` closes the space's tabs and forgets it.
+- Tabs created through raw CDP (`Target.createTarget`) are sniffed off the
+  passthrough channel and tracked into the current space, so bookkeeping stays
+  consistent however the runtime opens tabs.
+
+State lives in `spaces.json` under the state dir, written atomically.
+
+## Honest limitations vs the real app
+
+- **Snapshot quality.** `ego.snapshot()` here is a plain projection of
+  Chromium's accessibility tree with `[@backendNodeId]` refs. It is good enough
+  for semantic locators and `@ref` actions on ordinary DOM pages, but it is not
+  the app's kernel-level snapshot (deeply nested iframes and canvas-heavy
+  surfaces will be weaker).
+- **Profile.** The hosted browser uses its own persistent profile. Logins
+  accumulate there (log in once via `taskSpaces.handOff`), but it does not
+  import your daily browser's cookies the way ego lite's Chrome migration does.
+  This host never touches your daily browser profile.
+- **No Spaces UI.** Ownership is enforced at the bridge, but there is no
+  browser chrome showing which space an agent holds.
+- **Security.** The browser exposes CDP on a loopback port; any local process
+  can connect to it. Do not point `EGO_HOST_DEBUG_PORT` at a non-loopback
+  interface, and prefer a dedicated profile (the default) over a copy of a
+  profile holding sensitive sessions.
+
+## Tests
+
+```powershell
+npm test   # build + typecheck + node --test, no real browser required
+```
+
+Unit tests stub the browser side entirely. The real-browser path is exercised
+manually (see the PR that introduced this package for a full transcript against
+Edge on Windows 11).

--- a/package/ego-windows-host/README.md
+++ b/package/ego-windows-host/README.md
@@ -49,12 +49,13 @@ instructions written for `ego-browser nodejs` carry over.
 
 ## Environment
 
-| Variable                | Purpose                                                                     |
-| ----------------------- | --------------------------------------------------------------------------- |
-| `EGO_HOST_BROWSER_PATH` | Full path to `msedge.exe` / `chrome.exe` (default: auto-detect, Edge first) |
-| `EGO_HOST_DEBUG_PORT`   | CDP port for the hosted browser (default `9522`)                            |
-| `EGO_HOST_STATE_DIR`    | State root (default `%LOCALAPPDATA%\ego-windows-host`)                      |
-| `EGO_HOST_HEADLESS`     | `1` to launch the browser headless                                          |
+| Variable                 | Purpose                                                                     |
+| ------------------------ | --------------------------------------------------------------------------- |
+| `EGO_HOST_BROWSER_PATH`  | Full path to `msedge.exe` / `chrome.exe` (default: auto-detect, Edge first) |
+| `EGO_HOST_DEBUG_PORT`    | CDP port for the hosted browser (default `9522`)                            |
+| `EGO_HOST_STATE_DIR`     | State root (default `%LOCALAPPDATA%\ego-windows-host`)                      |
+| `EGO_HOST_HEADLESS`      | `1` to launch the browser headless                                          |
+| `EGO_HOST_SPACE_WINDOWS` | `1` to open each task space in its own browser window instead of a tab      |
 
 ## How task spaces are emulated
 
@@ -88,7 +89,9 @@ State lives in `spaces.json` under the state dir, written atomically.
   import your daily browser's cookies the way ego lite's Chrome migration does.
   This host never touches your daily browser profile.
 - **No Spaces UI.** Ownership is enforced at the bridge, but there is no
-  browser chrome showing which space an agent holds.
+  browser chrome showing which space an agent holds. `EGO_HOST_SPACE_WINDOWS=1`
+  gets part of the way there by giving each space its own browser window, so
+  parallel agents are at least visually separate.
 - **Security.** The browser exposes CDP on a loopback port; any local process
   can connect to it. Do not point `EGO_HOST_DEBUG_PORT` at a non-loopback
   interface, and prefer a dedicated profile (the default) over a copy of a

--- a/package/ego-windows-host/bin/ego-windows-host.mjs
+++ b/package/ego-windows-host/bin/ego-windows-host.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import { main } from "../dist/src/cli.js";
+
+try {
+  process.exitCode = await main();
+} catch (error) {
+  console.error(error?.stack || error?.message || String(error));
+  process.exitCode = 1;
+}

--- a/package/ego-windows-host/package-lock.json
+++ b/package/ego-windows-host/package-lock.json
@@ -1,0 +1,103 @@
+{
+  "name": "ego-windows-host",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ego-windows-host",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ego-browser-v2": "file:../ego-browser"
+      },
+      "bin": {
+        "ego-windows-host": "bin/ego-windows-host.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.29",
+        "prettier": "^3.8.4",
+        "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "../ego-browser": {
+      "name": "ego-browser-v2",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0"
+      },
+      "bin": {
+        "ego-browser": "dist/out/index.js"
+      },
+      "devDependencies": {
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "@rollup/plugin-typescript": "^12.3.0",
+        "@types/node": "^22.15.29",
+        "esbuild": "^0.28.1",
+        "lefthook": "^2.1.9",
+        "prettier": "^3.8.4",
+        "rollup": "^4.60.4",
+        "tslib": "^2.8.1",
+        "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/ego-browser-v2": {
+      "resolved": "../ego-browser",
+      "link": true
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package/ego-windows-host/package.json
+++ b/package/ego-windows-host/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ego-windows-host",
+  "version": "0.1.0",
+  "description": "Run the ego-browser agent runtime against stock Microsoft Edge or Google Chrome on Windows.",
+  "type": "module",
+  "bin": {
+    "ego-windows-host": "./bin/ego-windows-host.mjs"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.json",
+    "test": "npm run build && npm run typecheck && node --test \"src/**/*.test.mjs\""
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "ego-browser-v2": "file:../ego-browser"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.29",
+    "prettier": "^3.8.4",
+    "typescript": "^5.8.3"
+  }
+}

--- a/package/ego-windows-host/src/ax-snapshot.test.mjs
+++ b/package/ego-windows-host/src/ax-snapshot.test.mjs
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { renderAxTree } from "../dist/src/ax-snapshot.js";
+
+function node(nodeId, role, name, extra = {}) {
+  return {
+    nodeId,
+    role: { value: role },
+    name: { value: name },
+    ...extra,
+  };
+}
+
+const PAGE = [
+  node("1", "RootWebArea", "Example Domain", {
+    backendDOMNodeId: 10,
+    childIds: ["2", "3", "6"],
+  }),
+  node("2", "heading", "Example Domain", {
+    backendDOMNodeId: 11,
+    childIds: ["4"],
+  }),
+  node("3", "link", "More information...", {
+    backendDOMNodeId: 12,
+    childIds: ["5"],
+  }),
+  node("4", "StaticText", "Example Domain", { childIds: [] }),
+  node("5", "StaticText", "More information...", { childIds: [] }),
+  node("6", "generic", "", { backendDOMNodeId: 13, childIds: ["7"] }),
+  node("7", "button", "Accept", { backendDOMNodeId: 14, childIds: [] }),
+];
+
+test("renders roles, names, and @backendNodeId marks", () => {
+  const { content, refs } = renderAxTree(PAGE);
+  assert.match(content, /RootWebArea "Example Domain"/);
+  assert.match(content, /heading "Example Domain" \[@11\]/);
+  assert.match(content, /link "More information\.\.\." \[@12\]/);
+  assert.match(content, /button "Accept" \[@14\]/);
+  assert.deepEqual(refs, [
+    { backendNodeId: 11, role: "heading", name: "Example Domain" },
+    { backendNodeId: 12, role: "link", name: "More information..." },
+    { backendNodeId: 14, role: "button", name: "Accept" },
+  ]);
+});
+
+test("skips generic wrappers but keeps their children", () => {
+  const { content } = renderAxTree(PAGE);
+  assert.doesNotMatch(content, /generic/);
+  assert.match(content, /button "Accept"/);
+});
+
+test("drops StaticText that repeats its ancestor's name", () => {
+  const { content } = renderAxTree(PAGE);
+  const textLines = content
+    .split("\n")
+    .filter((line) => line.includes("- text:"));
+  assert.equal(textLines.length, 0, "both texts repeat their parents' names");
+});
+
+test("keeps StaticText that adds information", () => {
+  const { content } = renderAxTree([
+    node("1", "RootWebArea", "Page", { backendDOMNodeId: 1, childIds: ["2"] }),
+    node("2", "paragraph", "", { backendDOMNodeId: 2, childIds: ["3"] }),
+    node("3", "StaticText", "This domain is for use in examples.", {
+      childIds: [],
+    }),
+  ]);
+  assert.match(content, /- text: "This domain is for use in examples\."/);
+});
+
+test("promotes children of ignored nodes", () => {
+  const { content, refs } = renderAxTree([
+    node("1", "RootWebArea", "Page", { backendDOMNodeId: 1, childIds: ["2"] }),
+    { nodeId: "2", ignored: true, childIds: ["3"] },
+    node("3", "button", "Buried", { backendDOMNodeId: 3, childIds: [] }),
+  ]);
+  assert.match(content, /button "Buried" \[@3\]/);
+  assert.equal(refs.length, 1);
+});
+
+test("indentation follows rendered depth, not raw tree depth", () => {
+  const { content } = renderAxTree(PAGE);
+  const lines = content.split("\n");
+  assert.match(lines[0], /^- RootWebArea/);
+  assert.match(lines[1], /^ {2}- heading/);
+  const button = lines.find((line) => line.includes("button"));
+  assert.match(button, /^ {2}- button/, "generic wrapper adds no depth");
+});
+
+test("maxResultLength truncates the content but never the refs", () => {
+  const { content, refs } = renderAxTree(PAGE, { maxResultLength: 1 });
+  assert.equal(content.length, 1);
+  assert.equal(refs.length, 3);
+});
+
+test("an empty tree renders empty content", () => {
+  const { content, refs } = renderAxTree([]);
+  assert.equal(content, "");
+  assert.deepEqual(refs, []);
+});

--- a/package/ego-windows-host/src/ax-snapshot.ts
+++ b/package/ego-windows-host/src/ax-snapshot.ts
@@ -1,0 +1,139 @@
+/**
+ * Render Accessibility.getFullAXTree nodes into the { content, refs } shape
+ * ego.snapshot() must return. Refs are keyed by backendDOMNodeId, which is
+ * exactly what the runtime's browserSnapshotRefsToRefMap() expects and what
+ * its parseRef() resolves from an "@<id>" mark in the content.
+ *
+ * This is a deliberately simple text projection of the AX tree — the shipped
+ * app's kernel-level snapshot is richer. It is good enough for locators and
+ * targeted "@id" actions on ordinary DOM pages.
+ */
+
+const INTERACTIVE_ROLES = new Set([
+  "button",
+  "checkbox",
+  "combobox",
+  "link",
+  "listbox",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "option",
+  "radio",
+  "searchbox",
+  "slider",
+  "spinbutton",
+  "switch",
+  "tab",
+  "textbox",
+]);
+
+// Roles that carry no information of their own; their children are promoted.
+const SKIPPED_ROLES = new Set([
+  "none",
+  "generic",
+  "InlineTextBox",
+  "LineBreak",
+]);
+
+type AxNode = {
+  nodeId: string;
+  ignored?: boolean;
+  role?: { value?: string };
+  name?: { value?: string };
+  backendDOMNodeId?: number;
+  childIds?: string[];
+};
+
+export type SnapshotRef = {
+  backendNodeId: number;
+  role: string;
+  name: string;
+};
+
+type RenderOptions = {
+  maxResultLength?: number;
+};
+
+function refWorthy(node: AxNode, role: string, name: string) {
+  if (node.backendDOMNodeId === undefined || node.backendDOMNodeId === null) {
+    return false;
+  }
+  if (role === "StaticText" || role === "RootWebArea") {
+    return false;
+  }
+  return INTERACTIVE_ROLES.has(role) || Boolean(name);
+}
+
+function renderable(role: string, name: string) {
+  if (role === "StaticText") {
+    return Boolean(name);
+  }
+  return Boolean(name) || INTERACTIVE_ROLES.has(role) || role === "RootWebArea";
+}
+
+export function renderAxTree(nodes: AxNode[], options: RenderOptions = {}) {
+  const byId = new Map(nodes.map((node) => [node.nodeId, node]));
+  const hasParent = new Set<string>();
+  for (const node of nodes) {
+    for (const childId of node.childIds || []) {
+      hasParent.add(childId);
+    }
+  }
+
+  const lines: string[] = [];
+  const refs: SnapshotRef[] = [];
+
+  const visit = (
+    node: AxNode | undefined,
+    depth: number,
+    parentName: string,
+  ) => {
+    if (!node) {
+      return;
+    }
+    const role = node.role?.value || "";
+    const name = (node.name?.value || "").trim();
+    // A StaticText repeating its ancestor's accessible name adds nothing.
+    if (role === "StaticText" && name && name === parentName) {
+      return;
+    }
+    const skipped = node.ignored || !role || SKIPPED_ROLES.has(role);
+
+    let nextDepth = depth;
+    let nextParentName = parentName;
+    if (!skipped && renderable(role, name)) {
+      const indent = "  ".repeat(depth);
+      if (role === "StaticText") {
+        lines.push(`${indent}- text: ${JSON.stringify(name)}`);
+      } else {
+        const label = name ? ` ${JSON.stringify(name)}` : "";
+        const mark = refWorthy(node, role, name)
+          ? ` [@${node.backendDOMNodeId}]`
+          : "";
+        lines.push(`${indent}- ${role}${label}${mark}`);
+        if (refWorthy(node, role, name)) {
+          refs.push({ backendNodeId: node.backendDOMNodeId, role, name });
+        }
+      }
+      nextDepth = depth + 1;
+      nextParentName = name || parentName;
+    }
+    for (const childId of node.childIds || []) {
+      visit(byId.get(childId), nextDepth, nextParentName);
+    }
+  };
+
+  for (const node of nodes) {
+    if (!hasParent.has(node.nodeId)) {
+      visit(node, 0, "");
+    }
+  }
+
+  let content = lines.join("\n");
+  const maxResultLength = options.maxResultLength;
+  if (Number.isFinite(maxResultLength) && maxResultLength >= 0) {
+    content = content.slice(0, maxResultLength);
+  }
+  return { content, refs };
+}

--- a/package/ego-windows-host/src/browser-locator.test.mjs
+++ b/package/ego-windows-host/src/browser-locator.test.mjs
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+
+import { candidatePaths, locateBrowser } from "../dist/src/browser-locator.js";
+
+const ENV = {
+  PROGRAMFILES: join("C:", "Program Files"),
+  "PROGRAMFILES(X86)": join("C:", "Program Files (x86)"),
+  LOCALAPPDATA: join("C:", "Users", "agent", "AppData", "Local"),
+};
+
+const EDGE_X86 = join(
+  ENV["PROGRAMFILES(X86)"],
+  "Microsoft",
+  "Edge",
+  "Application",
+  "msedge.exe",
+);
+const CHROME = join(
+  ENV.PROGRAMFILES,
+  "Google",
+  "Chrome",
+  "Application",
+  "chrome.exe",
+);
+
+test("locateBrowser prefers the EGO_HOST_BROWSER_PATH override", () => {
+  const override = join("D:", "browsers", "chrome.exe");
+  const result = locateBrowser({
+    env: { ...ENV, EGO_HOST_BROWSER_PATH: override },
+    exists: (path) => path === override,
+  });
+  assert.equal(result, override);
+});
+
+test("locateBrowser rejects a missing override instead of falling back", () => {
+  assert.throws(
+    () =>
+      locateBrowser({
+        env: { ...ENV, EGO_HOST_BROWSER_PATH: join("D:", "missing.exe") },
+        exists: () => false,
+      }),
+    /EGO_HOST_BROWSER_PATH does not exist/,
+  );
+});
+
+test("locateBrowser finds Edge before Chrome", () => {
+  const result = locateBrowser({
+    env: ENV,
+    exists: (path) => path === EDGE_X86 || path === CHROME,
+  });
+  assert.equal(result, EDGE_X86);
+});
+
+test("locateBrowser falls back to Chrome when Edge is absent", () => {
+  const result = locateBrowser({
+    env: ENV,
+    exists: (path) => path === CHROME,
+  });
+  assert.equal(result, CHROME);
+});
+
+test("locateBrowser explains how to configure when nothing is found", () => {
+  assert.throws(
+    () => locateBrowser({ env: ENV, exists: () => false }),
+    /EGO_HOST_BROWSER_PATH/,
+  );
+});
+
+test("candidatePaths covers every root for every browser", () => {
+  const candidates = candidatePaths(ENV);
+  assert.equal(candidates.length, 9);
+  assert.ok(candidates.includes(EDGE_X86));
+  assert.ok(candidates.includes(CHROME));
+});

--- a/package/ego-windows-host/src/browser-locator.ts
+++ b/package/ego-windows-host/src/browser-locator.ts
@@ -1,0 +1,58 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+type LocateOptions = {
+  env?: Record<string, string | undefined>;
+  exists?: (path: string) => boolean;
+};
+
+/**
+ * Locate a CDP-capable Chromium browser on Windows. Preference order:
+ * the EGO_HOST_BROWSER_PATH override, then Microsoft Edge (preinstalled on
+ * every Windows 10/11 machine), then Google Chrome, then Chromium.
+ */
+export function locateBrowser({
+  env = process.env,
+  exists = existsSync,
+}: LocateOptions = {}) {
+  const override = env.EGO_HOST_BROWSER_PATH;
+  if (override) {
+    if (!exists(override)) {
+      throw new Error(`EGO_HOST_BROWSER_PATH does not exist: ${override}`);
+    }
+    return override;
+  }
+  for (const candidate of candidatePaths(env)) {
+    if (exists(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    "no Chromium-based browser found; set EGO_HOST_BROWSER_PATH to your msedge.exe or chrome.exe",
+  );
+}
+
+/**
+ * Standard Windows install locations, most specific browser first. Edge ships
+ * under Program Files (x86) even on x64 Windows; per-user Chrome installs land
+ * under LOCALAPPDATA.
+ */
+export function candidatePaths(env: Record<string, string | undefined>) {
+  const roots = [
+    env.PROGRAMFILES,
+    env["PROGRAMFILES(X86)"],
+    env.LOCALAPPDATA,
+  ].filter(Boolean) as string[];
+  const suffixes = [
+    join("Microsoft", "Edge", "Application", "msedge.exe"),
+    join("Google", "Chrome", "Application", "chrome.exe"),
+    join("Chromium", "Application", "chrome.exe"),
+  ];
+  const out: string[] = [];
+  for (const suffix of suffixes) {
+    for (const root of roots) {
+      out.push(join(root, suffix));
+    }
+  }
+  return out;
+}

--- a/package/ego-windows-host/src/cdp-connection.test.mjs
+++ b/package/ego-windows-host/src/cdp-connection.test.mjs
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { CdpConnection } from "../dist/src/cdp-connection.js";
+
+class FakeSocket {
+  constructor() {
+    this.sent = [];
+    this.listeners = new Map();
+  }
+  addEventListener(type, listener, options = {}) {
+    const wrapped = options.once
+      ? (event) => {
+          this.removeListener(type, wrapped);
+          listener(event);
+        }
+      : listener;
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+    this.listeners.get(type).add(wrapped);
+  }
+  removeListener(type, listener) {
+    this.listeners.get(type)?.delete(listener);
+  }
+  emit(type, event = {}) {
+    for (const listener of [...(this.listeners.get(type) || [])]) {
+      listener(event);
+    }
+  }
+  send(payload) {
+    this.sent.push(JSON.parse(payload));
+  }
+  close() {
+    this.emit("close");
+  }
+}
+
+async function openWithFake() {
+  const socket = new FakeSocket();
+  const promise = CdpConnection.open("ws://fake", () => socket);
+  socket.emit("open");
+  const connection = await promise;
+  return { connection, socket };
+}
+
+test("open rejects when the socket errors before opening", async () => {
+  const socket = new FakeSocket();
+  const promise = CdpConnection.open("ws://fake", () => socket);
+  socket.emit("error");
+  await assert.rejects(promise, /failed to open/);
+});
+
+test("request resolves with the matching response result", async () => {
+  const { connection, socket } = await openWithFake();
+  const promise = connection.request("Target.getTargets");
+  const sent = socket.sent[0];
+  assert.equal(sent.method, "Target.getTargets");
+  socket.emit("message", {
+    data: JSON.stringify({ id: sent.id, result: { targetInfos: [1] } }),
+  });
+  assert.deepEqual(await promise, { targetInfos: [1] });
+});
+
+test("request rejects on a CDP error response", async () => {
+  const { connection, socket } = await openWithFake();
+  const promise = connection.request("Bad.method");
+  socket.emit("message", {
+    data: JSON.stringify({
+      id: socket.sent[0].id,
+      error: { message: "'Bad.method' wasn't found" },
+    }),
+  });
+  await assert.rejects(promise, /wasn't found/);
+});
+
+test("request attaches the sessionId when given", async () => {
+  const { connection, socket } = await openWithFake();
+  const promise = connection.request("Page.enable", {}, "sess-9");
+  assert.equal(socket.sent[0].sessionId, "sess-9");
+  socket.emit("message", {
+    data: JSON.stringify({ id: socket.sent[0].id, result: {} }),
+  });
+  await promise;
+});
+
+test("request times out when no response arrives", async () => {
+  const { connection } = await openWithFake();
+  await assert.rejects(
+    connection.request("Slow.method", {}, undefined, 20),
+    /timed out: Slow\.method/,
+  );
+});
+
+test("pending requests reject when the socket closes", async () => {
+  const { connection, socket } = await openWithFake();
+  const promise = connection.request("Target.getTargets");
+  socket.close();
+  await assert.rejects(promise, /socket closed/);
+});
+
+test("onMessage subscribers see every raw message and can unsubscribe", async () => {
+  const { connection, socket } = await openWithFake();
+  const seen = [];
+  const unsubscribe = connection.onMessage((raw) => seen.push(raw));
+  socket.emit("message", { data: '{"method":"Page.loadEventFired"}' });
+  unsubscribe();
+  socket.emit("message", { data: '{"method":"Page.frameNavigated"}' });
+  assert.equal(seen.length, 1);
+  assert.match(seen[0], /loadEventFired/);
+});
+
+test("sendRaw forwards payloads verbatim", async () => {
+  const { connection, socket } = await openWithFake();
+  connection.sendRaw('{"id":1,"method":"Runtime.evaluate"}');
+  assert.deepEqual(socket.sent[0], { id: 1, method: "Runtime.evaluate" });
+});

--- a/package/ego-windows-host/src/cdp-connection.ts
+++ b/package/ego-windows-host/src/cdp-connection.ts
@@ -1,0 +1,149 @@
+const REQUEST_TIMEOUT_MS = 15000;
+
+// Host-internal request ids start far above the runtime's own counter (which
+// starts at 1) purely as a debugging aid when reading raw traffic; the host
+// and the runtime never share a websocket, so ids cannot actually collide.
+const FIRST_HOST_ID = 1_000_000;
+
+type SocketLike = {
+  send(payload: string): void;
+  close(): void;
+  addEventListener(
+    type: string,
+    listener: (event: any) => void,
+    options?: { once?: boolean },
+  ): void;
+};
+
+/**
+ * A minimal browser-level CDP client over the global WebSocket (Node >= 22).
+ * One instance per websocket: the host uses its own connection for internal
+ * calls (tab bookkeeping, snapshots) and hands a second, dedicated connection
+ * to the agent runtime, so flattened session state never crosses over.
+ */
+export class CdpConnection {
+  socket: SocketLike;
+  pending: Map<number, { resolve: (v: any) => void; reject: (e: any) => void }>;
+  handlers: Set<(raw: string) => void>;
+  nextId: number;
+
+  static async open(
+    url: string,
+    socketFactory: (url: string) => SocketLike = (u) => new WebSocket(u),
+  ) {
+    const socket = socketFactory(url);
+    await new Promise<void>((resolve, reject) => {
+      socket.addEventListener("open", () => resolve(), { once: true });
+      socket.addEventListener(
+        "error",
+        () => reject(new Error(`CDP websocket failed to open: ${url}`)),
+        { once: true },
+      );
+    });
+    return new CdpConnection(socket);
+  }
+
+  constructor(socket: SocketLike) {
+    this.socket = socket;
+    this.pending = new Map();
+    this.handlers = new Set();
+    this.nextId = FIRST_HOST_ID;
+    socket.addEventListener("message", (event) =>
+      this.dispatch(String(event.data)),
+    );
+    socket.addEventListener("close", () => this.rejectAll("CDP socket closed"));
+  }
+
+  /** Subscribe to every raw message on this connection. Returns unsubscribe. */
+  onMessage(handler: (raw: string) => void) {
+    this.handlers.add(handler);
+    return () => this.handlers.delete(handler);
+  }
+
+  /** Forward an already-serialized CDP payload verbatim. */
+  sendRaw(payload: string) {
+    this.socket.send(payload);
+  }
+
+  /** Send one host-internal CDP request and await its response. */
+  request(
+    method: string,
+    params: any = {},
+    sessionId: string | undefined = undefined,
+    timeoutMs = REQUEST_TIMEOUT_MS,
+  ) {
+    const id = this.nextId++;
+    const payload = JSON.stringify({
+      id,
+      method,
+      params,
+      ...(sessionId ? { sessionId } : {}),
+    });
+    return new Promise<any>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`CDP request timed out: ${method}`));
+      }, timeoutMs);
+      timer.unref?.();
+      this.pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      });
+      try {
+        this.socket.send(payload);
+      } catch (error) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(error);
+      }
+    });
+  }
+
+  close() {
+    try {
+      this.socket.close();
+    } catch {
+      // A socket that is already closing is fine.
+    }
+  }
+
+  private dispatch(raw: string) {
+    for (const handler of [...this.handlers]) {
+      try {
+        handler(raw);
+      } catch {
+        // One subscriber must not break delivery to the others.
+      }
+    }
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (!Object.hasOwn(data, "id") || !this.pending.has(data.id)) {
+      return;
+    }
+    const entry = this.pending.get(data.id);
+    this.pending.delete(data.id);
+    if (data.error) {
+      entry.reject(new Error(data.error.message || JSON.stringify(data.error)));
+      return;
+    }
+    entry.resolve(data.result ?? {});
+  }
+
+  private rejectAll(reason: string) {
+    const entries = [...this.pending.values()];
+    this.pending.clear();
+    for (const entry of entries) {
+      entry.reject(new Error(reason));
+    }
+  }
+}

--- a/package/ego-windows-host/src/chrome-launcher.test.mjs
+++ b/package/ego-windows-host/src/chrome-launcher.test.mjs
@@ -1,0 +1,118 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { browserEndpoint, ensureBrowser } from "../dist/src/chrome-launcher.js";
+
+const ENDPOINT = {
+  webSocketDebuggerUrl: "ws://127.0.0.1:9522/devtools/browser/abc",
+  Browser: "Edg/126.0",
+};
+
+function fetchAlive() {
+  return async () => ({ ok: true, json: async () => ENDPOINT });
+}
+
+function fetchDead() {
+  return async () => {
+    throw new Error("ECONNREFUSED");
+  };
+}
+
+function fakeSpawn(record) {
+  return (command, args, options) => {
+    record.command = command;
+    record.args = args;
+    record.options = options;
+    record.calls = (record.calls || 0) + 1;
+    return { unref() {} };
+  };
+}
+
+test("browserEndpoint returns the version info when CDP answers", async () => {
+  const info = await browserEndpoint(9522, fetchAlive());
+  assert.equal(info.webSocketDebuggerUrl, ENDPOINT.webSocketDebuggerUrl);
+});
+
+test("browserEndpoint returns null when nothing listens", async () => {
+  assert.equal(await browserEndpoint(9522, fetchDead()), null);
+});
+
+test("browserEndpoint returns null when something else listens", async () => {
+  const info = await browserEndpoint(9522, async () => ({
+    ok: true,
+    json: async () => ({ hello: "not cdp" }),
+  }));
+  assert.equal(info, null);
+});
+
+test("ensureBrowser reuses a running browser without spawning", async () => {
+  const record = {};
+  const result = await ensureBrowser({
+    port: 9522,
+    userDataDir: join(tmpdir(), "unused"),
+    browserPath: () => {
+      throw new Error("must not locate a browser when one is running");
+    },
+    spawnFn: fakeSpawn(record),
+    fetchFn: fetchAlive(),
+  });
+  assert.equal(result.launched, false);
+  assert.equal(record.calls, undefined);
+});
+
+test("ensureBrowser launches detached with the CDP and profile flags", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ego-host-launch-"));
+  try {
+    const userDataDir = join(dir, "profile");
+    const record = {};
+    let alive = false;
+    const result = await ensureBrowser({
+      port: 9522,
+      userDataDir,
+      browserPath: () => "C:\\fake\\msedge.exe",
+      spawnFn: (command, args, options) => {
+        const child = fakeSpawn(record)(command, args, options);
+        alive = true;
+        return child;
+      },
+      fetchFn: async (url) => {
+        if (!alive) throw new Error("ECONNREFUSED");
+        return { ok: true, json: async () => ENDPOINT };
+      },
+      sleep: async () => {},
+    });
+    assert.equal(result.launched, true);
+    assert.equal(record.command, "C:\\fake\\msedge.exe");
+    assert.ok(record.args.includes("--remote-debugging-port=9522"));
+    assert.ok(record.args.includes(`--user-data-dir=${userDataDir}`));
+    assert.ok(record.args.includes("--no-first-run"));
+    assert.equal(record.options.detached, true);
+    assert.ok(existsSync(userDataDir), "creates the profile directory");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensureBrowser reports a launch that never becomes ready", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ego-host-launch-"));
+  try {
+    await assert.rejects(
+      ensureBrowser({
+        port: 9522,
+        userDataDir: join(dir, "profile"),
+        browserPath: () => "C:\\fake\\msedge.exe",
+        spawnFn: fakeSpawn({}),
+        fetchFn: fetchDead(),
+        sleep: async () => {},
+        timeoutMs: 50,
+      }),
+      /did not expose CDP on port 9522/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/package/ego-windows-host/src/chrome-launcher.test.mjs
+++ b/package/ego-windows-host/src/chrome-launcher.test.mjs
@@ -90,6 +90,10 @@ test("ensureBrowser launches detached with the CDP and profile flags", async () 
     assert.ok(record.args.includes("--remote-debugging-port=9522"));
     assert.ok(record.args.includes(`--user-data-dir=${userDataDir}`));
     assert.ok(record.args.includes("--no-first-run"));
+    assert.ok(
+      record.args.includes("--window-size=1440,960"),
+      "launches at a desktop size so responsive sites do not collapse controls",
+    );
     assert.equal(record.options.detached, true);
     assert.ok(existsSync(userDataDir), "creates the profile directory");
   } finally {
@@ -112,6 +116,88 @@ test("ensureBrowser reports a launch that never becomes ready", async () => {
       }),
       /did not expose CDP on port 9522/,
     );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a failed launch names the port and prints a reproducible command", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ego-host-launch-"));
+  try {
+    await assert.rejects(
+      ensureBrowser({
+        port: 9700,
+        userDataDir: join(dir, "profile"),
+        browserPath: () => "C:\\fake\\msedge.exe",
+        spawnFn: fakeSpawn({}),
+        fetchFn: fetchDead(),
+        sleep: async () => {},
+        timeoutMs: 50,
+        exists: () => false,
+      }),
+      (error) => {
+        assert.match(
+          error.message,
+          /another process may already hold port 9700/,
+        );
+        assert.match(error.message, /Run this by hand/);
+        // The command has to be complete enough to paste into a shell.
+        assert.match(error.message, /--remote-debugging-port=9700/);
+        assert.match(error.message, /C:\\fake\\msedge\.exe/);
+        return true;
+      },
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a locked profile is called out as the likely cause", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ego-host-launch-"));
+  try {
+    const userDataDir = join(dir, "profile");
+    await assert.rejects(
+      ensureBrowser({
+        port: 9522,
+        userDataDir,
+        browserPath: () => "C:\\fake\\msedge.exe",
+        spawnFn: fakeSpawn({}),
+        fetchFn: fetchDead(),
+        sleep: async () => {},
+        timeoutMs: 50,
+        // Chromium leaves this behind while a process holds the profile; the
+        // second launch then forwards its command line and exits silently.
+        exists: (path) => path === join(userDataDir, "lockfile"),
+      }),
+      /looks locked by another browser process/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a caller can override the default window size", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "ego-host-launch-"));
+  try {
+    const record = {};
+    let alive = false;
+    await ensureBrowser({
+      port: 9522,
+      userDataDir: join(dir, "profile"),
+      browserPath: () => "C:\fake\msedge.exe",
+      windowSize: { width: 800, height: 600 },
+      spawnFn: (command, args, options) => {
+        const child = fakeSpawn(record)(command, args, options);
+        alive = true;
+        return child;
+      },
+      fetchFn: async () => {
+        if (!alive) throw new Error("ECONNREFUSED");
+        return { ok: true, json: async () => ENDPOINT };
+      },
+      sleep: async () => {},
+    });
+    assert.ok(record.args.includes("--window-size=800,600"));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/package/ego-windows-host/src/chrome-launcher.ts
+++ b/package/ego-windows-host/src/chrome-launcher.ts
@@ -1,0 +1,87 @@
+import { spawn } from "node:child_process";
+import { mkdirSync } from "node:fs";
+
+const READY_TIMEOUT_MS = 20000;
+const POLL_INTERVAL_MS = 250;
+
+type EndpointInfo = {
+  webSocketDebuggerUrl: string;
+  Browser?: string;
+};
+
+type EnsureBrowserOptions = {
+  port: number;
+  userDataDir: string;
+  /** Lazy so the browser is only located when a launch is actually needed. */
+  browserPath: () => string;
+  headless?: boolean;
+  spawnFn?: typeof spawn;
+  fetchFn?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  timeoutMs?: number;
+};
+
+/**
+ * Probe the DevTools HTTP endpoint on the loopback interface. Resolves with
+ * the version info (including the browser-level websocket URL) when a
+ * CDP-capable browser answers, or null when nothing (or something else)
+ * listens on the port.
+ */
+export async function browserEndpoint(
+  port: number,
+  fetchFn: typeof fetch = fetch,
+): Promise<EndpointInfo | null> {
+  try {
+    const response = await fetchFn(`http://127.0.0.1:${port}/json/version`);
+    if (!response.ok) {
+      return null;
+    }
+    const info = await response.json();
+    return typeof info?.webSocketDebuggerUrl === "string" ? info : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reuse the browser already serving CDP on the port, or launch one detached
+ * so it outlives this process. The browser itself is the persistent state
+ * holder across CLI invocations — there is no separate daemon to manage.
+ */
+export async function ensureBrowser(options: EnsureBrowserOptions) {
+  const fetchFn = options.fetchFn || fetch;
+  const sleep =
+    options.sleep ||
+    ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const existing = await browserEndpoint(options.port, fetchFn);
+  if (existing) {
+    return { endpoint: existing, launched: false };
+  }
+  const browserPath = options.browserPath();
+  mkdirSync(options.userDataDir, { recursive: true });
+  const args = [
+    `--remote-debugging-port=${options.port}`,
+    `--user-data-dir=${options.userDataDir}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    ...(options.headless ? ["--headless=new"] : []),
+    "about:blank",
+  ];
+  const spawnFn = options.spawnFn || spawn;
+  const child = spawnFn(browserPath, args, {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+  const deadline = Date.now() + (options.timeoutMs ?? READY_TIMEOUT_MS);
+  while (Date.now() < deadline) {
+    const endpoint = await browserEndpoint(options.port, fetchFn);
+    if (endpoint) {
+      return { endpoint, launched: true };
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(
+    `browser did not expose CDP on port ${options.port} within ${options.timeoutMs ?? READY_TIMEOUT_MS}ms`,
+  );
+}

--- a/package/ego-windows-host/src/chrome-launcher.ts
+++ b/package/ego-windows-host/src/chrome-launcher.ts
@@ -1,8 +1,14 @@
 import { spawn } from "node:child_process";
-import { mkdirSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
 
 const READY_TIMEOUT_MS = 20000;
 const POLL_INTERVAL_MS = 250;
+// Chromium's own default window is small enough that responsive sites collapse
+// their controls: Wikipedia replaces its search field with a toggle button and
+// leaves a 0x0 unfocusable input behind, so fill() silently writes nothing. A
+// desktop-sized window keeps agent scripts on the layout desktop users see.
+const DEFAULT_WINDOW = { width: 1440, height: 960 };
 
 type EndpointInfo = {
   webSocketDebuggerUrl: string;
@@ -19,6 +25,8 @@ type EnsureBrowserOptions = {
   fetchFn?: typeof fetch;
   sleep?: (ms: number) => Promise<void>;
   timeoutMs?: number;
+  exists?: (path: string) => boolean;
+  windowSize?: { width: number; height: number };
 };
 
 /**
@@ -58,12 +66,14 @@ export async function ensureBrowser(options: EnsureBrowserOptions) {
     return { endpoint: existing, launched: false };
   }
   const browserPath = options.browserPath();
+  const windowSize = options.windowSize ?? DEFAULT_WINDOW;
   mkdirSync(options.userDataDir, { recursive: true });
   const args = [
     `--remote-debugging-port=${options.port}`,
     `--user-data-dir=${options.userDataDir}`,
     "--no-first-run",
     "--no-default-browser-check",
+    `--window-size=${windowSize.width},${windowSize.height}`,
     ...(options.headless ? ["--headless=new"] : []),
     "about:blank",
   ];
@@ -73,7 +83,8 @@ export async function ensureBrowser(options: EnsureBrowserOptions) {
     stdio: "ignore",
   });
   child.unref();
-  const deadline = Date.now() + (options.timeoutMs ?? READY_TIMEOUT_MS);
+  const timeoutMs = options.timeoutMs ?? READY_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const endpoint = await browserEndpoint(options.port, fetchFn);
     if (endpoint) {
@@ -82,6 +93,53 @@ export async function ensureBrowser(options: EnsureBrowserOptions) {
     await sleep(POLL_INTERVAL_MS);
   }
   throw new Error(
-    `browser did not expose CDP on port ${options.port} within ${options.timeoutMs ?? READY_TIMEOUT_MS}ms`,
+    `browser did not expose CDP on port ${options.port} within ${timeoutMs}ms.` +
+      diagnoseLaunchFailure({
+        port: options.port,
+        userDataDir: options.userDataDir,
+        browserPath,
+        args,
+        exists: options.exists ?? existsSync,
+      }),
   );
+}
+
+/**
+ * Explain a launch that never came up. Two causes account for nearly all of
+ * them and neither is guessable from the bare timeout:
+ *
+ *  - The profile is already open in another browser process. Chromium forwards
+ *    the command line to the running instance and exits, so the debugging port
+ *    is never bound and no error is printed anywhere.
+ *  - Something else already holds the port, so binding fails silently.
+ *
+ * The launched command line is included so the failure can be reproduced by
+ * hand, which is the fastest way to see the browser's own message.
+ */
+function diagnoseLaunchFailure(context: {
+  port: number;
+  userDataDir: string;
+  browserPath: string;
+  args: string[];
+  exists: (path: string) => boolean;
+}) {
+  const causes: string[] = [];
+  // Chromium writes this while a process holds the profile; a stale one is left
+  // behind by a crash, which is equally worth reporting.
+  if (context.exists(join(context.userDataDir, "lockfile"))) {
+    causes.push(
+      `the profile at ${context.userDataDir} looks locked by another browser process (close it, or use a different EGO_HOST_STATE_DIR)`,
+    );
+  }
+  causes.push(
+    `another process may already hold port ${context.port} (set EGO_HOST_DEBUG_PORT to a free port)`,
+  );
+  return [
+    "",
+    "Possible causes:",
+    ...causes.map((cause) => `  - ${cause}`),
+    "",
+    "Run this by hand to see the browser's own error:",
+    `  "${context.browserPath}" ${context.args.join(" ")}`,
+  ].join("\n");
 }

--- a/package/ego-windows-host/src/cli.ts
+++ b/package/ego-windows-host/src/cli.ts
@@ -1,0 +1,156 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { stdin as processStdin } from "node:process";
+
+import { locateBrowser } from "./browser-locator.js";
+import { browserEndpoint, ensureBrowser } from "./chrome-launcher.js";
+import { CdpConnection } from "./cdp-connection.js";
+import { createEgoBridge } from "./ego-bridge.js";
+import { TaskSpaceRegistry } from "./task-spaces.js";
+
+export const HELP = `ego-windows-host
+
+Runs ego-browser scripts against stock Microsoft Edge or Google Chrome on
+Windows. The first call launches a dedicated browser profile (detached, it
+stays running); later calls reuse it, so task spaces and logins persist
+across invocations.
+
+Usage:
+  ego-windows-host <script.js>      run JavaScript from a file
+  ego-windows-host -e <code>        run inline JavaScript (alias: --eval)
+  ego-windows-host < task.js        read JavaScript from stdin
+  ego-windows-host --doctor         report browser, endpoint, and space state
+  ego-windows-host --help           print this help
+
+A leading "nodejs" argument is accepted for compatibility with the
+"ego-browser nodejs" invocation shape.
+
+Environment:
+  EGO_HOST_BROWSER_PATH   full path to msedge.exe / chrome.exe (default: auto-detect)
+  EGO_HOST_DEBUG_PORT     CDP port for the hosted browser (default: 9522)
+  EGO_HOST_STATE_DIR      state root (default: %LOCALAPPDATA%\\ego-windows-host)
+  EGO_HOST_HEADLESS       set to 1 to launch the browser headless
+`;
+
+export function hostConfig(
+  env: Record<string, string | undefined> = process.env,
+) {
+  const stateDir =
+    env.EGO_HOST_STATE_DIR ||
+    join(
+      env.LOCALAPPDATA || join(homedir(), ".local", "share"),
+      "ego-windows-host",
+    );
+  return {
+    port: Number(env.EGO_HOST_DEBUG_PORT) || 9522,
+    stateDir,
+    userDataDir: join(stateDir, "profile"),
+    headless: env.EGO_HOST_HEADLESS === "1" || env.EGO_HOST_HEADLESS === "true",
+  };
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = [...argv];
+  if (args[0] === "nodejs") {
+    args.shift();
+  }
+  if (args[0] === "-h" || args[0] === "--help") {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  const config = hostConfig();
+  if (args[0] === "--doctor") {
+    return runDoctor(config);
+  }
+
+  const code = await resolveInput(args);
+  if (code === null || !code.trim()) {
+    process.stderr.write(HELP);
+    return 2;
+  }
+
+  const { endpoint, launched } = await ensureBrowser({
+    port: config.port,
+    userDataDir: config.userDataDir,
+    browserPath: () => locateBrowser(),
+    headless: config.headless,
+  });
+  if (launched) {
+    process.stderr.write(
+      `[ego-windows-host] launched ${endpoint.Browser || "browser"} on port ${config.port}\n`,
+    );
+  }
+
+  const hostConnection = await CdpConnection.open(
+    endpoint.webSocketDebuggerUrl,
+  );
+  const agentConnection = await CdpConnection.open(
+    endpoint.webSocketDebuggerUrl,
+  );
+  const registry = new TaskSpaceRegistry(config.stateDir);
+  (globalThis as any).ego = createEgoBridge({
+    hostConnection,
+    agentConnection,
+    registry,
+    browserVersion: `${endpoint.Browser || "chromium"} (ego-windows-host)`,
+  });
+
+  // The runtime reads globalThis.ego at call time, so the bridge must exist
+  // before helpers run. run.js has no import-time side effects (unlike the
+  // package entry point, which auto-installs the SDK when imported).
+  const { runMain } = await import("ego-browser-v2/dist/src/run.js");
+  try {
+    return await runMain({ argv: [], stdinText: code });
+  } finally {
+    hostConnection.close();
+    agentConnection.close();
+  }
+}
+
+async function resolveInput(args: string[]): Promise<string | null> {
+  if (args[0] === "-e" || args[0] === "--eval") {
+    return args.length === 2 ? args[1] : null;
+  }
+  if (args.length === 1 && !args[0].startsWith("-")) {
+    return readFile(args[0], "utf8");
+  }
+  if (args.length > 0) {
+    return null;
+  }
+  return new Promise<string>((resolve, reject) => {
+    let data = "";
+    processStdin.setEncoding("utf8");
+    processStdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    processStdin.on("end", () => resolve(data));
+    processStdin.on("error", reject);
+  });
+}
+
+async function runDoctor(config: ReturnType<typeof hostConfig>) {
+  const lines: string[] = [];
+  try {
+    lines.push(`browser: ${locateBrowser()}`);
+  } catch (error) {
+    lines.push(`browser: NOT FOUND (${error.message})`);
+  }
+  const endpoint = await browserEndpoint(config.port);
+  lines.push(
+    endpoint
+      ? `endpoint: ${endpoint.Browser || "unknown"} on port ${config.port}`
+      : `endpoint: not running (will launch on port ${config.port} at next call)`,
+  );
+  lines.push(`state dir: ${config.stateDir}`);
+  const registry = new TaskSpaceRegistry(config.stateDir);
+  const spaces = registry.list();
+  lines.push(`task spaces: ${spaces.length}`);
+  for (const space of spaces) {
+    lines.push(
+      `  #${space.id} ${JSON.stringify(space.name)} ownership=${space.ownership} tabs=${space.targetIds.length}`,
+    );
+  }
+  process.stdout.write(lines.join("\n") + "\n");
+  return 0;
+}

--- a/package/ego-windows-host/src/cli.ts
+++ b/package/ego-windows-host/src/cli.ts
@@ -31,6 +31,7 @@ Environment:
   EGO_HOST_DEBUG_PORT     CDP port for the hosted browser (default: 9522)
   EGO_HOST_STATE_DIR      state root (default: %LOCALAPPDATA%\\ego-windows-host)
   EGO_HOST_HEADLESS       set to 1 to launch the browser headless
+  EGO_HOST_SPACE_WINDOWS  set to 1 to open each task space in its own window
 `;
 
 export function hostConfig(
@@ -47,6 +48,9 @@ export function hostConfig(
     stateDir,
     userDataDir: join(stateDir, "profile"),
     headless: env.EGO_HOST_HEADLESS === "1" || env.EGO_HOST_HEADLESS === "true",
+    spaceWindows:
+      env.EGO_HOST_SPACE_WINDOWS === "1" ||
+      env.EGO_HOST_SPACE_WINDOWS === "true",
   };
 }
 
@@ -94,6 +98,7 @@ export async function main(argv = process.argv.slice(2)) {
     agentConnection,
     registry,
     browserVersion: `${endpoint.Browser || "chromium"} (ego-windows-host)`,
+    spaceWindows: config.spaceWindows,
   });
 
   // The runtime reads globalThis.ego at call time, so the bridge must exist

--- a/package/ego-windows-host/src/ego-bridge.test.mjs
+++ b/package/ego-windows-host/src/ego-bridge.test.mjs
@@ -1,0 +1,325 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createEgoBridge } from "../dist/src/ego-bridge.js";
+import { TaskSpaceRegistry } from "../dist/src/task-spaces.js";
+
+function fakeConnection(handler = async () => ({})) {
+  const connection = {
+    requests: [],
+    sentRaw: [],
+    handlers: new Set(),
+    async request(method, params = {}, sessionId = undefined) {
+      connection.requests.push({ method, params, sessionId });
+      return handler(method, params, sessionId);
+    },
+    sendRaw(payload) {
+      connection.sentRaw.push(payload);
+    },
+    onMessage(listener) {
+      connection.handlers.add(listener);
+      return () => connection.handlers.delete(listener);
+    },
+    emit(raw) {
+      for (const listener of [...connection.handlers]) {
+        listener(raw);
+      }
+    },
+    close() {},
+  };
+  return connection;
+}
+
+let targetCounter = 0;
+function hostHandler(targets = []) {
+  return async (method, params, sessionId) => {
+    if (method === "Target.getTargets") {
+      return { targetInfos: targets };
+    }
+    if (method === "Target.createTarget") {
+      const targetId = `target-${++targetCounter}`;
+      targets.push({ targetId, type: "page", url: params.url, title: "" });
+      return { targetId };
+    }
+    if (method === "Target.closeTarget") {
+      const index = targets.findIndex((t) => t.targetId === params.targetId);
+      if (index >= 0) targets.splice(index, 1);
+      return {};
+    }
+    if (method === "Target.attachToTarget") {
+      return { sessionId: "host-sess-1" };
+    }
+    if (method === "Accessibility.getFullAXTree") {
+      return {
+        nodes: [
+          {
+            nodeId: "1",
+            role: { value: "RootWebArea" },
+            name: { value: "Page" },
+            backendDOMNodeId: 1,
+            childIds: ["2"],
+          },
+          {
+            nodeId: "2",
+            role: { value: "button" },
+            name: { value: "Go" },
+            backendDOMNodeId: 2,
+            childIds: [],
+          },
+        ],
+      };
+    }
+    return {};
+  };
+}
+
+async function withBridge(run) {
+  const dir = await mkdtemp(join(tmpdir(), "ego-host-bridge-"));
+  try {
+    const targets = [];
+    const hostConnection = fakeConnection(hostHandler(targets));
+    const agentConnection = fakeConnection();
+    const registry = new TaskSpaceRegistry(dir);
+    const ego = createEgoBridge({
+      hostConnection,
+      agentConnection,
+      registry,
+      browserVersion: "FakeBrowser/1.0 (ego-windows-host)",
+    });
+    await run({ ego, registry, hostConnection, agentConnection, targets });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function selectFreshSpace(ego, name = "research") {
+  const created = await ego.createTaskSpace(name);
+  await ego.useTaskSpace(created.id);
+  return created;
+}
+
+test("createTaskSpace returns the shape the runtime normalizes", async () => {
+  await withBridge(async ({ ego }) => {
+    const created = await ego.createTaskSpace("research");
+    assert.equal(typeof created.id, "number");
+    assert.equal(created.name, "research");
+    assert.equal(created.ownership, "agent");
+    assert.equal(created.taskId, String(created.id));
+  });
+});
+
+test("createTaskSpace opens an initial blank tab for the session", async () => {
+  await withBridge(async ({ ego, registry }) => {
+    const created = await ego.createTaskSpace("research");
+    const space = registry.get(created.id);
+    assert.equal(space.targetIds.length, 1);
+    assert.equal(space.activeTargetId, space.targetIds[0]);
+  });
+});
+
+test("createTaskSpace rejects an empty name with EGO_INVALID_ARGUMENT", async () => {
+  await withBridge(async ({ ego }) => {
+    const result = await ego.createTaskSpace("");
+    assert.equal(result.error_code, "EGO_INVALID_ARGUMENT");
+  });
+});
+
+test("listTaskSpaces wraps spaces in { taskSpaces }", async () => {
+  await withBridge(async ({ ego }) => {
+    await ego.createTaskSpace("research");
+    const result = await ego.listTaskSpaces();
+    assert.equal(result.taskSpaces.length, 1);
+    assert.equal(result.taskSpaces[0].name, "research");
+  });
+});
+
+test("useTaskSpace resolves not-found for unknown ids", async () => {
+  await withBridge(async ({ ego }) => {
+    const result = await ego.useTaskSpace(42);
+    assert.equal(result.error_code, "EGO_TASK_SPACE_NOT_FOUND");
+  });
+});
+
+test("listTabs scopes tabs to the selected space", async () => {
+  await withBridge(async ({ ego, targets }) => {
+    await selectFreshSpace(ego, "research");
+    targets.push({
+      targetId: "other-tab",
+      type: "page",
+      url: "https://outside.example",
+      title: "outside",
+    });
+    const { tabs } = await ego.listTabs();
+    assert.equal(tabs.length, 1);
+    assert.notEqual(tabs[0].targetId, "other-tab");
+    assert.equal(tabs[0].active, true);
+  });
+});
+
+test("listTabs without a selected space resolves EGO_TASK_SPACE_NOT_SELECTED", async () => {
+  await withBridge(async ({ ego }) => {
+    const result = await ego.listTabs();
+    assert.equal(result.error_code, "EGO_TASK_SPACE_NOT_SELECTED");
+  });
+});
+
+test("createTab tracks and activates the new tab in the space", async () => {
+  await withBridge(async ({ ego, registry }) => {
+    const created = await selectFreshSpace(ego);
+    const result = await ego.createTab("https://example.com");
+    const space = registry.get(created.id);
+    assert.ok(space.targetIds.includes(result.targetId));
+    assert.equal(space.activeTargetId, result.targetId);
+  });
+});
+
+test("sendCDPMessage forwards traffic verbatim for an agent-owned space", async () => {
+  await withBridge(async ({ ego, agentConnection }) => {
+    await selectFreshSpace(ego);
+    const payload = '{"id":1,"method":"Runtime.evaluate","params":{}}';
+    ego.sendCDPMessage(payload);
+    assert.deepEqual(agentConnection.sentRaw, [payload]);
+  });
+});
+
+test("sendCDPMessage without a space reports EGO_TASK_SPACE_NOT_SELECTED", async () => {
+  await withBridge(async ({ ego, agentConnection }) => {
+    const failures = [];
+    ego.onSendCDPMessageError = (message, code) =>
+      failures.push({ message, code });
+    ego.sendCDPMessage('{"id":1,"method":"Runtime.evaluate"}');
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].code, "EGO_TASK_SPACE_NOT_SELECTED");
+    assert.equal(agentConnection.sentRaw.length, 0, "nothing is forwarded");
+  });
+});
+
+test("a handed-off space pauses commands with EGO_TASK_SPACE_USER_IN_CONTROL", async () => {
+  await withBridge(async ({ ego, agentConnection }) => {
+    await selectFreshSpace(ego);
+    await ego.handOffTaskSpace();
+    const failures = [];
+    ego.onSendCDPMessageError = (message, code) =>
+      failures.push({ message, code });
+    ego.sendCDPMessage('{"id":1,"method":"Runtime.evaluate"}');
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(failures[0].code, "EGO_TASK_SPACE_USER_IN_CONTROL");
+    assert.equal(agentConnection.sentRaw.length, 0);
+
+    await ego.takeOverTaskSpace();
+    ego.sendCDPMessage('{"id":2,"method":"Runtime.evaluate"}');
+    assert.equal(agentConnection.sentRaw.length, 1, "commands resume");
+  });
+});
+
+test("snapshot rejects with the user-control code during a handoff", async () => {
+  await withBridge(async ({ ego }) => {
+    await selectFreshSpace(ego);
+    await ego.handOffTaskSpace();
+    await assert.rejects(ego.snapshot({ maxResultLength: 1 }), (error) => {
+      assert.equal(error.error_code, "EGO_TASK_SPACE_USER_IN_CONTROL");
+      return true;
+    });
+  });
+});
+
+test("claimTaskSpace returns ownership to the agent", async () => {
+  await withBridge(async ({ ego }) => {
+    const created = await selectFreshSpace(ego);
+    await ego.handOffTaskSpace();
+    const claimed = await ego.claimTaskSpace(created.id, created.name);
+    assert.equal(claimed.ownership, "agent");
+  });
+});
+
+test("snapshot renders the AX tree with refs from the active tab", async () => {
+  await withBridge(async ({ ego }) => {
+    await selectFreshSpace(ego);
+    const result = await ego.snapshot();
+    assert.match(result.content, /button "Go" \[@2\]/);
+    assert.deepEqual(result.refs, [
+      { backendNodeId: 2, role: "button", name: "Go" },
+    ]);
+  });
+});
+
+test("snapshot honors maxResultLength for the control probe", async () => {
+  await withBridge(async ({ ego }) => {
+    await selectFreshSpace(ego);
+    const result = await ego.snapshot({ maxResultLength: 1 });
+    assert.equal(result.content.length, 1);
+  });
+});
+
+test("closeTaskSpace closes every tracked tab and removes the space", async () => {
+  await withBridge(async ({ ego, registry, hostConnection }) => {
+    const created = await selectFreshSpace(ego);
+    await ego.createTab("https://example.com");
+    await ego.closeTaskSpace();
+    const closes = hostConnection.requests.filter(
+      (request) => request.method === "Target.closeTarget",
+    );
+    assert.equal(closes.length, 2);
+    assert.equal(registry.get(created.id), undefined);
+  });
+});
+
+test("completeTaskSpace keeps the tabs and hands the space to the user", async () => {
+  await withBridge(async ({ ego, registry, hostConnection }) => {
+    const created = await selectFreshSpace(ego);
+    await ego.completeTaskSpace();
+    assert.equal(registry.get(created.id).ownership, "agentDelegatedToUser");
+    const closes = hostConnection.requests.filter(
+      (request) => request.method === "Target.closeTarget",
+    );
+    assert.equal(closes.length, 0);
+  });
+});
+
+test("a raw Target.createTarget through the bridge is tracked into the space", async () => {
+  await withBridge(async ({ ego, registry, agentConnection }) => {
+    const created = await selectFreshSpace(ego);
+    ego.sendCDPMessage(
+      '{"id":7,"method":"Target.createTarget","params":{"url":"about:blank"}}',
+    );
+    agentConnection.emit('{"id":7,"result":{"targetId":"raw-created-tab"}}');
+    const space = registry.get(created.id);
+    assert.ok(space.targetIds.includes("raw-created-tab"));
+    assert.equal(space.activeTargetId, "raw-created-tab");
+  });
+});
+
+test("a raw Target.activateTarget updates the active tab", async () => {
+  await withBridge(async ({ ego, registry }) => {
+    const created = await selectFreshSpace(ego);
+    const second = await ego.createTab("https://example.com");
+    const first = registry.get(created.id).targetIds[0];
+    assert.equal(registry.get(created.id).activeTargetId, second.targetId);
+    ego.sendCDPMessage(
+      `{"id":9,"method":"Target.activateTarget","params":{"targetId":${JSON.stringify(first)}}}`,
+    );
+    assert.equal(registry.get(created.id).activeTargetId, first);
+  });
+});
+
+test("incoming CDP messages reach onCDPMessage verbatim", async () => {
+  await withBridge(async ({ ego, agentConnection }) => {
+    const seen = [];
+    ego.onCDPMessage = (raw) => seen.push(raw);
+    agentConnection.emit('{"method":"Page.loadEventFired","params":{}}');
+    assert.equal(seen.length, 1);
+    assert.match(seen[0], /loadEventFired/);
+  });
+});
+
+test("getBrowserVersion reports no update so the notice stays silent", async () => {
+  await withBridge(async ({ ego }) => {
+    const version = await ego.getBrowserVersion();
+    assert.equal(version.updateAvailable, false);
+    assert.match(version.currentVersion, /ego-windows-host/);
+  });
+});

--- a/package/ego-windows-host/src/ego-bridge.ts
+++ b/package/ego-windows-host/src/ego-bridge.ts
@@ -1,0 +1,301 @@
+import { CdpConnection } from "./cdp-connection.js";
+import { TaskSpaceRegistry, TaskSpace } from "./task-spaces.js";
+import { renderAxTree } from "./ax-snapshot.js";
+
+/**
+ * The globalThis.ego contract the ego-browser runtime expects, implemented
+ * against a stock Chromium browser over two dedicated CDP connections:
+ *
+ *   - agentConnection: verbatim passthrough for the runtime's own CDP traffic
+ *     (sendCDPMessage / onCDPMessage / onSendCDPMessageError).
+ *   - hostConnection: host-internal calls (tab bookkeeping, snapshots), so the
+ *     runtime's flattened sessions never mix with the host's.
+ *
+ * Error behavior mirrors the native bindings the runtime is written against
+ * (see package/ego-browser/src/ego-errors.ts): task-space methods RESOLVE
+ * with { error, error_code } shapes, snapshot REJECTS with an Error carrying
+ * .error_code, and local send failures surface through onSendCDPMessageError.
+ */
+
+const NOT_SELECTED = {
+  error: "no task space is selected; call taskSpaces.useOrCreate(name) first",
+  error_code: "EGO_TASK_SPACE_NOT_SELECTED",
+};
+
+const USER_IN_CONTROL = {
+  error: "the user is controlling this task space",
+  error_code: "EGO_TASK_SPACE_USER_IN_CONTROL",
+};
+
+function notFound(id: unknown) {
+  return {
+    error: `task space not found: ${JSON.stringify(id)}`,
+    error_code: "EGO_TASK_SPACE_NOT_FOUND",
+  };
+}
+
+function egoError(shape: { error: string; error_code: string }) {
+  const error: Error & { error_code?: string } = new Error(shape.error);
+  error.error_code = shape.error_code;
+  return error;
+}
+
+function shapeSpace(space: TaskSpace) {
+  return {
+    taskId: String(space.id),
+    id: space.id,
+    name: space.name,
+    createdBy: space.createdBy,
+    ownership: space.ownership,
+    recentTabTitles: [],
+  };
+}
+
+type BridgeOptions = {
+  hostConnection: CdpConnection;
+  agentConnection: CdpConnection;
+  registry: TaskSpaceRegistry;
+  browserVersion?: string;
+};
+
+export function createEgoBridge(options: BridgeOptions) {
+  const { hostConnection, agentConnection, registry } = options;
+  // Runtime requests worth reacting to on their response (Target.createTarget
+  // returns the new targetId asynchronously, under the runtime's own id).
+  const sniffedCreates = new Set<number>();
+
+  const bridge: Record<string, any> = {
+    onCDPMessage: null,
+    onSendCDPMessageError: null,
+
+    sendCDPMessage(payload: string) {
+      const space = registry.current();
+      const blocked = !space
+        ? NOT_SELECTED
+        : space.ownership !== "agent"
+          ? USER_IN_CONTROL
+          : null;
+      if (blocked) {
+        const callback = bridge.onSendCDPMessageError;
+        if (typeof callback === "function") {
+          queueMicrotask(() => callback(blocked.error, blocked.error_code));
+        }
+        return;
+      }
+      // Keep the space's tab bookkeeping consistent when the runtime manages
+      // tabs through raw CDP instead of ego.createTab.
+      let parsed;
+      try {
+        parsed = JSON.parse(payload);
+      } catch {
+        parsed = null;
+      }
+      if (
+        parsed?.method === "Target.activateTarget" &&
+        parsed.params?.targetId
+      ) {
+        registry.setActive(parsed.params.targetId);
+      } else if (parsed?.method === "Target.createTarget" && parsed.id) {
+        sniffedCreates.add(parsed.id);
+      } else if (
+        parsed?.method === "Target.closeTarget" &&
+        parsed.params?.targetId
+      ) {
+        registry.untrackTarget(parsed.params.targetId);
+      }
+      agentConnection.sendRaw(payload);
+    },
+
+    async listTabs() {
+      const space = registry.current();
+      if (!space) {
+        return NOT_SELECTED;
+      }
+      if (space.ownership !== "agent") {
+        return USER_IN_CONTROL;
+      }
+      const { targetInfos } = await hostConnection.request("Target.getTargets");
+      const pages = (targetInfos || []).filter((t) => t.type === "page");
+      registry.pruneTargets(pages.map((p) => p.targetId));
+      const tracked = new Set(registry.current()?.targetIds || []);
+      const tabs = pages
+        .filter((p) => tracked.has(p.targetId))
+        .map((p, index) => ({
+          targetId: p.targetId,
+          title: p.title || "",
+          url: p.url || "",
+          active: p.targetId === registry.current()?.activeTargetId,
+          index,
+        }));
+      if (tabs.length > 0 && !tabs.some((tab) => tab.active)) {
+        tabs[tabs.length - 1].active = true;
+      }
+      return { tabs };
+    },
+
+    async createTab(url = "about:blank") {
+      const space = registry.current();
+      if (!space) {
+        return NOT_SELECTED;
+      }
+      if (space.ownership !== "agent") {
+        return USER_IN_CONTROL;
+      }
+      const created = await hostConnection.request("Target.createTarget", {
+        url,
+      });
+      registry.trackTarget(created.targetId);
+      registry.setActive(created.targetId);
+      return { targetId: created.targetId };
+    },
+
+    async listTaskSpaces() {
+      return { taskSpaces: registry.list().map(shapeSpace) };
+    },
+
+    async createTaskSpace(name: string) {
+      if (typeof name !== "string" || name === "") {
+        return {
+          error: "createTaskSpace requires a non-empty name",
+          error_code: "EGO_INVALID_ARGUMENT",
+        };
+      }
+      const space = registry.create(name);
+      // A fresh space starts with one blank tab so the runtime always has a
+      // target to attach its session to.
+      const created = await hostConnection.request("Target.createTarget", {
+        url: "about:blank",
+      });
+      registry.trackTarget(created.targetId, space.id);
+      registry.setActive(created.targetId, space.id);
+      return shapeSpace(registry.get(space.id));
+    },
+
+    async useTaskSpace(id: number) {
+      const space = registry.select(Number(id));
+      if (!space) {
+        return notFound(id);
+      }
+      return {};
+    },
+
+    async claimTaskSpace(id: number, _name?: string) {
+      const space = registry.setOwnership(Number(id), "agent");
+      if (!space) {
+        return notFound(id);
+      }
+      return shapeSpace(space);
+    },
+
+    async handOffTaskSpace() {
+      const space = registry.current();
+      if (!space) {
+        return NOT_SELECTED;
+      }
+      registry.setOwnership(space.id, "agentDelegatedToUser");
+      return {};
+    },
+
+    async takeOverTaskSpace() {
+      const space = registry.current();
+      if (!space) {
+        return NOT_SELECTED;
+      }
+      registry.setOwnership(space.id, "agent");
+      return {};
+    },
+
+    async completeTaskSpace() {
+      // keep:true — the page stays open for the user; control moves to them.
+      const space = registry.current();
+      if (!space) {
+        return NOT_SELECTED;
+      }
+      registry.setOwnership(space.id, "agentDelegatedToUser");
+      return {};
+    },
+
+    async closeTaskSpace() {
+      const space = registry.current();
+      if (!space) {
+        return NOT_SELECTED;
+      }
+      for (const targetId of [...space.targetIds]) {
+        await hostConnection
+          .request("Target.closeTarget", { targetId })
+          .catch(() => {});
+      }
+      registry.remove(space.id);
+      return {};
+    },
+
+    async snapshot(snapshotOptions: any = {}) {
+      const space = registry.current();
+      if (!space) {
+        throw egoError(NOT_SELECTED);
+      }
+      if (space.ownership !== "agent") {
+        // Rejecting with the stable code is the contract probeAgentControl
+        // relies on while polling for control to come back.
+        throw egoError(USER_IN_CONTROL);
+      }
+      const targetId = space.activeTargetId ?? space.targetIds.at(-1);
+      if (!targetId) {
+        throw egoError({
+          error: "the task space has no tab to snapshot",
+          error_code: "EGO_SNAPSHOT_FAILED",
+        });
+      }
+      const attached = await hostConnection.request("Target.attachToTarget", {
+        targetId,
+        flatten: true,
+      });
+      const sessionId = attached.sessionId;
+      try {
+        await hostConnection.request("Accessibility.enable", {}, sessionId);
+        const tree = await hostConnection.request(
+          "Accessibility.getFullAXTree",
+          {},
+          sessionId,
+        );
+        return renderAxTree(tree.nodes || [], {
+          maxResultLength: snapshotOptions.maxResultLength,
+        });
+      } finally {
+        hostConnection
+          .request("Target.detachFromTarget", { sessionId })
+          .catch(() => {});
+      }
+    },
+
+    async getBrowserVersion() {
+      return {
+        currentVersion: options.browserVersion || "ego-windows-host",
+        updateAvailable: false,
+      };
+    },
+  };
+
+  agentConnection.onMessage((raw) => {
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      data = null;
+    }
+    if (data?.id && sniffedCreates.has(data.id)) {
+      sniffedCreates.delete(data.id);
+      const targetId = data.result?.targetId;
+      if (targetId) {
+        registry.trackTarget(targetId);
+        registry.setActive(targetId);
+      }
+    }
+    const callback = bridge.onCDPMessage;
+    if (typeof callback === "function") {
+      callback(raw);
+    }
+  });
+
+  return bridge;
+}

--- a/package/ego-windows-host/src/ego-bridge.ts
+++ b/package/ego-windows-host/src/ego-bridge.ts
@@ -56,6 +56,8 @@ type BridgeOptions = {
   agentConnection: CdpConnection;
   registry: TaskSpaceRegistry;
   browserVersion?: string;
+  // Open each new task space in its own browser window instead of a tab.
+  spaceWindows?: boolean;
 };
 
 export function createEgoBridge(options: BridgeOptions) {
@@ -162,9 +164,12 @@ export function createEgoBridge(options: BridgeOptions) {
       }
       const space = registry.create(name);
       // A fresh space starts with one blank tab so the runtime always has a
-      // target to attach its session to.
+      // target to attach its session to. Opening it in its own browser window
+      // (opt-in) gives each space the visual separation the macOS Spaces UI
+      // provides, so parallel agents are legible on screen.
       const created = await hostConnection.request("Target.createTarget", {
         url: "about:blank",
+        ...(options.spaceWindows ? { newWindow: true } : {}),
       });
       registry.trackTarget(created.targetId, space.id);
       registry.setActive(created.targetId, space.id);

--- a/package/ego-windows-host/src/task-spaces.test.mjs
+++ b/package/ego-windows-host/src/task-spaces.test.mjs
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { TaskSpaceRegistry } from "../dist/src/task-spaces.js";
+
+async function withRegistry(run) {
+  const dir = await mkdtemp(join(tmpdir(), "ego-host-spaces-"));
+  try {
+    await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("create assigns increasing numeric ids and agent ownership", async () => {
+  await withRegistry((dir) => {
+    const registry = new TaskSpaceRegistry(dir);
+    const first = registry.create("research");
+    const second = registry.create("checkout");
+    assert.equal(first.id, 1);
+    assert.equal(second.id, 2);
+    assert.equal(first.ownership, "agent");
+    assert.equal(registry.list().length, 2);
+  });
+});
+
+test("select tracks the current space; unknown ids return null", async () => {
+  await withRegistry((dir) => {
+    const registry = new TaskSpaceRegistry(dir);
+    const space = registry.create("research");
+    assert.equal(registry.current(), null);
+    assert.equal(registry.select(space.id).id, space.id);
+    assert.equal(registry.current().name, "research");
+    assert.equal(registry.select(99), null);
+  });
+});
+
+test("ownership transitions cover handoff, takeover, and claim", async () => {
+  await withRegistry((dir) => {
+    const registry = new TaskSpaceRegistry(dir);
+    const space = registry.create("research");
+    registry.setOwnership(space.id, "agentDelegatedToUser");
+    assert.equal(registry.get(space.id).ownership, "agentDelegatedToUser");
+    registry.setOwnership(space.id, "agent");
+    assert.equal(registry.get(space.id).ownership, "agent");
+    assert.equal(registry.setOwnership(99, "agent"), null);
+  });
+});
+
+test("target tracking keeps membership and the active tab consistent", async () => {
+  await withRegistry((dir) => {
+    const registry = new TaskSpaceRegistry(dir);
+    const space = registry.create("research");
+    registry.select(space.id);
+    registry.trackTarget("tab-1");
+    registry.trackTarget("tab-2");
+    registry.trackTarget("tab-2");
+    assert.deepEqual(registry.current().targetIds, ["tab-1", "tab-2"]);
+    registry.setActive("tab-1");
+    assert.equal(registry.current().activeTargetId, "tab-1");
+    registry.untrackTarget("tab-1");
+    assert.deepEqual(registry.current().targetIds, ["tab-2"]);
+    assert.equal(registry.current().activeTargetId, "tab-2");
+  });
+});
+
+test("setActive ignores targets that are not part of the space", async () => {
+  await withRegistry((dir) => {
+    const registry = new TaskSpaceRegistry(dir);
+    const space = registry.create("research");
+    registry.select(space.id);
+    registry.trackTarget("tab-1");
+    registry.setActive("someone-elses-tab");
+    assert.equal(registry.current().activeTargetId, null);
+  });
+});
+
+test("pruneTargets drops tabs the browser no longer reports", async () => {
+  await withRegistry((dir) => {
+    const registry = new TaskSpaceRegistry(dir);
+    const space = registry.create("research");
+    registry.select(space.id);
+    registry.trackTarget("tab-1");
+    registry.trackTarget("tab-2");
+    registry.setActive("tab-1");
+    registry.pruneTargets(["tab-2"]);
+    assert.deepEqual(registry.current().targetIds, ["tab-2"]);
+    assert.equal(registry.current().activeTargetId, "tab-2");
+  });
+});
+
+test("state persists across registry instances", async () => {
+  await withRegistry((dir) => {
+    const first = new TaskSpaceRegistry(dir);
+    const space = first.create("research");
+    first.select(space.id);
+    first.trackTarget("tab-1");
+
+    const second = new TaskSpaceRegistry(dir);
+    assert.equal(second.current().name, "research");
+    assert.deepEqual(second.current().targetIds, ["tab-1"]);
+    const another = second.create("checkout");
+    assert.equal(another.id, 2, "id counter persists too");
+  });
+});
+
+test("remove clears the current selection when it was selected", async () => {
+  await withRegistry((dir) => {
+    const registry = new TaskSpaceRegistry(dir);
+    const space = registry.create("research");
+    registry.select(space.id);
+    registry.remove(space.id);
+    assert.equal(registry.current(), null);
+    assert.equal(registry.list().length, 0);
+  });
+});

--- a/package/ego-windows-host/src/task-spaces.ts
+++ b/package/ego-windows-host/src/task-spaces.ts
@@ -1,0 +1,197 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type Ownership = "agent" | "agentDelegatedToUser" | "user";
+
+export type TaskSpace = {
+  id: number;
+  name: string;
+  ownership: Ownership;
+  createdBy: string;
+  targetIds: string[];
+  activeTargetId: string | null;
+};
+
+type PersistedState = {
+  nextId: number;
+  currentId: number | null;
+  spaces: TaskSpace[];
+};
+
+/**
+ * Task spaces emulated as tracked tab sets inside one shared browser profile,
+ * the same model PR #134/#202 use on Linux: the profile (and its logins) is
+ * shared, ownership and tab membership are host bookkeeping. State persists
+ * as JSON so spaces survive across CLI invocations — the browser holds the
+ * tabs, this registry holds which tab belongs to which space.
+ */
+export class TaskSpaceRegistry {
+  stateDir: string;
+  statePath: string;
+  nextId: number;
+  currentId: number | null;
+  spaces: Map<number, TaskSpace>;
+
+  constructor(stateDir: string) {
+    this.stateDir = stateDir;
+    this.statePath = join(stateDir, "spaces.json");
+    this.nextId = 1;
+    this.currentId = null;
+    this.spaces = new Map();
+    this.load();
+  }
+
+  list(): TaskSpace[] {
+    return [...this.spaces.values()];
+  }
+
+  get(id: number): TaskSpace | undefined {
+    return this.spaces.get(id);
+  }
+
+  current(): TaskSpace | null {
+    if (this.currentId === null) {
+      return null;
+    }
+    return this.spaces.get(this.currentId) ?? null;
+  }
+
+  create(name: string): TaskSpace {
+    const space: TaskSpace = {
+      id: this.nextId++,
+      name,
+      ownership: "agent",
+      createdBy: "agent",
+      targetIds: [],
+      activeTargetId: null,
+    };
+    this.spaces.set(space.id, space);
+    this.save();
+    return space;
+  }
+
+  select(id: number): TaskSpace | null {
+    const space = this.spaces.get(id);
+    if (!space) {
+      return null;
+    }
+    this.currentId = id;
+    this.save();
+    return space;
+  }
+
+  setOwnership(id: number, ownership: Ownership): TaskSpace | null {
+    const space = this.spaces.get(id);
+    if (!space) {
+      return null;
+    }
+    space.ownership = ownership;
+    this.save();
+    return space;
+  }
+
+  remove(id: number) {
+    this.spaces.delete(id);
+    if (this.currentId === id) {
+      this.currentId = null;
+    }
+    this.save();
+  }
+
+  trackTarget(targetId: string, spaceId = this.currentId) {
+    const space = spaceId === null ? null : this.spaces.get(spaceId);
+    if (!space || space.targetIds.includes(targetId)) {
+      return;
+    }
+    space.targetIds.push(targetId);
+    this.save();
+  }
+
+  untrackTarget(targetId: string) {
+    let changed = false;
+    for (const space of this.spaces.values()) {
+      const index = space.targetIds.indexOf(targetId);
+      if (index >= 0) {
+        space.targetIds.splice(index, 1);
+        changed = true;
+      }
+      if (space.activeTargetId === targetId) {
+        space.activeTargetId = space.targetIds.at(-1) ?? null;
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.save();
+    }
+  }
+
+  setActive(targetId: string, spaceId = this.currentId) {
+    const space = spaceId === null ? null : this.spaces.get(spaceId);
+    if (!space || !space.targetIds.includes(targetId)) {
+      return;
+    }
+    space.activeTargetId = targetId;
+    this.save();
+  }
+
+  /** Drop tracked targets the browser no longer reports (closed tabs). */
+  pruneTargets(liveTargetIds: string[]) {
+    const live = new Set(liveTargetIds);
+    let changed = false;
+    for (const space of this.spaces.values()) {
+      const kept = space.targetIds.filter((id) => live.has(id));
+      if (kept.length !== space.targetIds.length) {
+        space.targetIds = kept;
+        changed = true;
+      }
+      if (space.activeTargetId && !live.has(space.activeTargetId)) {
+        space.activeTargetId = kept.at(-1) ?? null;
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.save();
+    }
+  }
+
+  private load() {
+    let raw: string;
+    try {
+      raw = readFileSync(this.statePath, "utf8");
+    } catch {
+      return;
+    }
+    try {
+      const state: PersistedState = JSON.parse(raw);
+      if (!Number.isFinite(state?.nextId)) {
+        return;
+      }
+      this.nextId = state.nextId;
+      this.currentId = state.currentId ?? null;
+      for (const space of state.spaces || []) {
+        if (Number.isFinite(space?.id) && typeof space?.name === "string") {
+          this.spaces.set(space.id, {
+            ...space,
+            targetIds: Array.isArray(space.targetIds) ? space.targetIds : [],
+            activeTargetId: space.activeTargetId ?? null,
+          });
+        }
+      }
+    } catch {
+      // A corrupt state file starts fresh instead of blocking the host.
+    }
+  }
+
+  private save() {
+    const state: PersistedState = {
+      nextId: this.nextId,
+      currentId: this.currentId,
+      spaces: this.list(),
+    };
+    mkdirSync(this.stateDir, { recursive: true });
+    // Atomic replace so a failed write leaves the previous state valid.
+    const tempPath = `${this.statePath}.${process.pid}.tmp`;
+    writeFileSync(tempPath, JSON.stringify(state, null, 2));
+    renameSync(tempPath, this.statePath);
+  }
+}

--- a/package/ego-windows-host/tsconfig.build.json
+++ b/package/ego-windows-host/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.mjs"]
+}

--- a/package/ego-windows-host/tsconfig.json
+++ b/package/ego-windows-host/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2024", "DOM"],
+    "allowJs": false,
+    "checkJs": false,
+    "strict": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Windows users cannot run ego-browser at all while native Windows support (#203) is under evaluation. This PR adds `package/ego-windows-host`, a preview host that implements the `globalThis.ego` contract against stock Microsoft Edge or Chrome over loopback CDP and delegates execution to the **unmodified** `ego-browser` runtime. Everything the runtime offers — task spaces, `page`/locators, snapshots, screenshots, control handoff — works on Windows today, and scripts stay byte-identical when the native app ships. Additive only: no existing file is touched except one new, path-scoped workflow.

## Related issue

Closes #227 (proposal). Addresses the Windows-user half of #203 as a stopgap. Follows the host-contract prior art of #134/#202 (credit to @iagogfe and @olenanikita1980-cell); deliberately a sibling package rather than an extension of #202, whose daemon/Unix-socket design doesn't map to Windows and whose review shouldn't be bloated from the side.

## Changes

- `package/ego-windows-host/src/ego-bridge.ts` — the `ego` contract: verbatim CDP passthrough (`sendCDPMessage` / `onCDPMessage` / `onSendCDPMessageError`), `listTabs`/`createTab` scoped to the selected task space, the full task-space method set resolving the documented `{ error, error_code }` shapes, `snapshot()` (rejects with `EGO_TASK_SPACE_USER_IN_CONTROL` during handoff — the contract `probeAgentControl`/`waitForAgentControl` rely on), and `getBrowserVersion()` reporting no update so the notice stays silent. Raw `Target.createTarget`/`activateTarget`/`closeTarget` through the passthrough are sniffed so tab bookkeeping stays consistent however the runtime opens tabs.
- `src/task-spaces.ts` — spaces as persisted tab sets with ownership (`agent`/`agentDelegatedToUser`/`user`), atomic JSON state under `%LOCALAPPDATA%\ego-windows-host`. No daemon: the detached browser is the persistent process.
- `src/ax-snapshot.ts` — `{ content, refs }` from `Accessibility.getFullAXTree`, with `[@backendNodeId]` marks that resolve through the runtime's existing `browserSnapshotRefsToRefMap`/`parseRef` path. Honestly weaker than the app's kernel-level snapshot; documented as such.
- `src/browser-locator.ts`, `src/chrome-launcher.ts` — Edge-first detection across standard Windows install roots (`EGO_HOST_BROWSER_PATH` override), reuse-or-launch against a fixed loopback CDP port with a dedicated profile; never touches the user's daily browser profile.
- `src/cdp-connection.ts` — minimal CDP client over Node ≥ 22's global WebSocket (zero new runtime dependencies, matching the repo's no-Puppeteer/Playwright rule). Two connections per run: host-internal and agent passthrough, so flattened sessions never mix.
- `src/cli.ts`, `bin/ego-windows-host.mjs` — script file / `-e` / stdin input (PowerShell has no heredocs; same rationale as #225/#226), a leading `nodejs` accepted for compatibility, `--doctor` state report.
- `.github/workflows/windows-host.yml` — path-scoped test job on windows-latest + ubuntu-latest (`npm ci --ignore-scripts` until #148 makes the sibling prepare script Windows-safe). A new file so it cannot conflict with #202's CI edits.
- 57 unit tests across six suites (locator, launcher, CDP client, registry, snapshot renderer, bridge), all offline with injected fakes per the repo's stub-injection style.

## Verification

Unit/typecheck, run from `package/ego-windows-host` (Windows 11, Node 24):

```text
npm test  -> build + typecheck + 57 pass, 0 fail
package/ego-browser npm test unaffected (no existing file modified)
```

Real end-to-end against stock Edge 151 headless on Windows 11 (transcript):

```text
> node bin/ego-windows-host.mjs -e "...useOrCreate('host smoke'); openOrReuseTab('https://example.com')..."
{
  "taskSpaceId": 1,
  "url": "https://example.com/",
  "heading": "Example Domain",
  "snapshotPreview": [
    "- RootWebArea \"Example Domain\"",
    "  - heading \"Example Domain\" [@13]",
    "  - text: \"This domain is for use in documentation examples...\"",
    "  - link \"Learn more\" [@16]"
  ],
  "screenshot": "C:\\...\\ego-browser-shot-36172-1.png"
}

# separate invocation — persistence and interaction
{ "taskSpaceId": 1, "reusedExistingTab": true,
  "clickNavigatedTo": "https://www.iana.org/help/example-domains",
  "navigationWaitResolved": true }

# handoff / hard stop / takeover / completion
handOff: {"done":true}
(next invocation, browser command) -> the runtime's owned user-control hard-stop guidance, verbatim
--doctor after takeOver -> #1 "host smoke" ownership=agent tabs=2
complete({keep:false}) -> {"done":true}; --doctor -> task spaces: 0
```

The handoff transcript is worth a look: the bridge only supplies the stable `error_code`, and the runtime's own output sink produces the identical hard-stop collapse it produces against the real app — which is the point of implementing the contract instead of forking the runtime.

## Impact

- [ ] Public helper API or behavior
- [ ] Agent skill or instructions
- [ ] Site learning
- [x] Installation or update flow
- [x] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

Nothing existing changes: no `package/ego-browser` file is modified, no skill text changes, and the new workflow is path-scoped to the new package. The host is opt-in (its own bin, never on PATH unless installed). Known limitations are stated in the package README: plainer snapshot than the app, dedicated profile rather than Chrome import, no Spaces UI, loopback CDP port exposure. If the team prefers a different direction (e.g. converging with #202 into one cross-platform host, or waiting for the native app), closing this costs nothing — the contract knowledge is in #227 either way.

## Checklist

- [x] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained above.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [x] A release-note label is selected (`feat`).
