### PR TITLE
fix(ego-browser): scope the click probe fallback to primary-button clicks

### DIFF
--- a/package/ego-browser/src/driver/pointer.test.mjs
+++ b/package/ego-browser/src/driver/pointer.test.mjs
@@ -454,3 +454,95 @@ test("click absorbs CDP timeout when probe fallback succeeds", async () => {
     "probe install and finish were called despite CDP timeout",
   );
 });
+
+for (const button of ["right", "middle"]) {
+  test(`click with the ${button} button installs no untrusted-input probe`, async () => {
+    // The probe's only signal is a trusted "click" listener, which the browser
+    // fires only for the primary button — probing a right/middle click would
+    // always miss and dispatch the fallback's phantom button-0 click.
+    const originalEgo = globalThis.ego;
+    globalThis.ego = { sendCDPMessage: () => {} };
+    let probeEvaluateCount = 0;
+    const restore = setOverrides({
+      cdpOverride(method, params, sessionId) {
+        if (method === "Runtime.evaluate") {
+          // Probe calls contain __egoBrowserInputProbes; element resolution does not
+          if (params.expression?.includes("__egoBrowserInputProbes")) {
+            probeEvaluateCount++;
+            return { result: { value: true } };
+          }
+          if (params.objectGroup === "ego-browser") {
+            return { result: { objectId: "object-1" } };
+          }
+          // Element resolution (buildSelectorCenterJs) — return center point
+          return { result: { value: { x: 100, y: 200 } } };
+        }
+        if (method === "Runtime.callFunctionOn") {
+          return { result: { value: true } };
+        }
+        // Input.dispatchMouseEvent calls proceed normally
+        return {};
+      },
+    });
+    try {
+      await click("#target", { button });
+    } finally {
+      restore();
+      if (originalEgo === undefined) delete globalThis.ego;
+      else globalThis.ego = originalEgo;
+    }
+
+    assert.equal(
+      probeEvaluateCount,
+      0,
+      `no probe Runtime.evaluate calls for a ${button}-button click`,
+    );
+  });
+
+  test(`click with the ${button} button rethrows a CDP dispatch timeout`, async () => {
+    // With no probe there is no fallback to absorb the timeout, so the
+    // dispatch failure must surface instead of resolving as a phantom success.
+    const originalEgo = globalThis.ego;
+    globalThis.ego = { sendCDPMessage: () => {} };
+    let probeEvaluateCount = 0;
+    const restore = setOverrides({
+      cdpOverride(method, params, sessionId) {
+        if (method === "Runtime.evaluate") {
+          // Probe calls contain __egoBrowserInputProbes; element resolution does not
+          if (params.expression?.includes("__egoBrowserInputProbes")) {
+            probeEvaluateCount++;
+            if (probeEvaluateCount === 1) {
+              return { result: { value: true } };
+            }
+            // A probe finish (if one ever ran) would report fallback success,
+            // which before the fix absorbed the timeout
+            return { result: { value: { seen: false, fallback: true } } };
+          }
+          if (params.objectGroup === "ego-browser") {
+            return { result: { objectId: "object-1" } };
+          }
+          // Element resolution (buildSelectorCenterJs) — return center point
+          return { result: { value: { x: 100, y: 200 } } };
+        }
+        if (method === "Runtime.callFunctionOn") {
+          return { result: { value: true } };
+        }
+        if (method === "Input.dispatchMouseEvent") {
+          // Simulate CDP timeout — the browser couldn't dispatch the event
+          throw new Error("CDP request timed out: Input.dispatchMouseEvent");
+        }
+        return {};
+      },
+    });
+    try {
+      await assert.rejects(
+        () => click("#target", { button }),
+        /CDP request timed out: Input\.dispatchMouseEvent/,
+      );
+    } finally {
+      restore();
+      if (originalEgo === undefined) delete globalThis.ego;
+      else globalThis.ego = originalEgo;
+    }
+  });
+}

--- a/package/ego-browser/src/driver/pointer.ts
+++ b/package/ego-browser/src/driver/pointer.ts
@@ -67,7 +67,10 @@ export async function click(target: MouseTarget, options: ClickOptions = {}) {
   const buttons = pressedButtons(button);
   const clickCount = options.clickCount ?? 1;
   maybeHighlight(point, options.label);
-  const probeId = await installClickProbe(point);
+  // The probe's only delivery signal is a trusted "click" listener, and the
+  // browser fires "click" only for the primary button — a probed right/middle
+  // click could never be seen and would always dispatch the button-0 fallback.
+  const probeId = button === "left" ? await installClickProbe(point) : null;
   let dispatchError: unknown = null;
   try {
     await dispatchMouse(point, "mouseMoved", {


### PR DESCRIPTION
## What

`click()` now installs its untrusted-input probe only for primary-button clicks, so right/middle clicks no longer dispatch a phantom synthetic left click or silently absorb CDP dispatch timeouts.

## Why

Fixes #229

`click()` installed the input probe for every button, but the probe's only delivery signal is a trusted `"click"` DOM listener — and per the UI Events spec the browser fires `"click"` only for the primary button (right button fires `"contextmenu"`, middle fires `"auxclick"`). For `click(target, { button: "right" | "middle" })` the probe is therefore structurally never satisfied, so `finishClickProbe` always ran its fallback: synthetic `mousemove`/`mousedown`/`mouseup`/`click` events with hardcoded `button: 0, buttons: 1` — a phantom left click delivered to the element ~50 ms after every successful right/middle click. The fallback also returned `{ fallback: true }`, which marked the click "completed" and swallowed real `Input.dispatchMouseEvent` timeouts for non-primary buttons.

The fix gates probe installation on the button:

```ts
const probeId = button === "left" ? await installClickProbe(point) : null;
```

`finishClickProbe` already returns `false` for a null id, so non-left clicks skip the fallback entirely and a dispatch timeout is rethrown honestly.

## How to verify

```bash
cd package/ego-browser
npm ci
npm test            # build + typecheck + full node --test suite (315 tests)
```

New regression tests in `src/driver/pointer.test.mjs` (all four fail against the pre-fix code):

- `click with the right|middle button installs no untrusted-input probe` — counts probe `Runtime.evaluate` calls (expressions containing `__egoBrowserInputProbes`) and asserts zero; pre-fix there are two, and the finish expression carries the hardcoded `button: 0` fallback.
- `click with the right|middle button rethrows a CDP dispatch timeout` — pre-fix the fallback "success" absorbed the timeout and `click()` resolved.

Repro from the issue (run inside ego lite; before the fix `__log` includes a spurious `"click"`, after it is `["contextmenu"]` only):

```bash
ego-browser nodejs <<'EOF'
await gotoUrl('data:text/html,<button id="t">t</button><script>window.__log=[];const b=document.getElementById("t");b.addEventListener("contextmenu",e=>{e.preventDefault();window.__log.push("contextmenu")});b.addEventListener("click",()=>window.__log.push("click"));</script>')
await click('#t', { button: 'right' })
await wait(0.5)
cliLog(await js('JSON.stringify(window.__log)'))
EOF
```

Independently verified against real Chromium via raw CDP: `Input.dispatchMouseEvent` with `button: "right"` produces trusted `mousedown`/`contextmenu`/`mouseup`/`auxclick` (all `event.button === 2`) and **no** `"click"` event — the probe's only signal cannot fire for non-primary buttons. Playwright, the repo's stated reference model, likewise never emits button-0 events for right/middle clicks.

## Impact

- No helper-surface change (`click()` signature and behavior for the default/left button are untouched), so no `SKILL.md` / `SKILL.zh.md` sync is needed.
- Right/middle clicks lose the untrusted-input fallback **by design**: its only observable signal can never fire for them, so the fallback could only ever misfire. A possible follow-up (deliberately out of scope for this surgical fix) would be extending the probe to listen for `"contextmenu"`/`"auxclick"` and mapping the button in the fallback the way `finishDragProbe` already does.
- Real `Input.dispatchMouseEvent` timeouts on right/middle clicks now surface as errors instead of resolving silently.
