### PR TITLE
fix(ego-browser): harden Playwright routing and replace lease contention with takeover

### DIFF
--- a/package/ego-browser/src/helpers.test.mjs
+++ b/package/ego-browser/src/helpers.test.mjs
@@ -592,6 +592,7 @@ test("egoBrowser lists lightweight TaskSpace information without switching", asy
 
 test("egoBrowser complete and close return structured success results", async () => {
   const calls = [];
+  let closed = false;
   const task = {
     taskId: "inspect-products",
     id: 7,
@@ -602,7 +603,7 @@ test("egoBrowser complete and close return structured success results", async ()
     {
       async listTaskSpaces() {
         calls.push(["listTaskSpaces"]);
-        return { taskSpaces: [task] };
+        return { taskSpaces: closed ? [] : [task] };
       },
       async useTaskSpace(id) {
         calls.push(["useTaskSpace", id]);
@@ -614,6 +615,7 @@ test("egoBrowser complete and close return structured success results", async ()
       },
       async closeTaskSpace() {
         calls.push(["closeTaskSpace"]);
+        closed = true;
         return {};
       },
     },
@@ -635,7 +637,45 @@ test("egoBrowser complete and close return structured success results", async ()
     ["listTaskSpaces"],
     ["useTaskSpace", 7],
     ["closeTaskSpace"],
+    ["listTaskSpaces"],
   ]);
+});
+
+test("egoBrowser close waits until the TaskSpace is no longer listed", async () => {
+  let closed = false;
+  let listingsAfterClose = 0;
+  const task = {
+    taskId: "slow-teardown",
+    id: 9,
+    name: "Slow teardown",
+    ownership: "agent",
+  };
+  await withEgo(
+    {
+      async listTaskSpaces() {
+        if (!closed) return { taskSpaces: [task] };
+        listingsAfterClose += 1;
+        // The native side keeps listing the space for a few polls after the
+        // close command resolves, as the real browser does.
+        return { taskSpaces: listingsAfterClose < 3 ? [task] : [] };
+      },
+      async useTaskSpace() {
+        return {};
+      },
+      async closeTaskSpace() {
+        closed = true;
+        return {};
+      },
+    },
+    async () => {
+      const context = helperContext();
+      assert.deepEqual(await context.egoBrowser.closeTaskSpace(task.id), {
+        done: true,
+      });
+    },
+  );
+
+  assert.equal(listingsAfterClose, 3);
 });
 
 test("egoBrowser terminal actions close the active Playwright connection", async () => {
@@ -1191,19 +1231,22 @@ test("completeTaskSpace waits for async useTaskSpace before completing", async (
 
 test("completeTaskSpace claims user-owned spaces before closing", async () => {
   const calls = [];
+  let closed = false;
   await withEgo(
     {
       async listTaskSpaces() {
         calls.push(["listTaskSpaces"]);
         return {
-          taskSpaces: [
-            {
-              taskId: "checkout-flow",
-              id: 7,
-              name: "checkout-flow",
-              ownership: "user",
-            },
-          ],
+          taskSpaces: closed
+            ? []
+            : [
+                {
+                  taskId: "checkout-flow",
+                  id: 7,
+                  name: "checkout-flow",
+                  ownership: "user",
+                },
+              ],
         };
       },
       async claimTaskSpace(id, name) {
@@ -1216,6 +1259,7 @@ test("completeTaskSpace claims user-owned spaces before closing", async () => {
       },
       async closeTaskSpace() {
         calls.push(["closeTaskSpace"]);
+        closed = true;
         return "7 task space closed.";
       },
     },
@@ -1229,6 +1273,7 @@ test("completeTaskSpace claims user-owned spaces before closing", async () => {
     ["claimTaskSpace", 7, "checkout-flow"],
     ["useTaskSpace", 7],
     ["closeTaskSpace"],
+    ["listTaskSpaces"],
   ]);
 });
 

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -140,8 +140,7 @@ function isAgentOwned(ownership) {
 }
 
 export type TaskSpaceActionResult =
-  | { done: true }
-  | { done: false; skipped: "user-owned" };
+  { done: true } | { done: false; skipped: "user-owned" };
 
 /**
  * Select an existing task space by id/name for the current Node invocation.

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -140,7 +140,8 @@ function isAgentOwned(ownership) {
 }
 
 export type TaskSpaceActionResult =
-  { done: true } | { done: false; skipped: "user-owned" };
+  | { done: true }
+  | { done: false; skipped: "user-owned" };
 
 /**
  * Select an existing task space by id/name for the current Node invocation.
@@ -309,8 +310,25 @@ export async function completeTaskSpace(
       throw new Error("completeTaskSpace requires ego.closeTaskSpace");
     }
     assertNoEgoError(await ego.closeTaskSpace(), "completeTaskSpace");
+    await waitForTaskSpaceRemoval(match.id);
   }
   return { done: true };
+}
+
+// The native close resolves before the space finishes tearing down, so a
+// listing taken right afterwards can still include it (the window widens when
+// a Playwright connection was attached). Wait for the removal so a resolved
+// close means the space is actually gone.
+async function waitForTaskSpaceRemoval(
+  id: string | number,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const spaces = await listTaskSpaces().catch(() => undefined);
+    if (spaces && !spaces.some((space) => space.id === id)) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+  } while (Date.now() < deadline);
 }
 
 /**

--- a/package/ego-browser/src/index.ts
+++ b/package/ego-browser/src/index.ts
@@ -21,7 +21,10 @@ import {
   setNoticeTrailer,
 } from "./output-sink.js";
 import { runMain } from "./run.js";
-import { releaseTaskSpaceLease } from "./taskspace-lease.js";
+import {
+  onTaskSpaceLeaseLost,
+  releaseTaskSpaceLease,
+} from "./taskspace-lease.js";
 import { emitUpdateNotice, type VersionSource } from "./update-notice.js";
 
 type HelperFunction = (...args: unknown[]) => unknown;
@@ -190,6 +193,24 @@ function wrapReady(
   }
   return wrapped;
 }
+// Losing the TaskSpace lease to a newer session is a hard stop: this session
+// must not race the new owner for the same TaskSpace, so disconnect (with a
+// cap, in case the transport is wedged) and exit through the normal process
+// teardown, which releases every remaining native resource. The notice goes
+// through console.log — the only channel bridged back to the agent in SDK
+// mode — and the exit-event flush delivers it even on process.exit(1).
+onTaskSpaceLeaseLost(({ id }) => {
+  console.log(
+    `TaskSpace ${id} was taken over by a newer ego-browser session; stopping ` +
+      "this session. No action is needed: do not kill any process and do not " +
+      "create a replacement TaskSpace.",
+  );
+  setTimeout(() => process.exit(1), 2000);
+  void disconnectPlaywrightTaskSpace()
+    .catch(() => {})
+    .finally(() => process.exit(1));
+});
+
 if (isDirectCli()) {
   const restoreConnector = enablePlaywrightTaskSpaces();
   try {

--- a/package/ego-browser/src/playwright/fake-native-harness.mjs
+++ b/package/ego-browser/src/playwright/fake-native-harness.mjs
@@ -1,0 +1,313 @@
+// Test harness: a scripted fake of the native ego CDP backend, faithful enough
+// for a real playwright-core client to connect through the Ego transport.
+// Every request the transport forwards to "native" is recorded in `log`.
+//
+// Modeled native invariants (matched against the real browser):
+// - the main frame id equals the target id
+// - Target.getTargetInfo returns a browserContextId
+// - Page.navigate commits natively and emits frameNavigated + lifecycle events
+
+export class FakeNativeBrowser {
+  constructor() {
+    this.log = [];
+    this.tabs = new Map(); // targetId -> { url, frames: [{id, loaderId, url, parentId?}] }
+    this.sessions = new Map(); // sessionId -> targetId
+    this.detachedSessions = [];
+    this.closedTargets = [];
+    this.createdUrls = [];
+    this.nextSession = 1;
+    this.nextContext = 100;
+    this.nextLoader = 1;
+    this.nextTab = 1;
+    // Per-target override: report this URL from getFrameTree/evaluate until
+    // cleared, regardless of the tab's real URL (gates navigation commits).
+    this.frameUrlOverride = new Map();
+
+    const fake = this;
+    this.runtime = {
+      async listTabs() {
+        const tabs = [...fake.tabs.entries()].map(([targetId, tab], index) => ({
+          targetId,
+          url: tab.url,
+          active: index === 0,
+        }));
+        return { tabs };
+      },
+      async createTab(url) {
+        fake.createdUrls.push(url);
+        const targetId = `tab-${fake.nextTab++}`;
+        fake.addTab(targetId, url);
+        return { targetId };
+      },
+      sendCDPMessage(payload) {
+        fake.handle(JSON.parse(payload));
+      },
+    };
+  }
+
+  addTab(targetId, url, { childFrameUrl } = {}) {
+    const frames = [
+      { id: targetId, loaderId: `loader-${this.nextLoader++}`, url },
+    ];
+    if (childFrameUrl) {
+      frames.push({
+        id: `${targetId}-child`,
+        parentId: targetId,
+        loaderId: `loader-${this.nextLoader++}`,
+        url: childFrameUrl,
+      });
+    }
+    this.tabs.set(targetId, { url, frames });
+    return targetId;
+  }
+
+  emit(message) {
+    queueMicrotask(() => this.runtime.onCDPMessage?.(JSON.stringify(message)));
+  }
+
+  reply(request, result) {
+    this.emit({
+      id: request.id,
+      result,
+      ...(request.sessionId ? { sessionId: request.sessionId } : {}),
+    });
+  }
+
+  replyError(request, message) {
+    this.emit({
+      id: request.id,
+      error: { code: -32_000, message },
+      ...(request.sessionId ? { sessionId: request.sessionId } : {}),
+    });
+  }
+
+  sessionTab(request) {
+    const targetId = this.sessions.get(request.sessionId);
+    return targetId ? this.tabs.get(targetId) : undefined;
+  }
+
+  handle(request) {
+    this.log.push(request);
+    const method = request.method;
+
+    if (request.sessionId && !this.sessions.has(request.sessionId)) {
+      this.replyError(
+        request,
+        `Session with given id not found: ${request.sessionId}`,
+      );
+      return;
+    }
+
+    if (method === "Target.getTargetInfo") {
+      const targetId = request.params?.targetId;
+      if (targetId === undefined) {
+        return this.reply(request, {
+          targetInfo: {
+            targetId: "fake-browser-target",
+            type: "browser",
+            title: "",
+            url: "",
+            attached: true,
+          },
+        });
+      }
+      const tab = this.tabs.get(targetId);
+      if (!tab) {
+        return this.replyError(
+          request,
+          `No target with given id found: ${targetId}`,
+        );
+      }
+      return this.reply(request, {
+        targetInfo: {
+          targetId,
+          type: "page",
+          title: "",
+          url: tab.url,
+          attached: false,
+          browserContextId: "fake-context",
+        },
+      });
+    }
+    if (method === "Target.attachToTarget") {
+      const targetId = request.params.targetId;
+      if (!this.tabs.has(targetId)) {
+        return this.replyError(
+          request,
+          `No target with given id found: ${targetId}`,
+        );
+      }
+      const sessionId = `sess-${this.nextSession++}`;
+      this.sessions.set(sessionId, targetId);
+      return this.reply(request, { sessionId });
+    }
+    if (method === "Target.detachFromTarget") {
+      const sessionId = request.params.sessionId;
+      this.detachedSessions.push(sessionId);
+      this.sessions.delete(sessionId);
+      return this.reply(request, {});
+    }
+    if (method === "Target.closeTarget") {
+      const targetId = request.params.targetId;
+      this.closedTargets.push(targetId);
+      this.tabs.delete(targetId);
+      for (const [sessionId, sessionTargetId] of this.sessions) {
+        if (sessionTargetId === targetId) this.sessions.delete(sessionId);
+      }
+      return this.reply(request, { success: true });
+    }
+    if (method === "Page.getFrameTree") {
+      const tab = this.sessionTab(request);
+      if (!tab) return this.replyError(request, "No frame tree available");
+      const targetId = this.sessions.get(request.sessionId);
+      const override = this.frameUrlOverride.get(targetId);
+      const [main, ...children] = tab.frames;
+      return this.reply(request, {
+        frameTree: {
+          frame: {
+            id: main.id,
+            loaderId: main.loaderId,
+            url: override ?? main.url,
+            name: "",
+          },
+          childFrames: children.map((frame) => ({
+            frame: {
+              id: frame.id,
+              parentId: frame.parentId,
+              loaderId: frame.loaderId,
+              url: frame.url,
+              name: "",
+            },
+          })),
+        },
+      });
+    }
+    if (method === "Runtime.enable") {
+      const tab = this.sessionTab(request);
+      this.reply(request, {});
+      if (tab) {
+        for (const frame of tab.frames) {
+          this.emit({
+            method: "Runtime.executionContextCreated",
+            params: {
+              context: {
+                id: this.nextContext++,
+                origin: frame.url,
+                name: "",
+                auxData: {
+                  isDefault: true,
+                  type: "default",
+                  frameId: frame.id,
+                },
+              },
+            },
+            sessionId: request.sessionId,
+          });
+        }
+      }
+      return;
+    }
+    if (method === "Page.createIsolatedWorld") {
+      const contextId = this.nextContext++;
+      this.emit({
+        method: "Runtime.executionContextCreated",
+        params: {
+          context: {
+            id: contextId,
+            origin: "",
+            name: request.params.worldName || "isolated",
+            auxData: {
+              isDefault: false,
+              type: "isolated",
+              frameId: request.params.frameId,
+            },
+          },
+        },
+        sessionId: request.sessionId,
+      });
+      return this.reply(request, { executionContextId: contextId });
+    }
+    if (method === "Runtime.evaluate") {
+      const expression = String(request.params?.expression || "");
+      const tab = this.sessionTab(request);
+      const targetId = this.sessions.get(request.sessionId);
+      const override = this.frameUrlOverride.get(targetId);
+      if (expression === "document.readyState") {
+        return this.reply(request, {
+          result: { type: "string", value: "complete" },
+        });
+      }
+      if (expression.includes("performance.getEntriesByType")) {
+        return this.reply(request, {
+          result: {
+            type: "object",
+            value: {
+              url: override ?? tab?.url ?? "about:blank",
+              readyState: "complete",
+              contentType: "text/html",
+              responseStatus: 200,
+            },
+          },
+        });
+      }
+      return this.reply(request, { result: { type: "undefined" } });
+    }
+    if (method === "Runtime.callFunctionOn") {
+      return this.reply(request, {
+        result: { type: "string", value: "fake-result" },
+      });
+    }
+    if (method === "Network.getAllCookies") {
+      return this.reply(request, { cookies: [] });
+    }
+    if (method === "Page.navigate") {
+      const tab = this.sessionTab(request);
+      if (!tab) return this.replyError(request, "Cannot navigate: no tab");
+      const frameId = request.params.frameId || tab.frames[0].id;
+      const frame = tab.frames.find((candidate) => candidate.id === frameId);
+      if (!frame) {
+        return this.replyError(request, `No frame with id ${frameId}`);
+      }
+      const loaderId = `loader-${this.nextLoader++}`;
+      frame.url = request.params.url;
+      frame.loaderId = loaderId;
+      if (frame === tab.frames[0]) tab.url = request.params.url;
+      this.reply(request, { frameId, loaderId });
+      this.emit({
+        method: "Page.frameNavigated",
+        params: {
+          frame: {
+            id: frameId,
+            ...(frame.parentId ? { parentId: frame.parentId } : {}),
+            loaderId,
+            url: frame.url,
+            name: "",
+          },
+        },
+        sessionId: request.sessionId,
+      });
+      for (const name of ["DOMContentLoaded", "load"]) {
+        this.emit({
+          method: "Page.lifecycleEvent",
+          params: { frameId, loaderId, name, timestamp: 1 },
+          sessionId: request.sessionId,
+        });
+      }
+      return;
+    }
+    return this.reply(request, {});
+  }
+}
+
+export async function waitForCondition(
+  condition,
+  timeoutMs = 2_000,
+  intervalMs = 20,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) return true;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  return condition();
+}

--- a/package/ego-browser/src/playwright/fake-native-harness.mjs
+++ b/package/ego-browser/src/playwright/fake-native-harness.mjs
@@ -5,16 +5,22 @@
 // Modeled native invariants (matched against the real browser):
 // - the main frame id equals the target id
 // - Target.getTargetInfo returns a browserContextId
-// - Page.navigate commits natively and emits frameNavigated + lifecycle events
+// - Page.navigate commits natively, responds {frameId, loaderId} (errorText on
+//   failure, isDownload for downloads) and emits frameNavigated + lifecycle
+//   events
 // - the document request id equals the committed loader id
 //
-// `interceptNavigations` models the Fetch-interception race on a created tab:
-// the document request stays in flight, and the first Fetch.enable on a
-// session attached to that tab pauses it (Fetch.requestPaused only — the
-// session attached after the request started, so it never sees the request's
-// Network.requestWillBeSent, matching real Chromium). Only
-// Fetch.continueRequest / fulfillRequest lets the navigation commit — a test
-// using this flag must answer the pause.
+// `interceptNavigations` models Fetch interception of the document request:
+// a session-level Page.navigate on a fetch-enabled session pauses the request
+// (Fetch.requestPaused only — Chromium withholds the request's
+// Network.requestWillBeSent while the pause is unresolved) and holds the
+// Page.navigate response. Only Fetch.continueRequest / fulfillRequest lets
+// the navigation commit — a test using this flag must answer the pause. The
+// commit then emits the withheld Network events (matching the real browser)
+// before the navigate response.
+//
+// `navigationErrors` (url -> errorText) and `downloadUrls` make Page.navigate
+// respond with errorText / isDownload without navigating the frame.
 
 export class FakeNativeBrowser {
   constructor({ interceptNavigations = false } = {}) {
@@ -25,15 +31,19 @@ export class FakeNativeBrowser {
     this.closedTargets = [];
     this.createdUrls = [];
     this.continuedRequests = [];
+    this.fetchEnabledSessions = new Set();
+    this.navigationErrors = new Map(); // url -> errorText
+    this.downloadUrls = new Set();
     this.nextSession = 1;
     this.nextContext = 100;
     this.nextLoader = 1;
     this.nextTab = 1;
     this.nextInterception = 1;
     this.interceptNavigations = interceptNavigations;
-    this.pendingNavigations = new Map(); // targetId -> { url, requestId, interceptionId, paused }
-    // Per-target override: report this URL from getFrameTree/evaluate until
-    // cleared, regardless of the tab's real URL (gates navigation commits).
+    this.pendingNavigations = new Map(); // targetId -> { url, requestId, interceptionId, navigateRequest, frame, frameId }
+    // Per-target override: report this URL (and a held loaderId) from
+    // getFrameTree/evaluate until cleared, regardless of the tab's real state
+    // (gates navigation commit confirmation).
     this.frameUrlOverride = new Map();
 
     const fake = this;
@@ -50,15 +60,6 @@ export class FakeNativeBrowser {
         fake.createdUrls.push(url);
         const targetId = `tab-${fake.nextTab++}`;
         fake.addTab(targetId, url);
-        if (fake.interceptNavigations) {
-          fake.frameUrlOverride.set(targetId, "about:blank");
-          fake.pendingNavigations.set(targetId, {
-            url,
-            requestId: fake.tabs.get(targetId).frames[0].loaderId,
-            interceptionId: `int-${fake.nextInterception++}`,
-            paused: false,
-          });
-        }
         return { targetId };
       },
       sendCDPMessage(payload) {
@@ -188,7 +189,10 @@ export class FakeNativeBrowser {
         frameTree: {
           frame: {
             id: main.id,
-            loaderId: main.loaderId,
+            // While the override gates a commit, the committed loaderId must
+            // stay hidden too, or a loaderId-based commit check bypasses it.
+            loaderId:
+              override === undefined ? main.loaderId : `${main.loaderId}-held`,
             url: override ?? main.url,
             name: "",
           },
@@ -283,35 +287,8 @@ export class FakeNativeBrowser {
       return this.reply(request, { cookies: [] });
     }
     if (method === "Fetch.enable") {
-      this.reply(request, {});
-      const targetId = this.sessions.get(request.sessionId);
-      const pending = targetId
-        ? this.pendingNavigations.get(targetId)
-        : undefined;
-      if (pending && !pending.paused) {
-        pending.paused = true;
-        // No Network.requestWillBeSent here: the session attached after the
-        // document request started, and real Chromium never re-sends it to a
-        // late-attached session. Only the pause reaches this session.
-        this.emit({
-          method: "Fetch.requestPaused",
-          params: {
-            requestId: pending.interceptionId,
-            request: {
-              url: pending.url,
-              method: "GET",
-              headers: {},
-              initialPriority: "VeryHigh",
-              referrerPolicy: "strict-origin-when-cross-origin",
-            },
-            frameId: targetId,
-            resourceType: "Document",
-            networkId: pending.requestId,
-          },
-          sessionId: request.sessionId,
-        });
-      }
-      return;
+      this.fetchEnabledSessions.add(request.sessionId);
+      return this.reply(request, {});
     }
     if (
       method === "Fetch.continueRequest" ||
@@ -327,8 +304,26 @@ export class FakeNativeBrowser {
       const [targetId, pending] = entry;
       this.continuedRequests.push(interceptionId);
       this.pendingNavigations.delete(targetId);
-      this.frameUrlOverride.delete(targetId);
       this.reply(request, {});
+      // The pause is resolved: the withheld real Network events for the
+      // document request now reach the session (matching real Chromium),
+      // followed by the commit and the held Page.navigate response.
+      this.emit({
+        method: "Network.requestWillBeSent",
+        params: {
+          requestId: pending.requestId,
+          loaderId: pending.requestId,
+          documentURL: pending.url,
+          request: { url: pending.url, method: "GET", headers: {} },
+          timestamp: 2,
+          wallTime: 2,
+          initiator: { type: "other" },
+          type: "Document",
+          frameId: targetId,
+          hasUserGesture: false,
+        },
+        sessionId: request.sessionId,
+      });
       this.emit({
         method: "Network.responseReceived",
         params: {
@@ -361,6 +356,13 @@ export class FakeNativeBrowser {
         },
         sessionId: request.sessionId,
       });
+      this.commitNavigation(
+        pending.navigateRequest,
+        pending.frame,
+        pending.frameId,
+        pending.url,
+        pending.requestId,
+      );
       return;
     }
     if (method === "Page.navigate") {
@@ -371,34 +373,83 @@ export class FakeNativeBrowser {
       if (!frame) {
         return this.replyError(request, `No frame with id ${frameId}`);
       }
+      const url = request.params.url;
+      const errorText = this.navigationErrors.get(url);
+      if (errorText !== undefined) {
+        return this.reply(request, { frameId, errorText });
+      }
       const loaderId = `loader-${this.nextLoader++}`;
-      frame.url = request.params.url;
-      frame.loaderId = loaderId;
-      if (frame === tab.frames[0]) tab.url = request.params.url;
-      this.reply(request, { frameId, loaderId });
-      this.emit({
-        method: "Page.frameNavigated",
-        params: {
-          frame: {
-            id: frameId,
-            ...(frame.parentId ? { parentId: frame.parentId } : {}),
-            loaderId,
-            url: frame.url,
-            name: "",
-          },
-        },
-        sessionId: request.sessionId,
-      });
-      for (const name of ["DOMContentLoaded", "load"]) {
+      if (this.downloadUrls.has(url)) {
+        // A download never navigates the frame; only the response reports it.
+        return this.reply(request, { frameId, loaderId, isDownload: true });
+      }
+      const targetId = this.sessions.get(request.sessionId);
+      if (
+        this.interceptNavigations &&
+        frame === tab.frames[0] &&
+        this.fetchEnabledSessions.has(request.sessionId)
+      ) {
+        // The document request pauses and the navigate response is held until
+        // Fetch.continueRequest / fulfillRequest resolves the pause.
+        this.pendingNavigations.set(targetId, {
+          url,
+          requestId: loaderId,
+          interceptionId: `int-${this.nextInterception++}`,
+          navigateRequest: request,
+          frame,
+          frameId,
+        });
         this.emit({
-          method: "Page.lifecycleEvent",
-          params: { frameId, loaderId, name, timestamp: 1 },
+          method: "Fetch.requestPaused",
+          params: {
+            requestId: this.pendingNavigations.get(targetId).interceptionId,
+            request: {
+              url,
+              method: "GET",
+              headers: {},
+              initialPriority: "VeryHigh",
+              referrerPolicy: "strict-origin-when-cross-origin",
+            },
+            frameId: targetId,
+            resourceType: "Document",
+            networkId: loaderId,
+          },
           sessionId: request.sessionId,
         });
+        return;
       }
-      return;
+      return this.commitNavigation(request, frame, frameId, url, loaderId);
     }
     return this.reply(request, {});
+  }
+
+  commitNavigation(request, frame, frameId, url, loaderId) {
+    const targetId = this.sessions.get(request.sessionId);
+    const tab = targetId ? this.tabs.get(targetId) : undefined;
+    frame.url = url;
+    frame.loaderId = loaderId;
+    if (tab && frame === tab.frames[0]) tab.url = url;
+    this.reply(request, { frameId, loaderId });
+    this.emit({
+      method: "Page.frameNavigated",
+      params: {
+        frame: {
+          id: frameId,
+          ...(frame.parentId ? { parentId: frame.parentId } : {}),
+          loaderId,
+          url: frame.url,
+          name: "",
+        },
+      },
+      sessionId: request.sessionId,
+    });
+    for (const name of ["DOMContentLoaded", "load"]) {
+      this.emit({
+        method: "Page.lifecycleEvent",
+        params: { frameId, loaderId, name, timestamp: 1 },
+        sessionId: request.sessionId,
+      });
+    }
   }
 }
 

--- a/package/ego-browser/src/playwright/fake-native-harness.mjs
+++ b/package/ego-browser/src/playwright/fake-native-harness.mjs
@@ -6,19 +6,32 @@
 // - the main frame id equals the target id
 // - Target.getTargetInfo returns a browserContextId
 // - Page.navigate commits natively and emits frameNavigated + lifecycle events
+// - the document request id equals the committed loader id
+//
+// `interceptNavigations` models the Fetch-interception race on a created tab:
+// the document request stays in flight, and the first Fetch.enable on a
+// session attached to that tab pauses it (Fetch.requestPaused only — the
+// session attached after the request started, so it never sees the request's
+// Network.requestWillBeSent, matching real Chromium). Only
+// Fetch.continueRequest / fulfillRequest lets the navigation commit — a test
+// using this flag must answer the pause.
 
 export class FakeNativeBrowser {
-  constructor() {
+  constructor({ interceptNavigations = false } = {}) {
     this.log = [];
     this.tabs = new Map(); // targetId -> { url, frames: [{id, loaderId, url, parentId?}] }
     this.sessions = new Map(); // sessionId -> targetId
     this.detachedSessions = [];
     this.closedTargets = [];
     this.createdUrls = [];
+    this.continuedRequests = [];
     this.nextSession = 1;
     this.nextContext = 100;
     this.nextLoader = 1;
     this.nextTab = 1;
+    this.nextInterception = 1;
+    this.interceptNavigations = interceptNavigations;
+    this.pendingNavigations = new Map(); // targetId -> { url, requestId, interceptionId, paused }
     // Per-target override: report this URL from getFrameTree/evaluate until
     // cleared, regardless of the tab's real URL (gates navigation commits).
     this.frameUrlOverride = new Map();
@@ -37,6 +50,15 @@ export class FakeNativeBrowser {
         fake.createdUrls.push(url);
         const targetId = `tab-${fake.nextTab++}`;
         fake.addTab(targetId, url);
+        if (fake.interceptNavigations) {
+          fake.frameUrlOverride.set(targetId, "about:blank");
+          fake.pendingNavigations.set(targetId, {
+            url,
+            requestId: fake.tabs.get(targetId).frames[0].loaderId,
+            interceptionId: `int-${fake.nextInterception++}`,
+            paused: false,
+          });
+        }
         return { targetId };
       },
       sendCDPMessage(payload) {
@@ -259,6 +281,87 @@ export class FakeNativeBrowser {
     }
     if (method === "Network.getAllCookies") {
       return this.reply(request, { cookies: [] });
+    }
+    if (method === "Fetch.enable") {
+      this.reply(request, {});
+      const targetId = this.sessions.get(request.sessionId);
+      const pending = targetId
+        ? this.pendingNavigations.get(targetId)
+        : undefined;
+      if (pending && !pending.paused) {
+        pending.paused = true;
+        // No Network.requestWillBeSent here: the session attached after the
+        // document request started, and real Chromium never re-sends it to a
+        // late-attached session. Only the pause reaches this session.
+        this.emit({
+          method: "Fetch.requestPaused",
+          params: {
+            requestId: pending.interceptionId,
+            request: {
+              url: pending.url,
+              method: "GET",
+              headers: {},
+              initialPriority: "VeryHigh",
+              referrerPolicy: "strict-origin-when-cross-origin",
+            },
+            frameId: targetId,
+            resourceType: "Document",
+            networkId: pending.requestId,
+          },
+          sessionId: request.sessionId,
+        });
+      }
+      return;
+    }
+    if (
+      method === "Fetch.continueRequest" ||
+      method === "Fetch.fulfillRequest"
+    ) {
+      const interceptionId = request.params?.requestId;
+      const entry = [...this.pendingNavigations.entries()].find(
+        ([, pending]) => pending.interceptionId === interceptionId,
+      );
+      if (!entry) {
+        return this.replyError(request, `Invalid InterceptionId.`);
+      }
+      const [targetId, pending] = entry;
+      this.continuedRequests.push(interceptionId);
+      this.pendingNavigations.delete(targetId);
+      this.frameUrlOverride.delete(targetId);
+      this.reply(request, {});
+      this.emit({
+        method: "Network.responseReceived",
+        params: {
+          requestId: pending.requestId,
+          loaderId: pending.requestId,
+          timestamp: 2,
+          type: "Document",
+          response: {
+            url: pending.url,
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            mimeType: "text/html",
+            connectionReused: false,
+            connectionId: 0,
+            encodedDataLength: 0,
+            securityState: "secure",
+          },
+          hasExtraInfo: false,
+          frameId: targetId,
+        },
+        sessionId: request.sessionId,
+      });
+      this.emit({
+        method: "Network.loadingFinished",
+        params: {
+          requestId: pending.requestId,
+          timestamp: 2,
+          encodedDataLength: 0,
+        },
+        sessionId: request.sessionId,
+      });
+      return;
     }
     if (method === "Page.navigate") {
       const tab = this.sessionTab(request);

--- a/package/ego-browser/src/playwright/playwright-client.test.mjs
+++ b/package/ego-browser/src/playwright/playwright-client.test.mjs
@@ -16,9 +16,10 @@ const playwrightTransport =
 async function connectFakeTaskSpace({
   startUrl = "https://start.test/",
   childFrameUrl,
+  harnessOptions,
   transportOptions = {},
 } = {}) {
-  const fake = new FakeNativeBrowser();
+  const fake = new FakeNativeBrowser(harnessOptions);
   fake.addTab("tab-start", startUrl, { childFrameUrl });
   const connector = playwrightTaskSpace.createPlaywrightTaskSpaceConnector({
     runtime: () => fake.runtime,
@@ -100,6 +101,39 @@ test("request interception and viewport emulation survive a TaskSpace navigation
     assert.ok(
       onReplacement("Emulation.setDeviceMetricsOverride") >= 1,
       "the viewport override is replayed onto the replacement target",
+    );
+  } finally {
+    await session.close().catch(() => {});
+  }
+});
+
+test("page.route intercepts the document request of a TaskSpace navigation", async () => {
+  const { fake, session } = await connectFakeTaskSpace({
+    harnessOptions: { interceptNavigations: true },
+    transportOptions: { navigationCommitTimeoutMs: 2_000 },
+  });
+  try {
+    const { page } = session;
+    const routedUrls = [];
+    await page.route("**/*", (route) => {
+      routedUrls.push(route.request().url());
+      return route.continue();
+    });
+
+    await page.goto("https://start.test/second", {
+      waitUntil: "commit",
+      timeout: 8_000,
+    });
+
+    assert.ok(
+      routedUrls.includes("https://start.test/second"),
+      `the route handler must see the document request, saw: ${JSON.stringify(routedUrls)}`,
+    );
+    assert.equal(page.url(), "https://start.test/second");
+    assert.equal(
+      fake.continuedRequests.length,
+      1,
+      "the paused document request was continued through the route handler",
     );
   } finally {
     await session.close().catch(() => {});

--- a/package/ego-browser/src/playwright/playwright-client.test.mjs
+++ b/package/ego-browser/src/playwright/playwright-client.test.mjs
@@ -1,0 +1,244 @@
+// Integration tests driving a real playwright-core client through the Ego CDP
+// transport against the scripted fake native backend. These lock in the
+// Playwright-side behavior assumptions the transport must satisfy.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { chromium } from "#playwright-runtime";
+
+import { FakeNativeBrowser, waitForCondition } from "./fake-native-harness.mjs";
+
+const playwrightTaskSpace =
+  await import("../../dist/src/playwright/taskspace.js");
+const playwrightTransport =
+  await import("../../dist/src/playwright/transport.js");
+
+async function connectFakeTaskSpace({
+  startUrl = "https://start.test/",
+  childFrameUrl,
+  transportOptions = {},
+} = {}) {
+  const fake = new FakeNativeBrowser();
+  fake.addTab("tab-start", startUrl, { childFrameUrl });
+  const connector = playwrightTaskSpace.createPlaywrightTaskSpaceConnector({
+    runtime: () => fake.runtime,
+    transport: (runtime) =>
+      playwrightTransport.createEgoPlaywrightTransport(
+        runtime,
+        transportOptions,
+      ),
+    connectOverCDP: (connectToken) => chromium.connectOverCDP(connectToken),
+  });
+  const session = await connector({ id: 1 });
+  await waitForCondition(() => session.page.url() === startUrl, 3_000);
+  return { fake, session };
+}
+
+test("a subframe goto navigates natively instead of replacing the TaskSpace tab", async () => {
+  const { fake, session } = await connectFakeTaskSpace({
+    childFrameUrl: "https://child.test/inner",
+  });
+  try {
+    const { page } = session;
+    await waitForCondition(() => page.frames().length === 2, 3_000);
+    const child = page
+      .frames()
+      .find((frame) => frame.url() === "https://child.test/inner");
+    assert.ok(child, "child frame is visible to Playwright");
+
+    await child.goto("https://child.test/next", { timeout: 5_000 });
+
+    assert.deepEqual(
+      fake.createdUrls,
+      [],
+      "subframe navigation must not create a replacement tab",
+    );
+    assert.deepEqual(
+      [...fake.tabs.keys()],
+      ["tab-start"],
+      "the TaskSpace tab set is unchanged",
+    );
+    const nativeNavigate = fake.log.filter(
+      (request) => request.method === "Page.navigate",
+    );
+    assert.equal(nativeNavigate.length, 1, "navigation reached native CDP");
+    assert.equal(nativeNavigate[0].params.frameId, "tab-start-child");
+    assert.equal(child.url(), "https://child.test/next");
+    assert.equal(
+      page.url(),
+      "https://start.test/",
+      "the main frame stays on its document",
+    );
+  } finally {
+    await session.close().catch(() => {});
+  }
+});
+
+test("request interception and viewport emulation survive a TaskSpace navigation", async () => {
+  const { fake, session } = await connectFakeTaskSpace({});
+  try {
+    const { page } = session;
+    await page.route("**/*", (route) => route.continue());
+    await page.setViewportSize({ width: 555, height: 444 });
+
+    await page.goto("https://start.test/second", {
+      waitUntil: "load",
+      timeout: 10_000,
+    });
+    await waitForCondition(() => fake.sessions.size === 1, 2_000);
+
+    const replacementSession = [...fake.sessions.keys()].at(-1);
+    const onReplacement = (method) =>
+      fake.log.filter(
+        (request) =>
+          request.sessionId === replacementSession && request.method === method,
+      ).length;
+    assert.ok(
+      onReplacement("Fetch.enable") >= 1,
+      "Fetch.enable is replayed so page.route keeps intercepting",
+    );
+    assert.ok(
+      onReplacement("Emulation.setDeviceMetricsOverride") >= 1,
+      "the viewport override is replayed onto the replacement target",
+    );
+  } finally {
+    await session.close().catch(() => {});
+  }
+});
+
+test("a failed navigation cleans up the replacement tab and leaves the page usable", async () => {
+  const { fake, session } = await connectFakeTaskSpace({
+    transportOptions: { navigationCommitTimeoutMs: 500 },
+  });
+  try {
+    const { page } = session;
+    const originalCreateTab = fake.runtime.createTab;
+    let replacementTargetId;
+    fake.runtime.createTab = async (url) => {
+      const created = await originalCreateTab(url);
+      replacementTargetId = created.targetId;
+      fake.frameUrlOverride.set(created.targetId, "about:blank");
+      return created;
+    };
+
+    await assert.rejects(
+      page.goto("https://start.test/second", {
+        waitUntil: "load",
+        timeout: 6_000,
+      }),
+      /did not commit/,
+    );
+    await waitForCondition(
+      () => fake.closedTargets.includes(replacementTargetId),
+      2_000,
+    );
+    assert.ok(
+      fake.closedTargets.includes(replacementTargetId),
+      "the replacement tab is closed after the navigation fails",
+    );
+    assert.deepEqual(
+      [...fake.tabs.keys()],
+      ["tab-start"],
+      "only the original tab stays open",
+    );
+
+    const evaluated = await Promise.race([
+      page.evaluate(() => "still-alive"),
+      new Promise((_resolve, reject) =>
+        setTimeout(() => reject(new Error("evaluate hung")), 4_000),
+      ),
+    ]);
+    assert.equal(
+      evaluated,
+      "fake-result",
+      "the page still evaluates after the failed navigation",
+    );
+  } finally {
+    await session.close().catch(() => {});
+  }
+});
+
+test("concurrent navigations settle on a single native tab", async () => {
+  const { fake, session } = await connectFakeTaskSpace({});
+  try {
+    const { page } = session;
+    const originalCreateTab = fake.runtime.createTab;
+    fake.runtime.createTab = async (url) => {
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      return originalCreateTab(url);
+    };
+
+    await Promise.allSettled([
+      page.goto("https://start.test/nav-a", {
+        waitUntil: "commit",
+        timeout: 8_000,
+      }),
+      page.goto("https://start.test/nav-b", {
+        waitUntil: "commit",
+        timeout: 8_000,
+      }),
+    ]);
+    await waitForCondition(() => fake.tabs.size === 1, 3_000);
+
+    assert.equal(
+      fake.tabs.size,
+      1,
+      "exactly one native tab remains after concurrent navigations",
+    );
+    assert.equal(
+      fake.sessions.size,
+      1,
+      "no orphaned native sessions are left attached",
+    );
+  } finally {
+    await session.close().catch(() => {});
+  }
+});
+
+test("an init script issued during navigation reaches the replacement target", async () => {
+  const { fake, session } = await connectFakeTaskSpace({});
+  try {
+    const { page } = session;
+    const originalCreateTab = fake.runtime.createTab;
+    let replacementTargetId;
+    fake.runtime.createTab = async (url) => {
+      const created = await originalCreateTab(url);
+      replacementTargetId = created.targetId;
+      fake.frameUrlOverride.set(created.targetId, "about:blank");
+      return created;
+    };
+
+    const gotoPromise = page.goto("https://start.test/second", {
+      waitUntil: "commit",
+      timeout: 10_000,
+    });
+    await waitForCondition(() => replacementTargetId !== undefined, 5_000);
+
+    const initScriptPromise = page.addInitScript(
+      "window.__probe_marker__ = 42;",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    fake.frameUrlOverride.delete(replacementTargetId);
+
+    await gotoPromise;
+    await initScriptPromise;
+    await waitForCondition(() => fake.sessions.size === 1, 2_000);
+
+    const replacementSession = [...fake.sessions.entries()].find(
+      ([, targetId]) => targetId === replacementTargetId,
+    )?.[0];
+    const markerOn = (sessionId) =>
+      fake.log.filter(
+        (request) =>
+          request.sessionId === sessionId &&
+          request.method === "Page.addScriptToEvaluateOnNewDocument" &&
+          String(request.params?.source || "").includes("__probe_marker__"),
+      ).length;
+    assert.ok(
+      markerOn(replacementSession) >= 1,
+      "the init script reaches the replacement target",
+    );
+  } finally {
+    await session.close().catch(() => {});
+  }
+});

--- a/package/ego-browser/src/playwright/routing.test.mjs
+++ b/package/ego-browser/src/playwright/routing.test.mjs
@@ -3282,6 +3282,549 @@ test("a held command whose replay throws synchronously still gets an error reply
   await transport.closeAndWait();
 });
 
+test("commands during a pending navigation are answered from the old session", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+    harnessOptions: { interceptNavigations: true },
+    transportOptions: { navigationCommitTimeoutMs: 5_000 },
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  transport.send({
+    id: 90,
+    method: "Fetch.enable",
+    params: { patterns: [{ urlPattern: "*", requestStage: "Request" }] },
+    sessionId: mainSession,
+  });
+  await waitForMessage(received, (message) => message.id === 90);
+
+  transport.send({
+    id: 91,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/next" },
+    sessionId: mainSession,
+  });
+  const paused = await waitForMessage(
+    received,
+    (message) => message.method === "Fetch.requestPaused",
+  );
+  assert.ok(paused, "the gated document request holds the navigation open");
+
+  transport.send({
+    id: 92,
+    method: "Runtime.evaluate",
+    params: { expression: "1 + 1", returnByValue: true },
+    sessionId: mainSession,
+  });
+  const evaluated = await waitForMessage(
+    received,
+    (message) => message.id === 92,
+    1_000,
+  );
+  assert.ok(
+    evaluated,
+    "the command is answered while the navigation is still pending",
+  );
+  assert.equal(evaluated.error, undefined);
+  assert.equal(
+    received.some((message) => message.id === 91),
+    false,
+    "the navigation has not committed when the command is answered",
+  );
+  const evaluateRequest = fake.log.find(
+    (request) =>
+      request.method === "Runtime.evaluate" &&
+      request.params?.expression === "1 + 1",
+  );
+  assert.equal(
+    evaluateRequest?.sessionId,
+    mainSession,
+    "the command is served by the old native session",
+  );
+
+  transport.send({
+    id: 93,
+    method: "Fetch.continueRequest",
+    params: { requestId: paused.params.requestId },
+    sessionId: mainSession,
+  });
+  const navigated = await waitForMessage(
+    received,
+    (message) => message.id === 91,
+    5_000,
+  );
+  assert.ok(navigated, "the navigation settles once the gate opens");
+  assert.equal(
+    navigated.error,
+    undefined,
+    `the navigation must commit, got: ${JSON.stringify(navigated?.error)}`,
+  );
+
+  const replacementSession = [...fake.sessions.keys()].at(-1);
+  assert.notEqual(replacementSession, mainSession);
+  transport.send({
+    id: 94,
+    method: "Runtime.evaluate",
+    params: { expression: "2 + 2", returnByValue: true },
+    sessionId: mainSession,
+  });
+  await waitForMessage(received, (message) => message.id === 94);
+  const postSwapRequest = fake.log.find(
+    (request) =>
+      request.method === "Runtime.evaluate" &&
+      request.params?.expression === "2 + 2",
+  );
+  assert.equal(
+    postSwapRequest?.sessionId,
+    replacementSession,
+    "post-swap commands go to the replacement session",
+  );
+  await transport.closeAndWait();
+});
+
+test("replayable commands during a pending navigation are held and replayed to the replacement session", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+    harnessOptions: { interceptNavigations: true },
+    transportOptions: { navigationCommitTimeoutMs: 5_000 },
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  transport.send({
+    id: 95,
+    method: "Fetch.enable",
+    params: { patterns: [{ urlPattern: "*", requestStage: "Request" }] },
+    sessionId: mainSession,
+  });
+  await waitForMessage(received, (message) => message.id === 95);
+
+  transport.send({
+    id: 96,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/next" },
+    sessionId: mainSession,
+  });
+  const paused = await waitForMessage(
+    received,
+    (message) => message.method === "Fetch.requestPaused",
+  );
+  assert.ok(paused, "the gated document request holds the navigation open");
+
+  transport.send({
+    id: 97,
+    method: "Network.setExtraHTTPHeaders",
+    params: { headers: { "x-mid-transition": "1" } },
+    sessionId: mainSession,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  assert.equal(
+    received.find((message) => message.id === 97),
+    undefined,
+    "the replayable command is held while the transition is pending",
+  );
+  assert.equal(
+    fake.log.some(
+      (request) => request.method === "Network.setExtraHTTPHeaders",
+    ),
+    false,
+    "the held command reaches no native session before the swap",
+  );
+
+  transport.send({
+    id: 98,
+    method: "Fetch.continueRequest",
+    params: { requestId: paused.params.requestId },
+    sessionId: mainSession,
+  });
+  await waitForMessage(received, (message) => message.id === 96, 5_000);
+  const reply = await waitForMessage(received, (message) => message.id === 97);
+  assert.ok(reply, "the held command completes after the swap");
+  assert.equal(reply.error, undefined);
+  const replacementSession = [...fake.sessions.keys()].at(-1);
+  assert.notEqual(replacementSession, mainSession);
+  const delivered = fake.log.find(
+    (request) => request.method === "Network.setExtraHTTPHeaders",
+  );
+  assert.equal(
+    delivered?.sessionId,
+    replacementSession,
+    "the replayed command reaches the replacement session",
+  );
+  await transport.closeAndWait();
+});
+
+test("commands during a same-target navigation replacement are held until the swap", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+    transportOptions: { navigationCommitTimeoutMs: 5_000 },
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  // Model the native tab-reuse branch: createTab hands back the existing
+  // target (navigated to the blank staging page) instead of a fresh one.
+  fake.runtime.createTab = async (url) => {
+    fake.createdUrls.push(url);
+    const tab = fake.tabs.get("tab-main");
+    tab.url = url;
+    tab.frames[0].url = url;
+    return { targetId: "tab-main" };
+  };
+  // Gate the commit: the frame keeps reporting the blank staging URL until
+  // the override is cleared, so the transition stays pending.
+  fake.frameUrlOverride.set("tab-main", "about:blank");
+
+  transport.send({
+    id: 100,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/next" },
+    sessionId: mainSession,
+  });
+  const detachDeadline = Date.now() + 2_000;
+  while (
+    !fake.detachedSessions.includes(mainSession) &&
+    Date.now() < detachDeadline
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.ok(
+    fake.detachedSessions.includes(mainSession),
+    "the reused tab's old session is detached for the replacement attach",
+  );
+
+  transport.send({
+    id: 101,
+    method: "Runtime.evaluate",
+    params: { expression: "1 + 1", returnByValue: true },
+    sessionId: mainSession,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  assert.equal(
+    received.find((message) => message.id === 101),
+    undefined,
+    "the command is held: the old session is already detached",
+  );
+  assert.equal(
+    fake.log.some(
+      (request) =>
+        request.method === "Runtime.evaluate" &&
+        request.params?.expression === "1 + 1",
+    ),
+    false,
+    "the held command is never sent to the detached session",
+  );
+
+  fake.frameUrlOverride.delete("tab-main");
+  const navigated = await waitForMessage(
+    received,
+    (message) => message.id === 100,
+    5_000,
+  );
+  assert.ok(navigated, "the navigation settles once the commit gate opens");
+  assert.equal(
+    navigated.error,
+    undefined,
+    `the navigation must commit, got: ${JSON.stringify(navigated?.error)}`,
+  );
+  const evaluated = await waitForMessage(
+    received,
+    (message) => message.id === 101,
+  );
+  assert.ok(evaluated, "the held command completes after the swap");
+  assert.equal(evaluated.error, undefined);
+  const replacementSession = [...fake.sessions.keys()].at(-1);
+  assert.notEqual(replacementSession, mainSession);
+  const delivered = fake.log.find(
+    (request) =>
+      request.method === "Runtime.evaluate" &&
+      request.params?.expression === "1 + 1",
+  );
+  assert.equal(
+    delivered?.sessionId,
+    replacementSession,
+    "the held command is answered by the replacement session",
+  );
+  await transport.closeAndWait();
+});
+
+test("a new client navigation supersedes the pending one instead of queuing behind it", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+    harnessOptions: { interceptNavigations: true },
+    transportOptions: { navigationCommitTimeoutMs: 10_000 },
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  transport.send({
+    id: 110,
+    method: "Fetch.enable",
+    params: { patterns: [{ urlPattern: "*", requestStage: "Request" }] },
+    sessionId: mainSession,
+  });
+  await waitForMessage(received, (message) => message.id === 110);
+
+  // Navigation A is gated: its paused document request is never continued,
+  // modeling a hung server that would otherwise burn the full commit budget.
+  transport.send({
+    id: 111,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/hung" },
+    sessionId: mainSession,
+  });
+  const pausedA = await waitForMessage(
+    received,
+    (message) => message.method === "Fetch.requestPaused",
+  );
+  assert.ok(pausedA, "navigation A is gated on its paused document request");
+
+  const startedAt = Date.now();
+  transport.send({
+    id: 112,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/recovery" },
+    sessionId: mainSession,
+  });
+  const superseded = await waitForMessage(
+    received,
+    (message) => message.id === 111,
+  );
+  assert.match(
+    superseded.error?.message || "",
+    /superseded by a newer navigation/,
+    "the aborted navigation's client message must not dangle",
+  );
+
+  const pausedB = await waitForMessage(
+    received,
+    (message) =>
+      message.method === "Fetch.requestPaused" &&
+      message.params.requestId !== pausedA.params.requestId,
+  );
+  assert.ok(pausedB, "navigation B starts its own document request");
+  transport.send({
+    id: 113,
+    method: "Fetch.continueRequest",
+    params: { requestId: pausedB.params.requestId },
+    sessionId: mainSession,
+  });
+  const navigated = await waitForMessage(
+    received,
+    (message) => message.id === 112,
+    5_000,
+  );
+  assert.ok(navigated, "navigation B settles");
+  assert.equal(
+    navigated.error,
+    undefined,
+    `navigation B must commit, got: ${JSON.stringify(navigated?.error)}`,
+  );
+  assert.ok(
+    Date.now() - startedAt < 5_000,
+    "navigation B must commit far below the pending navigation's commit budget",
+  );
+  assert.ok(
+    fake.closedTargets.includes("tab-1"),
+    "the superseded navigation's replacement tab is closed",
+  );
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  assert.equal(
+    received.filter((message) => message.id === 111).length,
+    1,
+    "the superseded navigation gets exactly one response",
+  );
+  await transport.closeAndWait();
+});
+
+test("rapid successive navigations supersede each other and the final one wins", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+    harnessOptions: { interceptNavigations: true },
+    transportOptions: { navigationCommitTimeoutMs: 10_000 },
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  transport.send({
+    id: 115,
+    method: "Fetch.enable",
+    params: { patterns: [{ urlPattern: "*", requestStage: "Request" }] },
+    sessionId: mainSession,
+  });
+  await waitForMessage(received, (message) => message.id === 115);
+
+  transport.send({
+    id: 116,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/a" },
+    sessionId: mainSession,
+  });
+  await waitForMessage(
+    received,
+    (message) => message.method === "Fetch.requestPaused",
+  );
+  // B supersedes the in-flight A; C supersedes the still-queued B.
+  transport.send({
+    id: 117,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/b" },
+    sessionId: mainSession,
+  });
+  transport.send({
+    id: 118,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/c" },
+    sessionId: mainSession,
+  });
+
+  const abortedA = await waitForMessage(
+    received,
+    (message) => message.id === 116,
+  );
+  assert.match(abortedA.error?.message || "", /superseded by a newer/);
+  const abortedB = await waitForMessage(
+    received,
+    (message) => message.id === 117,
+  );
+  assert.match(abortedB.error?.message || "", /superseded by a newer/);
+
+  const pausedC = await waitForMessage(
+    received,
+    (message) =>
+      message.method === "Fetch.requestPaused" &&
+      message.params.request?.url === "https://main.test/c",
+  );
+  assert.ok(pausedC, "the final navigation starts its own document request");
+  transport.send({
+    id: 119,
+    method: "Fetch.continueRequest",
+    params: { requestId: pausedC.params.requestId },
+    sessionId: mainSession,
+  });
+  const navigated = await waitForMessage(
+    received,
+    (message) => message.id === 118,
+    5_000,
+  );
+  assert.ok(navigated, "the final navigation settles");
+  assert.equal(
+    navigated.error,
+    undefined,
+    `the final navigation must commit, got: ${JSON.stringify(navigated?.error)}`,
+  );
+
+  // A's replacement was the first tab the fake minted; B never started, so it
+  // created none; C's replacement (the second minted tab) is the only tab
+  // left after the swap closed the original.
+  assert.ok(
+    fake.closedTargets.includes("tab-1"),
+    "the aborted navigation's replacement tab is closed",
+  );
+  assert.ok(
+    fake.closedTargets.includes("tab-main"),
+    "the original tab is closed by the final swap",
+  );
+  assert.deepEqual(
+    [...fake.tabs.keys()],
+    ["tab-2"],
+    "no replacement tab leaks from the aborted navigations",
+  );
+  assert.equal(fake.tabs.get("tab-2").url, "https://main.test/c");
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  assert.equal(
+    received.filter((message) => message.id === 116).length,
+    1,
+    "navigation A gets exactly one response",
+  );
+  assert.equal(
+    received.filter((message) => message.id === 117).length,
+    1,
+    "navigation B gets exactly one response",
+  );
+  await transport.closeAndWait();
+});
+
+test("a navigation stuck confirming its commit is superseded without waiting out the poll", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+    transportOptions: { navigationCommitTimeoutMs: 10_000 },
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  // Gate only navigation A's replacement tab: its frame keeps reporting the
+  // blank staging URL, so A hangs in commit confirmation even though the
+  // native Page.navigate itself already succeeded.
+  const originalCreateTab = fake.runtime.createTab;
+  let gatedTargetId;
+  fake.runtime.createTab = async (url) => {
+    fake.runtime.createTab = originalCreateTab;
+    const created = await originalCreateTab(url);
+    gatedTargetId = created.targetId;
+    fake.frameUrlOverride.set(created.targetId, "about:blank");
+    return created;
+  };
+
+  transport.send({
+    id: 120,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/stuck" },
+    sessionId: mainSession,
+  });
+  // Page.getFrameTree traffic is the commit-confirmation poll: nothing else
+  // in this harness flow issues it, so its appearance proves A is polling.
+  const pollDeadline = Date.now() + 2_000;
+  while (
+    !fake.log.some((request) => request.method === "Page.getFrameTree") &&
+    Date.now() < pollDeadline
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.ok(
+    fake.log.some((request) => request.method === "Page.getFrameTree"),
+    "navigation A reaches its commit-confirmation poll",
+  );
+
+  const startedAt = Date.now();
+  transport.send({
+    id: 121,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/recovery" },
+    sessionId: mainSession,
+  });
+  const superseded = await waitForMessage(
+    received,
+    (message) => message.id === 120,
+  );
+  assert.match(
+    superseded.error?.message || "",
+    /superseded by a newer navigation/,
+    "the poll-gated navigation resolves with the superseded error",
+  );
+  const navigated = await waitForMessage(
+    received,
+    (message) => message.id === 121,
+    5_000,
+  );
+  assert.ok(navigated, "the superseding navigation settles");
+  assert.equal(
+    navigated.error,
+    undefined,
+    `the superseding navigation must commit, got: ${JSON.stringify(navigated?.error)}`,
+  );
+  assert.ok(
+    Date.now() - startedAt < 5_000,
+    "the superseding navigation must not wait out the aborted commit poll",
+  );
+  assert.ok(
+    fake.closedTargets.includes(gatedTargetId),
+    "the aborted navigation's replacement tab is closed",
+  );
+  await transport.closeAndWait();
+});
+
 async function assertInPlaceNavigation(initialUrl) {
   const harness = await createTaskSpaceTransportHarness({
     tabs: [["tab-main", initialUrl]],

--- a/package/ego-browser/src/playwright/routing.test.mjs
+++ b/package/ego-browser/src/playwright/routing.test.mjs
@@ -963,7 +963,7 @@ test("the Ego Playwright transport keeps the Playwright Page identity while repl
     id: 33,
     method: "Page.navigate",
     params: {
-      frameId: "client-frame",
+      frameId: "client-target",
       url: "https://example.test/after",
     },
     sessionId: "client-session",
@@ -993,7 +993,7 @@ test("the Ego Playwright transport keeps the Playwright Page identity while repl
     {
       id: 33,
       result: {
-        frameId: "client-frame",
+        frameId: "client-target",
         loaderId: "replacement-loader",
       },
       sessionId: "client-session",
@@ -1004,7 +1004,7 @@ test("the Ego Playwright transport keeps the Playwright Page identity while repl
       (message) =>
         message.method === "Page.frameNavigated" &&
         message.sessionId === "client-session" &&
-        message.params.frame.id === "client-frame",
+        message.params.frame.id === "client-target",
     ),
   );
   assert.ok(
@@ -1012,7 +1012,7 @@ test("the Ego Playwright transport keeps the Playwright Page identity while repl
       (message) =>
         message.method === "Page.lifecycleEvent" &&
         message.params.name === "load" &&
-        message.params.frameId === "client-frame",
+        message.params.frameId === "client-target",
     ),
   );
   const replacementRuntimeEnableIndex = sent.findIndex(
@@ -1090,7 +1090,7 @@ async function createNavigatedCdpSessionTransport({
               id:
                 request.sessionId === "replacement-session"
                   ? "replacement-frame"
-                  : "client-frame",
+                  : "client-target",
               loaderId:
                 request.sessionId === "replacement-session"
                   ? "replacement-loader"
@@ -1187,7 +1187,7 @@ async function createNavigatedCdpSessionTransport({
     id: 51,
     method: "Page.navigate",
     params: {
-      frameId: "client-frame",
+      frameId: "client-target",
       url: "https://example.test/after",
     },
     sessionId: "client-session",
@@ -1420,7 +1420,7 @@ test("the Ego Playwright transport reports the committed redirect URL for Page.n
               id:
                 request.sessionId === "replacement-session"
                   ? "replacement-frame"
-                  : "client-frame",
+                  : "client-target",
               loaderId:
                 request.sessionId === "replacement-session"
                   ? "replacement-loader"
@@ -1481,7 +1481,7 @@ test("the Ego Playwright transport reports the committed redirect URL for Page.n
     id: 36,
     method: "Page.navigate",
     params: {
-      frameId: "client-frame",
+      frameId: "client-target",
       url: "https://example.test/redirect",
     },
     sessionId: "client-session",
@@ -1504,7 +1504,7 @@ test("the Ego Playwright transport reports the committed redirect URL for Page.n
     {
       id: 36,
       result: {
-        frameId: "client-frame",
+        frameId: "client-target",
         loaderId: "replacement-loader",
       },
       sessionId: "client-session",
@@ -2005,12 +2005,18 @@ test("the Ego Playwright transport does not close a target reused by createTab n
     id: 41,
     method: "Page.navigate",
     params: {
-      frameId: "client-frame",
+      frameId: "reused-target",
       url: "https://example.test/after",
     },
     sessionId: "client-session",
   });
-  for (let index = 0; index < 10; index += 1) await waitForImmediate();
+  const navigationDeadline = Date.now() + 1_000;
+  while (
+    !received.some((message) => message.id === 41) &&
+    Date.now() < navigationDeadline
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
 
   assert.equal(
     sent.some((request) => request.method === "Target.closeTarget"),
@@ -2454,4 +2460,248 @@ test("the TaskSpace Playwright transport does not fall back to getCDPEndpoint", 
 
 test("the removed local CDP bridge is no longer exported", () => {
   assert.equal(playwrightTaskSpace.createLocalCdpBridge, undefined);
+});
+
+async function createTaskSpaceTransportHarness({ tabs }) {
+  const { FakeNativeBrowser } = await import("./fake-native-harness.mjs");
+  const fake = new FakeNativeBrowser();
+  for (const [targetId, url] of tabs) fake.addTab(targetId, url);
+  const received = [];
+  const pendingWork = [];
+  const transport = egoTransport.createEgoCdpTransport(fake.runtime, {
+    targetIds: tabs.map(([targetId]) => targetId),
+    onPendingWorkChange: (count) => pendingWork.push(count),
+  });
+  transport.releaseConnectionKeepAlive();
+  transport.onmessage = (message) => received.push(message);
+  transport.send({
+    id: 1,
+    method: "Target.setAutoAttach",
+    params: { autoAttach: true, waitForDebuggerOnStart: true, flatten: true },
+  });
+  const settled = Date.now() + 2_000;
+  while (fake.sessions.size < tabs.length && Date.now() < settled) {
+    await waitForImmediate();
+  }
+  return { fake, transport, received, pendingWork };
+}
+
+function gateListTabs(fake) {
+  let release;
+  const gate = new Promise((resolve) => (release = resolve));
+  const originalListTabs = fake.runtime.listTabs;
+  fake.runtime.listTabs = async () => {
+    await gate;
+    return originalListTabs();
+  };
+  return () => release();
+}
+
+async function waitForMessage(received, predicate, timeoutMs = 3_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const match = received.find(predicate);
+    if (match) return match;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return received.find(predicate);
+}
+
+test("commands sent during a session rebind are delivered after the route rebinds", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+  });
+  const { fake, transport, received } = harness;
+  const oldSession = [...fake.sessions.keys()][0];
+  const releaseListTabs = gateListTabs(fake);
+
+  fake.sessions.delete(oldSession);
+  fake.emit({
+    method: "Target.detachedFromTarget",
+    params: { sessionId: oldSession, targetId: "tab-main" },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  transport.send({
+    id: 70,
+    method: "Runtime.evaluate",
+    params: { expression: "1 + 1" },
+    sessionId: oldSession,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  assert.equal(
+    received.find((message) => message.id === 70),
+    undefined,
+    "the command is held while the route rebinds instead of failing",
+  );
+
+  releaseListTabs();
+  const reply = await waitForMessage(received, (message) => message.id === 70);
+  assert.ok(reply, "the held command completes after the rebind");
+  assert.equal(reply.error, undefined);
+  assert.equal(reply.sessionId, oldSession);
+  await transport.closeAndWait();
+});
+
+test("browser-level cookie commands prefer an attached route", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [
+      ["tab-a", "https://a.test/"],
+      ["tab-b", "https://b.test/"],
+    ],
+  });
+  const { fake, transport, received } = harness;
+  const sessionA = [...fake.sessions.entries()].find(
+    ([, targetId]) => targetId === "tab-a",
+  )[0];
+  const releaseListTabs = gateListTabs(fake);
+
+  fake.sessions.delete(sessionA);
+  fake.emit({
+    method: "Target.detachedFromTarget",
+    params: { sessionId: sessionA, targetId: "tab-a" },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  transport.send({ id: 77, method: "Storage.getCookies", params: {} });
+  const reply = await waitForMessage(received, (message) => message.id === 77);
+  assert.ok(reply, "the cookie command completes");
+  assert.equal(
+    reply.error,
+    undefined,
+    "the cookie command uses a healthy route instead of the rebinding one",
+  );
+  assert.deepEqual(reply.result, { cookies: [] });
+  releaseListTabs();
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  await transport.closeAndWait();
+});
+
+test("a native send error rejects in-flight commands without closing the transport", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  const originalSend = fake.runtime.sendCDPMessage;
+  fake.runtime.sendCDPMessage = () => {};
+  transport.send({
+    id: 91,
+    method: "Runtime.evaluate",
+    params: { expression: "1" },
+    sessionId: mainSession,
+  });
+  await waitForImmediate();
+  fake.runtime.onSendCDPMessageError?.(
+    "Task space is not assigned to an agent.",
+    "EGO_TASK_SPACE_INACTIVE",
+  );
+
+  const failed = await waitForMessage(received, (message) => message.id === 91);
+  assert.ok(failed, "the in-flight command is rejected");
+  assert.match(failed.error?.message || "", /EGO_TASK_SPACE_INACTIVE/);
+  assert.equal(
+    transport.closed,
+    false,
+    "a task-level send error must not tear down the whole transport",
+  );
+
+  fake.runtime.sendCDPMessage = originalSend;
+  transport.send({ id: 92, method: "Target.getTargets", params: {} });
+  const recovered = await waitForMessage(
+    received,
+    (message) => message.id === 92,
+  );
+  assert.ok(recovered, "the transport keeps working after the send error");
+  assert.equal(recovered.error, undefined);
+  await transport.closeAndWait();
+});
+
+test("popups opened concurrently with different URLs are both attached", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+  const releaseListTabs = gateListTabs(fake);
+
+  fake.addTab("tab-popup-a", "https://popup.test/a");
+  fake.addTab("tab-popup-b", "https://popup.test/b");
+  fake.emit({
+    method: "Page.windowOpen",
+    params: { url: "https://popup.test/a", windowName: "a" },
+    sessionId: mainSession,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  fake.emit({
+    method: "Page.windowOpen",
+    params: { url: "https://popup.test/b", windowName: "b" },
+    sessionId: mainSession,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  releaseListTabs();
+
+  const attachedA = await waitForMessage(
+    received,
+    (message) =>
+      message.method === "Target.attachedToTarget" &&
+      message.params?.targetInfo?.targetId === "tab-popup-a",
+  );
+  const attachedB = await waitForMessage(
+    received,
+    (message) =>
+      message.method === "Target.attachedToTarget" &&
+      message.params?.targetInfo?.targetId === "tab-popup-b",
+  );
+  assert.ok(attachedA, "the first popup is attached");
+  assert.ok(attachedB, "the second popup is attached as well");
+  await transport.closeAndWait();
+});
+
+test("replayed toggle commands preserve the client's final state", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  const toggles = [
+    { id: 50, cacheDisabled: true },
+    { id: 51, cacheDisabled: false },
+    { id: 52, cacheDisabled: true },
+  ];
+  for (const toggle of toggles) {
+    transport.send({
+      id: toggle.id,
+      method: "Network.setCacheDisabled",
+      params: { cacheDisabled: toggle.cacheDisabled },
+      sessionId: mainSession,
+    });
+  }
+  await waitForMessage(received, (message) => message.id === 52);
+
+  transport.send({
+    id: 53,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/next" },
+    sessionId: mainSession,
+  });
+  await waitForMessage(received, (message) => message.id === 53, 5_000);
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const replacementSession = [...fake.sessions.keys()].at(-1);
+  assert.notEqual(replacementSession, mainSession);
+  const replayed = fake.log.filter(
+    (request) =>
+      request.sessionId === replacementSession &&
+      request.method === "Network.setCacheDisabled",
+  );
+  assert.ok(replayed.length >= 1, "the toggle command is replayed");
+  assert.equal(
+    replayed.at(-1).params.cacheDisabled,
+    true,
+    "the replayed toggle ends on the client's final state",
+  );
+  await transport.closeAndWait();
 });

--- a/package/ego-browser/src/playwright/routing.test.mjs
+++ b/package/ego-browser/src/playwright/routing.test.mjs
@@ -846,20 +846,26 @@ test("the Ego Playwright transport keeps the Playwright Page identity while repl
     sendCDPMessage(payload) {
       const request = JSON.parse(payload);
       sent.push(request);
-      if (request.method === "Page.navigate") return;
 
       let result = {};
-      if (request.method === "Target.getTargetInfo") {
+      if (request.method === "Page.navigate") {
+        result = {
+          frameId: "replacement-frame",
+          loaderId: "replacement-loader",
+        };
+      } else if (request.method === "Target.getTargetInfo") {
         const targetId = request.params.targetId;
         result = {
           targetInfo: {
             targetId,
             type: "page",
             title: targetId === "replacement-target" ? "After" : "Before",
+            // A non-blank starting page: navigations from a blank page take
+            // the in-place path and never reach the replacement flow.
             url:
               targetId === "replacement-target"
                 ? "https://example.test/after"
-                : "chrome://newtab/",
+                : "https://example.test/before",
           },
         };
       } else if (request.method === "Target.attachToTarget") {
@@ -870,6 +876,10 @@ test("the Ego Playwright transport keeps the Playwright Page identity while repl
               : "client-session",
         };
       } else if (request.method === "Page.getFrameTree") {
+        // The frame tree lags the native commit: it first reports the initial
+        // blank document, then a transient pre-reflection state whose loader
+        // does not yet match the navigate response; neither may be mistaken
+        // for the committed navigation.
         const replacementFrameTreeCall =
           request.sessionId === "replacement-session"
             ? replacementFrameTreeCalls++
@@ -888,9 +898,10 @@ test("the Ego Playwright transport keeps the Playwright Page identity while repl
                   ? "transient-loader"
                   : "replacement-loader",
               name: "",
-              url: beforeReplacementCommit
-                ? "about:blank"
-                : "https://example.test/after",
+              url:
+                beforeReplacementCommit || transientReplacementCommit
+                  ? "about:blank"
+                  : "https://example.test/after",
             },
           },
         };
@@ -976,10 +987,21 @@ test("the Ego Playwright transport keeps the Playwright Page identity while repl
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
 
-  assert.deepEqual(createdUrls, ["https://example.test/after"]);
-  assert.equal(
-    sent.some((request) => request.method === "Page.navigate"),
-    false,
+  assert.deepEqual(createdUrls, ["about:blank"]);
+  const nativeNavigate = sent.find(
+    (request) => request.method === "Page.navigate",
+  );
+  assert.equal(nativeNavigate?.sessionId, "replacement-session");
+  assert.equal(nativeNavigate?.params.url, "https://example.test/after");
+  const replacementFetchEnableIndex = sent.findIndex(
+    (request) =>
+      request.method === "Runtime.enable" &&
+      request.sessionId === "replacement-session",
+  );
+  assert.ok(
+    replacementFetchEnableIndex !== -1 &&
+      replacementFetchEnableIndex < sent.indexOf(nativeNavigate),
+    "enable commands are replayed before the native navigation starts",
   );
   assert.ok(
     sent.some(
@@ -1065,10 +1087,12 @@ async function createNavigatedCdpSessionTransport({
             targetId: request.params.targetId,
             type: "page",
             title: "Selected",
+            // A non-blank starting page: navigations from a blank page take
+            // the in-place path and never reach the replacement flow.
             url:
               request.params.targetId === "replacement-target"
                 ? "https://example.test/after"
-                : "about:blank",
+                : "https://example.test/before",
           },
         };
       } else if (request.method === "Target.attachToTarget") {
@@ -1400,10 +1424,12 @@ test("the Ego Playwright transport reports the committed redirect URL for Page.n
           targetInfo: {
             targetId: request.params.targetId,
             type: "page",
+            // A non-blank starting page: navigations from a blank page take
+            // the in-place path and never reach the replacement flow.
             url:
               request.params.targetId === "replacement-target"
                 ? "https://example.test/redirect-target"
-                : "about:blank",
+                : "https://example.test/before",
           },
         };
       } else if (request.method === "Target.attachToTarget") {
@@ -2787,6 +2813,174 @@ test("a document request paused by replayed interception reaches the client befo
   await transport.closeAndWait();
 });
 
+test("a client Fetch.fulfillRequest mocks the document of a TaskSpace navigation", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+    harnessOptions: { interceptNavigations: true },
+    transportOptions: { navigationCommitTimeoutMs: 2_000 },
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  transport.send({
+    id: 83,
+    method: "Fetch.enable",
+    params: { patterns: [{ urlPattern: "*", requestStage: "Request" }] },
+    sessionId: mainSession,
+  });
+  await waitForMessage(received, (message) => message.id === 83);
+
+  transport.send({
+    id: 84,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/mocked" },
+    sessionId: mainSession,
+  });
+
+  const paused = await waitForMessage(
+    received,
+    (message) => message.method === "Fetch.requestPaused",
+  );
+  assert.ok(paused, "the document request pauses after the native navigate");
+  assert.equal(
+    received.some((message) => message.id === 84),
+    false,
+    "the pause is bridged to the client before the navigation resolves",
+  );
+
+  transport.send({
+    id: 85,
+    method: "Fetch.fulfillRequest",
+    params: {
+      requestId: paused.params.requestId,
+      responseCode: 200,
+      body: Buffer.from("<html>mocked</html>").toString("base64"),
+    },
+    sessionId: mainSession,
+  });
+
+  const navigated = await waitForMessage(
+    received,
+    (message) => message.id === 84,
+    5_000,
+  );
+  assert.ok(navigated, "the navigation settles once the request is fulfilled");
+  assert.equal(
+    navigated.error,
+    undefined,
+    `the navigation must commit, got: ${JSON.stringify(navigated?.error)}`,
+  );
+  assert.equal(navigated.result.frameId, "tab-main");
+  assert.deepEqual(fake.continuedRequests, [paused.params.requestId]);
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  const documentAnnouncements = received.filter(
+    (message) =>
+      message.method === "Network.requestWillBeSent" &&
+      message.params?.requestId === paused.params.networkId,
+  );
+  assert.equal(
+    documentAnnouncements.length,
+    1,
+    "the bridged announcement and the real deferred event must not both reach the client",
+  );
+  assert.equal(
+    received.filter(
+      (message) =>
+        message.method === "Network.responseReceived" &&
+        message.params?.requestId === paused.params.networkId,
+    ).length,
+    1,
+    "the real document response reaches the client exactly once",
+  );
+  await transport.closeAndWait();
+});
+
+test("a native Page.navigate errorText fails the client navigation and closes the replacement tab", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+  fake.navigationErrors.set(
+    "https://nowhere.invalid/",
+    "net::ERR_NAME_NOT_RESOLVED",
+  );
+
+  transport.send({
+    id: 86,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://nowhere.invalid/" },
+    sessionId: mainSession,
+  });
+  const failed = await waitForMessage(received, (message) => message.id === 86);
+  assert.ok(failed, "the client navigation settles");
+  assert.match(failed.error?.message || "", /net::ERR_NAME_NOT_RESOLVED/);
+
+  const closeDeadline = Date.now() + 2_000;
+  while (fake.closedTargets.length === 0 && Date.now() < closeDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  assert.equal(fake.closedTargets.length, 1, "the replacement tab is closed");
+  assert.deepEqual(
+    [...fake.tabs.keys()],
+    ["tab-main"],
+    "only the original tab remains",
+  );
+
+  transport.send({
+    id: 87,
+    method: "Runtime.evaluate",
+    params: { expression: "1 + 1", returnByValue: true },
+    sessionId: mainSession,
+  });
+  const evaluated = await waitForMessage(
+    received,
+    (message) => message.id === 87,
+  );
+  assert.ok(evaluated, "the page still answers commands");
+  assert.equal(evaluated.error, undefined);
+  await transport.closeAndWait();
+});
+
+test("a download navigation fails the client Page.navigate promptly", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+    transportOptions: { navigationCommitTimeoutMs: 10_000 },
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+  fake.downloadUrls.add("https://main.test/report.xlsx");
+
+  const startedAt = Date.now();
+  transport.send({
+    id: 88,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/report.xlsx" },
+    sessionId: mainSession,
+  });
+  const failed = await waitForMessage(received, (message) => message.id === 88);
+  assert.ok(failed, "the client navigation settles");
+  assert.match(
+    failed.error?.message || "",
+    /net::ERR_ABORTED; maybe frame was detached\?/,
+  );
+  assert.ok(
+    Date.now() - startedAt < 5_000,
+    "a download must fail well before the commit timeout",
+  );
+
+  const closeDeadline = Date.now() + 2_000;
+  while (fake.closedTargets.length === 0 && Date.now() < closeDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  assert.deepEqual(
+    [...fake.tabs.keys()],
+    ["tab-main"],
+    "the replacement tab does not leak after the failed download navigation",
+  );
+  await transport.closeAndWait();
+});
+
 test("a held command whose replay throws synchronously still gets an error reply", async () => {
   const harness = await createTaskSpaceTransportHarness({
     tabs: [["tab-main", "https://main.test/"]],
@@ -2833,5 +3027,232 @@ test("a held command whose replay throws synchronously still gets an error reply
   assert.equal(reply.sessionId, oldSession);
 
   fake.runtime.sendCDPMessage = originalSend;
+  await transport.closeAndWait();
+});
+
+async function assertInPlaceNavigation(initialUrl) {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", initialUrl]],
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  transport.send({
+    id: 130,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/landing" },
+    sessionId: mainSession,
+  });
+  const navigated = await waitForMessage(
+    received,
+    (message) => message.id === 130,
+  );
+  assert.ok(navigated, "the client navigation settles");
+  assert.equal(
+    navigated.error,
+    undefined,
+    `the navigation must commit, got: ${JSON.stringify(navigated?.error)}`,
+  );
+  assert.equal(navigated.result.frameId, "tab-main");
+  assert.equal(typeof navigated.result.loaderId, "string");
+  assert.equal(navigated.sessionId, mainSession);
+
+  assert.deepEqual(fake.createdUrls, [], "no replacement tab is created");
+  assert.deepEqual(fake.closedTargets, [], "no tab is closed");
+  const nativeNavigate = fake.log.find(
+    (request) => request.method === "Page.navigate",
+  );
+  assert.equal(
+    nativeNavigate?.sessionId,
+    mainSession,
+    "the native navigate runs on the route's existing session",
+  );
+  assert.equal(nativeNavigate?.params.url, "https://main.test/landing");
+  assert.deepEqual(
+    [...fake.tabs.keys()],
+    ["tab-main"],
+    "the route keeps its native target",
+  );
+  assert.equal(fake.tabs.get("tab-main").url, "https://main.test/landing");
+  assert.equal(
+    fake.log.filter((request) => request.method === "Target.attachToTarget")
+      .length,
+    1,
+    "no replacement session is attached",
+  );
+  const frameNavigated = await waitForMessage(
+    received,
+    (message) =>
+      message.method === "Page.frameNavigated" &&
+      message.params?.frame?.url === "https://main.test/landing",
+  );
+  assert.ok(frameNavigated, "the real frameNavigated reaches the client");
+  assert.equal(frameNavigated.sessionId, mainSession);
+  await transport.closeAndWait();
+}
+
+test("a navigation from a blank page navigates in place", async () => {
+  await assertInPlaceNavigation("about:blank");
+});
+
+test("an in-place navigation from chrome://newtab", async () => {
+  await assertInPlaceNavigation("chrome://newtab/");
+});
+
+test("in-place navigation propagates errorText", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "about:blank"]],
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+  fake.navigationErrors.set(
+    "https://nowhere.invalid/",
+    "net::ERR_NAME_NOT_RESOLVED",
+  );
+
+  transport.send({
+    id: 132,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://nowhere.invalid/" },
+    sessionId: mainSession,
+  });
+  const failed = await waitForMessage(
+    received,
+    (message) => message.id === 132,
+  );
+  assert.ok(failed, "the client navigation settles");
+  assert.match(failed.error?.message || "", /net::ERR_NAME_NOT_RESOLVED/);
+  assert.deepEqual(fake.createdUrls, [], "no replacement tab is created");
+  assert.equal(fake.tabs.get("tab-main").url, "about:blank");
+
+  transport.send({
+    id: 133,
+    method: "Runtime.evaluate",
+    params: { expression: "1 + 1", returnByValue: true },
+    sessionId: mainSession,
+  });
+  const evaluated = await waitForMessage(
+    received,
+    (message) => message.id === 133,
+  );
+  assert.ok(evaluated, "the page still answers commands");
+  assert.equal(evaluated.error, undefined);
+  await transport.closeAndWait();
+});
+
+test("in-place navigation reports a download as an aborted navigation", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "about:blank"]],
+    transportOptions: { navigationCommitTimeoutMs: 10_000 },
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+  fake.downloadUrls.add("https://main.test/report.xlsx");
+
+  const startedAt = Date.now();
+  transport.send({
+    id: 134,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/report.xlsx" },
+    sessionId: mainSession,
+  });
+  const failed = await waitForMessage(
+    received,
+    (message) => message.id === 134,
+  );
+  assert.ok(failed, "the client navigation settles");
+  assert.match(
+    failed.error?.message || "",
+    /net::ERR_ABORTED; maybe frame was detached\?/,
+  );
+  assert.ok(
+    Date.now() - startedAt < 5_000,
+    "a download must fail well before the commit timeout",
+  );
+  assert.deepEqual(fake.createdUrls, [], "no replacement tab is created");
+  await transport.closeAndWait();
+});
+
+test("commands during an in-place navigation are not held", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "about:blank"]],
+    harnessOptions: { interceptNavigations: true },
+    transportOptions: { navigationCommitTimeoutMs: 5_000 },
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  transport.send({
+    id: 135,
+    method: "Fetch.enable",
+    params: { patterns: [{ urlPattern: "*", requestStage: "Request" }] },
+    sessionId: mainSession,
+  });
+  await waitForMessage(received, (message) => message.id === 135);
+
+  transport.send({
+    id: 136,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/gated" },
+    sessionId: mainSession,
+  });
+  const paused = await waitForMessage(
+    received,
+    (message) => message.method === "Fetch.requestPaused",
+  );
+  assert.ok(paused, "the gated document request holds the navigation open");
+  assert.equal(paused.sessionId, mainSession);
+
+  transport.send({
+    id: 137,
+    method: "Runtime.evaluate",
+    params: { expression: "1 + 1", returnByValue: true },
+    sessionId: mainSession,
+  });
+  const evaluated = await waitForMessage(
+    received,
+    (message) => message.id === 137,
+    1_000,
+  );
+  assert.ok(
+    evaluated,
+    "the command is answered while the in-place navigation is pending",
+  );
+  assert.equal(evaluated.error, undefined);
+  assert.equal(
+    received.some((message) => message.id === 136),
+    false,
+    "the navigation has not committed when the command is answered",
+  );
+  const evaluateRequest = fake.log.find(
+    (request) =>
+      request.method === "Runtime.evaluate" &&
+      request.params?.expression === "1 + 1",
+  );
+  assert.equal(
+    evaluateRequest?.sessionId,
+    mainSession,
+    "the command is served by the route's own session",
+  );
+
+  transport.send({
+    id: 138,
+    method: "Fetch.continueRequest",
+    params: { requestId: paused.params.requestId },
+    sessionId: mainSession,
+  });
+  const navigated = await waitForMessage(
+    received,
+    (message) => message.id === 136,
+    5_000,
+  );
+  assert.ok(navigated, "the navigation settles once the gate opens");
+  assert.equal(
+    navigated.error,
+    undefined,
+    `the navigation must commit, got: ${JSON.stringify(navigated?.error)}`,
+  );
+  assert.equal(navigated.result.frameId, "tab-main");
+  assert.deepEqual(fake.createdUrls, [], "no replacement tab is created");
   await transport.closeAndWait();
 });

--- a/package/ego-browser/src/playwright/routing.test.mjs
+++ b/package/ego-browser/src/playwright/routing.test.mjs
@@ -2462,15 +2462,20 @@ test("the removed local CDP bridge is no longer exported", () => {
   assert.equal(playwrightTaskSpace.createLocalCdpBridge, undefined);
 });
 
-async function createTaskSpaceTransportHarness({ tabs }) {
+async function createTaskSpaceTransportHarness({
+  tabs,
+  harnessOptions,
+  transportOptions,
+}) {
   const { FakeNativeBrowser } = await import("./fake-native-harness.mjs");
-  const fake = new FakeNativeBrowser();
+  const fake = new FakeNativeBrowser(harnessOptions);
   for (const [targetId, url] of tabs) fake.addTab(targetId, url);
   const received = [];
   const pendingWork = [];
   const transport = egoTransport.createEgoCdpTransport(fake.runtime, {
     targetIds: tabs.map(([targetId]) => targetId),
     onPendingWorkChange: (count) => pendingWork.push(count),
+    ...transportOptions,
   });
   transport.releaseConnectionKeepAlive();
   transport.onmessage = (message) => received.push(message);
@@ -2703,5 +2708,130 @@ test("replayed toggle commands preserve the client's final state", async () => {
     true,
     "the replayed toggle ends on the client's final state",
   );
+  await transport.closeAndWait();
+});
+
+test("a document request paused by replayed interception reaches the client before commit", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+    harnessOptions: { interceptNavigations: true },
+    transportOptions: { navigationCommitTimeoutMs: 1_500 },
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  transport.send({
+    id: 80,
+    method: "Fetch.enable",
+    params: {
+      patterns: [{ urlPattern: "*", requestStage: "Request" }],
+      handleAuthRequests: true,
+    },
+    sessionId: mainSession,
+  });
+  await waitForMessage(received, (message) => message.id === 80);
+
+  transport.send({
+    id: 81,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/second" },
+    sessionId: mainSession,
+  });
+
+  const paused = await waitForMessage(
+    received,
+    (message) => message.method === "Fetch.requestPaused",
+  );
+  assert.ok(
+    paused,
+    "the replacement target's paused document request must reach the client " +
+      "while the navigation waits for commit",
+  );
+  assert.equal(paused.sessionId, mainSession);
+  assert.equal(
+    paused.params.frameId,
+    "tab-main",
+    "the paused request reports the client's main frame id",
+  );
+  assert.equal(typeof paused.params.networkId, "string");
+  assert.ok(
+    received.some(
+      (message) =>
+        message.method === "Network.requestWillBeSent" &&
+        message.params?.requestId === paused.params.networkId &&
+        message.sessionId === mainSession,
+    ),
+    "the paired requestWillBeSent reaches the client so interception can dispatch",
+  );
+
+  transport.send({
+    id: 82,
+    method: "Fetch.continueRequest",
+    params: { requestId: paused.params.requestId },
+    sessionId: mainSession,
+  });
+
+  const navigated = await waitForMessage(
+    received,
+    (message) => message.id === 81,
+    5_000,
+  );
+  assert.ok(navigated, "the navigation settles once the request is continued");
+  assert.equal(
+    navigated.error,
+    undefined,
+    `the navigation must commit, got: ${JSON.stringify(navigated?.error)}`,
+  );
+  assert.equal(navigated.result.frameId, "tab-main");
+  assert.deepEqual(fake.continuedRequests, [paused.params.requestId]);
+  await transport.closeAndWait();
+});
+
+test("a held command whose replay throws synchronously still gets an error reply", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+  });
+  const { fake, transport, received } = harness;
+  const oldSession = [...fake.sessions.keys()][0];
+  const releaseListTabs = gateListTabs(fake);
+
+  fake.sessions.delete(oldSession);
+  fake.emit({
+    method: "Target.detachedFromTarget",
+    params: { sessionId: oldSession, targetId: "tab-main" },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  transport.send({
+    id: 85,
+    method: "DOM.getDocument",
+    params: {},
+    sessionId: oldSession,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  assert.equal(
+    received.find((message) => message.id === 85),
+    undefined,
+    "the command is held while the route rebinds",
+  );
+
+  const originalSend = fake.runtime.sendCDPMessage;
+  fake.runtime.sendCDPMessage = (payload) => {
+    if (JSON.parse(payload).method === "DOM.getDocument") {
+      throw new Error("native send failed synchronously");
+    }
+    return originalSend(payload);
+  };
+  releaseListTabs();
+
+  const reply = await waitForMessage(received, (message) => message.id === 85);
+  assert.ok(
+    reply,
+    "the held command must be answered even when its replay throws",
+  );
+  assert.match(reply.error?.message || "", /native send failed synchronously/);
+  assert.equal(reply.sessionId, oldSession);
+
+  fake.runtime.sendCDPMessage = originalSend;
   await transport.closeAndWait();
 });

--- a/package/ego-browser/src/playwright/routing.test.mjs
+++ b/package/ego-browser/src/playwright/routing.test.mjs
@@ -2690,6 +2690,258 @@ test("popups opened concurrently with different URLs are both attached", async (
   await transport.closeAndWait();
 });
 
+test("a popup whose tab URL changed before discovery is still attached", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  // The native tab already shows the post-redirect URL, so it can never
+  // equal the windowOpen URL.
+  fake.addTab("tab-popup-moved", "https://popup.test/final");
+  fake.emit({
+    method: "Page.windowOpen",
+    params: { url: "https://popup.test/r", windowName: "" },
+    sessionId: mainSession,
+  });
+
+  const attached = await waitForMessage(
+    received,
+    (message) =>
+      message.method === "Target.attachedToTarget" &&
+      message.params?.targetInfo?.targetId === "tab-popup-moved",
+  );
+  assert.ok(attached, "the redirected popup is attached");
+  assert.equal(attached.params.targetInfo.openerId, "tab-main");
+  await transport.closeAndWait();
+});
+
+test("an exact URL match is preferred over queue order when adopting a popup", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [
+      ["tab-a", "https://a.test/"],
+      ["tab-b", "https://b.test/"],
+    ],
+  });
+  const { fake, transport, received } = harness;
+  const sessionA = [...fake.sessions].find(
+    ([, targetId]) => targetId === "tab-a",
+  )[0];
+  const sessionB = [...fake.sessions].find(
+    ([, targetId]) => targetId === "tab-b",
+  )[0];
+  const releaseListTabs = gateListTabs(fake);
+
+  // The older queued entry does not match the tab URL; the newer one does.
+  fake.emit({
+    method: "Page.windowOpen",
+    params: { url: "https://popup.test/r", windowName: "" },
+    sessionId: sessionA,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  fake.emit({
+    method: "Page.windowOpen",
+    params: { url: "https://popup.test/exact", windowName: "" },
+    sessionId: sessionB,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  fake.addTab("tab-popup", "https://popup.test/exact");
+  releaseListTabs();
+
+  const attached = await waitForMessage(
+    received,
+    (message) =>
+      message.method === "Target.attachedToTarget" &&
+      message.params?.targetInfo?.targetId === "tab-popup",
+  );
+  assert.ok(attached, "the popup is attached");
+  assert.equal(
+    attached.params.targetInfo.openerId,
+    "tab-b",
+    "the exact URL match wins over the older queued entry",
+  );
+  await transport.closeAndWait();
+});
+
+test("concurrent popups both attach when one URL changed before discovery", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+  const releaseListTabs = gateListTabs(fake);
+
+  fake.addTab("tab-popup-exact", "https://popup.test/exact");
+  fake.addTab("tab-popup-moved", "https://popup.test/final");
+  fake.emit({
+    method: "Page.windowOpen",
+    params: { url: "https://popup.test/exact", windowName: "exact" },
+    sessionId: mainSession,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  fake.emit({
+    method: "Page.windowOpen",
+    params: { url: "https://popup.test/r", windowName: "moved" },
+    sessionId: mainSession,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  releaseListTabs();
+
+  const attachedExact = await waitForMessage(
+    received,
+    (message) =>
+      message.method === "Target.attachedToTarget" &&
+      message.params?.targetInfo?.targetId === "tab-popup-exact",
+  );
+  const attachedMoved = await waitForMessage(
+    received,
+    (message) =>
+      message.method === "Target.attachedToTarget" &&
+      message.params?.targetInfo?.targetId === "tab-popup-moved",
+  );
+  assert.ok(attachedExact, "the exact-match popup is attached");
+  assert.ok(attachedMoved, "the redirected popup is attached as well");
+  assert.equal(attachedExact.params.targetInfo.openerId, "tab-main");
+  assert.equal(attachedMoved.params.targetInfo.openerId, "tab-main");
+  await transport.closeAndWait();
+});
+
+test("a redirecting popup is adopted only after its URL settles", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  // Mirror the native timeline: the tab first appears with an empty URL and
+  // only commits to the final URL a few polls later.
+  fake.addTab("tab-popup-late", "");
+  const startedAt = Date.now();
+  fake.emit({
+    method: "Page.windowOpen",
+    params: { url: "https://popup.test/r", windowName: "" },
+    sessionId: mainSession,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  fake.tabs.get("tab-popup-late").url = "https://popup.test/final";
+
+  const attached = await waitForMessage(
+    received,
+    (message) =>
+      message.method === "Target.attachedToTarget" &&
+      message.params?.targetInfo?.targetId === "tab-popup-late",
+  );
+  assert.ok(attached, "the popup is attached after its URL settles");
+  assert.equal(
+    attached.params.targetInfo.url,
+    "https://popup.test/final",
+    "adoption waits for the committed URL instead of racing the navigation",
+  );
+  assert.ok(
+    Date.now() - startedAt < 1_500,
+    "a settled URL is adopted well before the deadline phase",
+  );
+  await transport.closeAndWait();
+});
+
+test("a popup that never navigates is adopted in the deadline phase", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  // A bare window.open() popup: the tab URL stays empty forever, so only the
+  // end-of-deadline adoption can claim it.
+  fake.addTab("tab-popup-blank", "");
+  const startedAt = Date.now();
+  fake.emit({
+    method: "Page.windowOpen",
+    params: { url: "https://popup.test/never", windowName: "" },
+    sessionId: mainSession,
+  });
+
+  const attached = await waitForMessage(
+    received,
+    (message) =>
+      message.method === "Target.attachedToTarget" &&
+      message.params?.targetInfo?.targetId === "tab-popup-blank",
+  );
+  assert.ok(attached, "the blank popup is still attached");
+  assert.equal(attached.params.targetInfo.openerId, "tab-main");
+  assert.ok(
+    Date.now() - startedAt >= 1_000,
+    "an empty URL is never adopted eagerly",
+  );
+  await transport.closeAndWait();
+});
+
+test("a popup after a TaskSpace navigation replacement adopts the popup tab, not the opener", async () => {
+  const harness = await createTaskSpaceTransportHarness({
+    tabs: [["tab-main", "https://main.test/"]],
+  });
+  const { fake, transport, received } = harness;
+  const mainSession = [...fake.sessions.keys()][0];
+
+  // A TaskSpace navigation replacement rebinds the route onto a brand new
+  // native tab (the fake's createTab always mints a fresh targetId).
+  transport.send({
+    id: 60,
+    method: "Page.navigate",
+    params: { frameId: "tab-main", url: "https://main.test/next" },
+    sessionId: mainSession,
+  });
+  await waitForMessage(received, (message) => message.id === 60, 5_000);
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  const replacementSession = [...fake.sessions.keys()].at(-1);
+  const replacementTargetId = fake.sessions.get(replacementSession);
+  assert.notEqual(replacementTargetId, "tab-main");
+  const attachesBefore = fake.log.filter(
+    (request) =>
+      request.method === "Target.attachToTarget" &&
+      request.params?.targetId === replacementTargetId,
+  ).length;
+
+  // Redirect case: the popup tab's URL never matches the windowOpen URL, so
+  // adoption must go through the fallback path — which used to grab the
+  // route's own replacement tab because #targetIds had lost track of it.
+  fake.addTab("tab-popup-after-nav", "https://popup.test/final");
+  fake.emit({
+    method: "Page.windowOpen",
+    params: { url: "https://popup.test/r", windowName: "" },
+    sessionId: replacementSession,
+  });
+
+  const attached = await waitForMessage(
+    received,
+    (message) =>
+      message.method === "Target.attachedToTarget" &&
+      message.params?.targetInfo?.targetId === "tab-popup-after-nav",
+  );
+  assert.ok(attached, "the popup tab is adopted");
+  assert.equal(attached.params.targetInfo.openerId, "tab-main");
+  const attachesAfter = fake.log.filter(
+    (request) =>
+      request.method === "Target.attachToTarget" &&
+      request.params?.targetId === replacementTargetId,
+  ).length;
+  assert.equal(
+    attachesAfter,
+    attachesBefore,
+    "the route's native target must not be attached a second time",
+  );
+  assert.ok(
+    !received.some(
+      (message) =>
+        message.method === "Target.attachedToTarget" &&
+        message.params?.targetInfo?.targetId === replacementTargetId,
+    ),
+    "no ghost page is announced for the route's own native target",
+  );
+  await transport.closeAndWait();
+});
+
 test("replayed toggle commands preserve the client's final state", async () => {
   const harness = await createTaskSpaceTransportHarness({
     tabs: [["tab-main", "https://main.test/"]],

--- a/package/ego-browser/src/playwright/routing.ts
+++ b/package/ego-browser/src/playwright/routing.ts
@@ -43,9 +43,12 @@ type NavigationTransition = {
   nativeTargetId: string;
   clientFrameId: string;
   // networkIds whose Network.requestWillBeSent the bridge has synthesized:
-  // the replacement session attaches after the document request starts, so
-  // Chromium never sends the real one to it. Also consulted at commit so the
-  // navigation-response synthesis does not announce the request twice.
+  // while interception holds the document request paused, Chromium withholds
+  // the request's real Network.requestWillBeSent, so the bridge announces it
+  // from the pause payload. The real event arrives once the pause resolves
+  // (deferred until the swap) and is dropped there, and the commit-time
+  // navigation-response synthesis consults this set so the request is never
+  // announced twice.
   announcedRequests: Set<string>;
 };
 
@@ -56,6 +59,12 @@ type PageRoute = {
   nativeSessionId: string;
   clientMainFrameId?: string;
   nativeMainFrameId?: string;
+  // The route's current committed main-frame URL: seeded from the attach-time
+  // targetInfo, updated on every observed main-frame Page.frameNavigated, and
+  // set to the committed URL when a navigation replacement swaps the route.
+  // While it is blank ("", about:blank, chrome://newtab) a client navigation
+  // runs natively in place instead of through the tab-replacement flow.
+  currentMainFrameUrl?: string;
   generation: number;
   state: "attached" | "navigating" | "rebinding" | "closed";
   replayCommands: Map<string, ReplayCommand>;
@@ -234,6 +243,21 @@ export class EgoCdpTransport {
         route &&
         (typeof navigateFrameId !== "string" || navigateFrameId === mainFrameId)
       ) {
+        // A blank page needs no replacement tab: the route's session already
+        // has the client's enables armed, so a native Page.navigate on it is
+        // fully interceptable and all real events flow through the normal
+        // delivery path. Skipping createTab here also avoids the app-level
+        // race where a createTab issued while another fresh tab's
+        // initialization is still in flight returns a tab whose CDP
+        // passthrough never answers. The route stays "attached" throughout —
+        // no holds, no synthetic events.
+        if (
+          route.state === "attached" &&
+          isBlankPageUrl(route.currentMainFrameUrl)
+        ) {
+          this.#runInPlaceNavigation(message, route);
+          return;
+        }
         const run = () => this.#runNavigationReplacement(message, route);
         const previous = route.pendingTransition ?? Promise.resolve();
         route.pendingTransition = previous.then(run, run);
@@ -614,10 +638,11 @@ export class EgoCdpTransport {
       typeof networkId === "string" &&
       !transition.announcedRequests.has(networkId)
     ) {
-      // The replacement session attached after the document request started,
-      // so Chromium never sends it the request's Network.requestWillBeSent —
-      // yet Playwright dispatches interception only for paused requests it can
-      // pair with one. Announce the request from the pause's own payload.
+      // Chromium withholds the request's Network.requestWillBeSent until the
+      // pause is resolved — yet Playwright dispatches interception only for
+      // paused requests it can pair with one. Announce the request from the
+      // pause's own payload; the real event arrives after the client resolves
+      // the pause and is dropped at the swap so it is not delivered twice.
       transition.announcedRequests.add(networkId);
       const timestamp = Date.now() / 1_000;
       const isDocument = message.params?.resourceType === "Document";
@@ -783,11 +808,11 @@ export class EgoCdpTransport {
   #observeRouteEvent(message: any, route: PageRoute) {
     if (message.method === "Page.frameNavigated") {
       const frame = message.params?.frame;
-      if (
-        frame?.parentId === undefined &&
-        typeof frame?.id === "string" &&
-        route.state === "attached"
-      ) {
+      if (frame?.parentId === undefined && typeof frame?.id === "string") {
+        if (typeof frame.url === "string") {
+          route.currentMainFrameUrl = frame.url;
+        }
+        if (route.state !== "attached") return;
         route.nativeMainFrameId = frame.id;
         route.clientMainFrameId ||= frame.id;
         const key = `${frame.id}\0${frame.loaderId || ""}\0${frame.url || ""}`;
@@ -1155,6 +1180,8 @@ export class EgoCdpTransport {
       nativeTargetId: targetId,
       clientSessionId: sessionId,
       nativeSessionId: sessionId,
+      currentMainFrameUrl:
+        typeof targetInfo.url === "string" ? targetInfo.url : "",
       generation: 0,
       state: "attached",
       replayCommands: new Map(),
@@ -1244,6 +1271,59 @@ export class EgoCdpTransport {
     this.#targetsBySession.set(nativeSessionId, nativeTargetId);
   }
 
+  // Navigate the route's existing tab natively. Only reached while the
+  // current page is blank (see send()): the tab keeps its target and session,
+  // so the response is simply relayed to the client with the frame id mapped
+  // back, and errorText / isDownload get the same client-visible semantics as
+  // the replacement flow.
+  #runInPlaceNavigation(message: any, route: PageRoute) {
+    const url = message.params?.url;
+    if (typeof url !== "string") {
+      this.#emit({
+        id: message.id,
+        error: { code: -32_000, message: "Page.navigate requires a url" },
+        sessionId: route.clientSessionId,
+      });
+      return;
+    }
+    void this.#sendNativeCommand(
+      "Page.navigate",
+      rewriteOutgoingProtocolParams(message.params || {}, route),
+      route.nativeSessionId,
+      this.#navigationCommitTimeoutMs,
+    )
+      .then((result) => {
+        if (typeof result?.errorText === "string" && result.errorText !== "") {
+          throw new Error(result.errorText);
+        }
+        if (result?.isDownload === true) {
+          // A download never commits a document; failing here mirrors
+          // Playwright's own abort for download navigations.
+          throw new Error("net::ERR_ABORTED; maybe frame was detached?");
+        }
+        const rewritten = { ...(result || {}) };
+        rewriteIncomingProtocolMessage({ params: rewritten }, route);
+        this.#emit({
+          id: message.id,
+          result: rewritten,
+          sessionId: route.clientSessionId,
+        });
+      })
+      .catch((error) => {
+        const description = (error as Error)?.message || String(error);
+        this.#emit({
+          id: message.id,
+          error: {
+            code: -32_000,
+            message: description.includes("timed out")
+              ? `navigation did not commit within ${this.#navigationCommitTimeoutMs}ms (requested ${JSON.stringify(url)})`
+              : description,
+          },
+          sessionId: route.clientSessionId,
+        });
+      });
+  }
+
   async #runNavigationReplacement(message: any, route: PageRoute) {
     const clientFrameId = message.params?.frameId;
     const url = message.params?.url;
@@ -1269,7 +1349,6 @@ export class EgoCdpTransport {
       });
       return;
     }
-
     route.state = "navigating";
     this.#activeOperations += 1;
     this.#updatePendingWork();
@@ -1280,14 +1359,12 @@ export class EgoCdpTransport {
     let replacementSessionId: string | undefined;
 
     await (async () => {
-      const previousFrameTree = await this.#sendNativeCommand(
-        "Page.getFrameTree",
-        {},
-        route.nativeSessionId,
-        1_000,
-      ).catch(() => undefined);
-      const previousFrame = previousFrameTree?.frameTree?.frame;
-      const created: any = await this.#runtime.createTab!(url);
+      // The replacement tab is created blank on purpose: the enable commands
+      // replayed below must exist on the session before the document request
+      // starts, otherwise the request is structurally un-interceptable (a
+      // navigation begun by createTab(url) is already in flight by the time
+      // Fetch.enable reaches the new session).
+      const created: any = await this.#runtime.createTab!("about:blank");
       const newTargetId = created?.targetId || created?.result?.targetId;
       if (created?.error || typeof newTargetId !== "string") {
         throw new Error(
@@ -1331,10 +1408,46 @@ export class EgoCdpTransport {
         {},
         newSessionId,
       );
+      // Only now start the real navigation, natively on the armed session.
+      // Page.navigate responds when the navigation commits (or fails), which
+      // can hinge on the client: a replayed Fetch.enable pauses the document
+      // request, and the transition bridge above keeps interception traffic
+      // flowing so the client can resume it while this await is pending.
+      let navigateResult: any;
+      try {
+        navigateResult = await this.#sendNativeCommand(
+          "Page.navigate",
+          { url },
+          newSessionId,
+          this.#navigationCommitTimeoutMs,
+        );
+      } catch (error) {
+        const message = (error as Error)?.message || String(error);
+        if (message.includes("timed out")) {
+          throw new Error(
+            `navigation did not commit within ${this.#navigationCommitTimeoutMs}ms (requested ${JSON.stringify(url)})`,
+          );
+        }
+        throw error;
+      }
+      if (
+        typeof navigateResult?.errorText === "string" &&
+        navigateResult.errorText !== ""
+      ) {
+        throw new Error(navigateResult.errorText);
+      }
+      if (navigateResult?.isDownload === true) {
+        // A download never commits a document; failing here mirrors
+        // Playwright's own abort for download navigations so goto rejects
+        // promptly instead of burning the whole commit timeout.
+        throw new Error("net::ERR_ABORTED; maybe frame was detached?");
+      }
       const { frame, documentState } = await this.#waitForNavigationCommit(
         newSessionId,
         url,
-        previousFrame,
+        typeof navigateResult?.loaderId === "string"
+          ? navigateResult.loaderId
+          : undefined,
         this.#navigationCommitTimeoutMs,
       );
       const replacementFrameId =
@@ -1344,6 +1457,12 @@ export class EgoCdpTransport {
       const transition = route.transition;
       route.transition = undefined;
       route.clientMainFrameId = clientFrameId;
+      route.currentMainFrameUrl =
+        typeof documentState?.url === "string"
+          ? documentState.url
+          : typeof frame.url === "string" && frame.url !== ""
+            ? frame.url
+            : url;
       this.#replaceNativeRoute(
         route,
         newTargetId,
@@ -1358,6 +1477,35 @@ export class EgoCdpTransport {
         params: {},
         sessionId: route.clientSessionId,
       });
+      if (transition) {
+        // The transition bridge already announced paused requests to the
+        // client from their pause payloads; the real Network.requestWillBeSent
+        // for those requests arrived afterwards (deferred until this swap) and
+        // must not reach the client a second time. Redirect hops (they carry
+        // redirectResponse) are new information and pass through.
+        for (let index = this.#deferredEvents.length - 1; index >= 0; index--) {
+          const event = this.#deferredEvents[index];
+          if (
+            event.sessionId === newSessionId &&
+            event.method === "Network.requestWillBeSent" &&
+            typeof event.params?.requestId === "string" &&
+            transition.announcedRequests.has(event.params.requestId) &&
+            !event.params.redirectResponse
+          ) {
+            this.#deferredEvents.splice(index, 1);
+          }
+        }
+      }
+      // With Page enabled before the navigation starts, the real committed
+      // Page.frameNavigated is usually sitting in the deferred queue; the
+      // synthetic one below is only the fallback for when it is not.
+      const realFrameNavigated = this.#deferredEvents.some(
+        (event) =>
+          event.sessionId === newSessionId &&
+          event.method === "Page.frameNavigated" &&
+          event.params?.frame?.parentId === undefined &&
+          event.params?.frame?.loaderId === frame.loaderId,
+      );
       const requestFinished = this.#emitNavigationResponse(
         route,
         url,
@@ -1382,18 +1530,20 @@ export class EgoCdpTransport {
         },
         sessionId: route.clientSessionId,
       });
-      this.#emit({
-        method: "Page.frameNavigated",
-        params: {
-          frame: {
-            ...frame,
-            id: clientFrameId,
-            name: frame.name || "",
-            url,
+      if (!realFrameNavigated) {
+        this.#emit({
+          method: "Page.frameNavigated",
+          params: {
+            frame: {
+              ...frame,
+              id: clientFrameId,
+              name: frame.name || "",
+              url,
+            },
           },
-        },
-        sessionId: route.clientSessionId,
-      });
+          sessionId: route.clientSessionId,
+        });
+      }
 
       for (const command of route.replayCommands.values()) {
         if (!Object.hasOwn(command.params, "frameId")) continue;
@@ -1579,18 +1729,22 @@ export class EgoCdpTransport {
       });
   }
 
+  // Page.navigate has already committed natively when this runs; it only
+  // waits for the frame tree to reflect that commit. The navigate response's
+  // loaderId is the authoritative marker. A frame still on its initial blank
+  // state ("" or about:blank) is never mistaken for the committed page — the
+  // replacement tab (new or reused) starts on about:blank — but any other
+  // document is accepted: after a successful navigate response a non-blank
+  // frame is the committed document or its successor (e.g. an instant
+  // client-side redirect that already replaced the expected loader).
   async #waitForNavigationCommit(
     sessionId: string,
     requestedUrl: string,
-    previousFrame?: { loaderId?: string; url?: string },
-    timeoutMs = 30_000,
+    expectedLoaderId: string | undefined,
+    timeoutMs: number,
   ) {
     const deadline = Date.now() + timeoutMs;
-    const stableForMs = 50;
     let lastFrame: any;
-    let lastDocumentState: any;
-    let commitCandidateKey: string | undefined;
-    let commitCandidateSince = 0;
     do {
       if (this.closed) throw new Error("Ego CDP transport is closed");
       const frameTree = await this.#sendNativeCommand(
@@ -1602,40 +1756,28 @@ export class EgoCdpTransport {
       const frame = frameTree?.frameTree?.frame;
       if (frame) lastFrame = frame;
       const frameUrl = typeof frame?.url === "string" ? frame.url : "";
-      const documentResult = await this.#sendNativeCommand(
-        "Runtime.evaluate",
-        {
-          expression:
-            "(() => { const entry = performance.getEntriesByType('navigation')[0]; return { url: location.href, readyState: document.readyState, contentType: document.contentType, responseStatus: entry?.responseStatus }; })()",
-          returnByValue: true,
-        },
-        sessionId,
-        1_000,
-      ).catch(() => undefined);
-      const documentState = documentResult?.result?.value;
-      if (documentState && typeof documentState === "object") {
-        lastDocumentState = documentState;
-      }
-      const frameCommitted =
-        frameUrl === requestedUrl ||
-        (frameUrl !== "" &&
-          frameUrl !== "about:blank" &&
-          (frameUrl !== previousFrame?.url ||
-            frame?.loaderId !== previousFrame?.loaderId));
-      const documentCommitted =
-        !lastDocumentState ||
-        lastDocumentState.url === frameUrl ||
-        lastDocumentState.url === requestedUrl;
-      if (frameCommitted && documentCommitted) {
-        const candidateKey = `${frame.loaderId || ""}\0${frameUrl}`;
-        if (candidateKey !== commitCandidateKey) {
-          commitCandidateKey = candidateKey;
-          commitCandidateSince = Date.now();
-        } else if (Date.now() - commitCandidateSince >= stableForMs) {
-          return { frame, documentState: lastDocumentState };
-        }
-      } else {
-        commitCandidateKey = undefined;
+      const committed =
+        frame !== undefined &&
+        ((expectedLoaderId !== undefined &&
+          frame.loaderId === expectedLoaderId) ||
+          frameUrl === requestedUrl ||
+          (frameUrl !== "" && frameUrl !== "about:blank"));
+      if (committed) {
+        const documentResult = await this.#sendNativeCommand(
+          "Runtime.evaluate",
+          {
+            expression:
+              "(() => { const entry = performance.getEntriesByType('navigation')[0]; return { url: location.href, readyState: document.readyState, contentType: document.contentType, responseStatus: entry?.responseStatus }; })()",
+            returnByValue: true,
+          },
+          sessionId,
+          1_000,
+        ).catch(() => undefined);
+        const value = documentResult?.result?.value;
+        return {
+          frame,
+          documentState: value && typeof value === "object" ? value : undefined,
+        };
       }
       await new Promise<void>((resolve) => setTimeout(resolve, 10));
     } while (Date.now() < deadline);
@@ -1858,6 +2000,17 @@ function rewriteIncomingProtocolMessage(message: any, route: PageRoute) {
   replaceFrameId(params.frame, "id");
   replaceFrameId(params.frame, "parentId");
   replaceFrameId(params.context?.auxData, "frameId");
+}
+
+// The blank states a route's tab can sit on before its first real document:
+// a fresh tab ("" or about:blank) or the task space's initial chrome://newtab.
+// Navigating away from any of them works natively in place.
+function isBlankPageUrl(url: string | undefined): boolean {
+  return (
+    url === "" ||
+    url === "about:blank" ||
+    (typeof url === "string" && url.startsWith("chrome://newtab"))
+  );
 }
 
 function isReplayableSessionCommand(method: unknown): method is string {

--- a/package/ego-browser/src/playwright/routing.ts
+++ b/package/ego-browser/src/playwright/routing.ts
@@ -31,6 +31,24 @@ type PassthroughSession = {
   nativeTargetId: string;
 };
 
+// While a navigation replacement waits for its commit, interception traffic
+// must keep flowing: a replayed Fetch.enable pauses the replacement's document
+// request, and only the client can continue it. The bridge exposes the
+// replacement session's Fetch events to the client (and routes the client's
+// Fetch commands back) before the route itself is swapped. Network events are
+// NOT bridged: they stay deferred until commit like every other event, so the
+// commit-time synthesis keeps seeing them in arrival order.
+type NavigationTransition = {
+  nativeSessionId: string;
+  nativeTargetId: string;
+  clientFrameId: string;
+  // networkIds whose Network.requestWillBeSent the bridge has synthesized:
+  // the replacement session attaches after the document request starts, so
+  // Chromium never sends the real one to it. Also consulted at commit so the
+  // navigation-response synthesis does not announce the request twice.
+  announcedRequests: Set<string>;
+};
+
 type PageRoute = {
   clientTargetId: string;
   nativeTargetId: string;
@@ -43,6 +61,7 @@ type PageRoute = {
   replayCommands: Map<string, ReplayCommand>;
   heldMessages?: any[];
   pendingTransition?: Promise<void>;
+  transition?: NavigationTransition;
   passiveNavigation?: {
     key: string;
     generation: number;
@@ -226,14 +245,25 @@ export class EgoCdpTransport {
     const route = clientSessionId
       ? this.#routesByClientSession.get(clientSessionId)
       : undefined;
+    let transitionSessionId: string | undefined;
     if (
       route &&
       (route.state === "navigating" || route.state === "rebinding")
     ) {
-      // The native session is being swapped; hold the command and replay it
-      // against the replacement session once the transition settles.
-      (route.heldMessages ??= []).push(message);
-      return;
+      if (
+        route.transition &&
+        typeof message.method === "string" &&
+        message.method.startsWith("Fetch.")
+      ) {
+        // Interception responses must reach the in-flight replacement session
+        // now: its paused document request is what the commit is waiting on.
+        transitionSessionId = route.transition.nativeSessionId;
+      } else {
+        // The native session is being swapped; hold the command and replay it
+        // against the replacement session once the transition settles.
+        (route.heldMessages ??= []).push(message);
+        return;
+      }
     }
     const attachTargetId =
       message.method === "Target.attachToTarget" &&
@@ -270,7 +300,7 @@ export class EgoCdpTransport {
       clientId: message.id,
       method: message.method,
       clientSessionId,
-      nativeSessionId: route?.nativeSessionId,
+      nativeSessionId: transitionSessionId ?? route?.nativeSessionId,
       attachedTarget,
       detachedSessionId,
     });
@@ -280,7 +310,7 @@ export class EgoCdpTransport {
         ? {
             ...message,
             id: nativeId,
-            sessionId: route.nativeSessionId,
+            sessionId: transitionSessionId ?? route.nativeSessionId,
             params: rewriteOutgoingProtocolParams(message.params || {}, route),
           }
         : { ...message, id: nativeId };
@@ -392,8 +422,22 @@ export class EgoCdpTransport {
       if (this.closed) return;
       try {
         this.send(message);
-      } catch {
-        // The command's own error handling already reported the failure.
+      } catch (error) {
+        // send() rethrows a synchronous native failure without replying, and a
+        // held command has no other caller to report to — answer it here or
+        // the client request hangs forever.
+        if (message.id !== undefined) {
+          this.#emit({
+            id: message.id,
+            error: {
+              code: -32_000,
+              message: (error as Error)?.message || String(error),
+            },
+            ...(typeof message.sessionId === "string"
+              ? { sessionId: message.sessionId }
+              : {}),
+          });
+        }
       }
     }
   }
@@ -499,6 +543,7 @@ export class EgoCdpTransport {
       this.#retiredNativeSessions.delete(message.params.sessionId);
     }
     if (this.#deliverPassthroughDetach(message)) return;
+    if (this.#bridgeTransitionEvent(message)) return;
     if (!this.#acceptEvent(message)) {
       if (
         this.#activeOperations > 0 &&
@@ -532,6 +577,75 @@ export class EgoCdpTransport {
     if (message.method === "Page.windowOpen") {
       this.#discoverOpenedTargets(openerTargetId, message.params?.url);
     }
+  }
+
+  // Deliver Fetch events from an in-flight replacement session to the client
+  // while the navigation waits for commit. Interception cannot wait for the
+  // route swap: the paused document request is what commit is waiting on.
+  // Only the Fetch domain crosses early — Fetch traffic on the replacement
+  // session begins with our own post-transition replay, so the stream cannot
+  // straddle the deferred queue and arrive out of order.
+  #bridgeTransitionEvent(message: any) {
+    const sessionId = message.sessionId;
+    const method = message.method;
+    if (typeof sessionId !== "string" || typeof method !== "string") {
+      return false;
+    }
+    if (!method.startsWith("Fetch.")) return false;
+    let route: PageRoute | undefined;
+    for (const candidate of this.#routesByClientSession.values()) {
+      if (
+        candidate.transition?.nativeSessionId === sessionId &&
+        candidate.state !== "closed"
+      ) {
+        route = candidate;
+        break;
+      }
+    }
+    if (!route) return false;
+    const transition = route.transition!;
+    const clientFrameId =
+      message.params?.frameId === transition.nativeTargetId
+        ? transition.clientFrameId
+        : message.params?.frameId;
+    const networkId = message.params?.networkId;
+    if (
+      method === "Fetch.requestPaused" &&
+      typeof networkId === "string" &&
+      !transition.announcedRequests.has(networkId)
+    ) {
+      // The replacement session attached after the document request started,
+      // so Chromium never sends it the request's Network.requestWillBeSent —
+      // yet Playwright dispatches interception only for paused requests it can
+      // pair with one. Announce the request from the pause's own payload.
+      transition.announcedRequests.add(networkId);
+      const timestamp = Date.now() / 1_000;
+      const isDocument = message.params?.resourceType === "Document";
+      this.#emit({
+        method: "Network.requestWillBeSent",
+        params: {
+          requestId: networkId,
+          ...(isDocument ? { loaderId: networkId } : {}),
+          documentURL: message.params?.request?.url,
+          request: message.params?.request,
+          timestamp,
+          wallTime: timestamp,
+          initiator: { type: "other" },
+          type: message.params?.resourceType,
+          ...(clientFrameId !== undefined ? { frameId: clientFrameId } : {}),
+          hasUserGesture: false,
+        },
+        sessionId: route.clientSessionId,
+      });
+    }
+    // The replacement's main frame id equals its target id (native invariant);
+    // the client knows that frame by the id it navigated.
+    if (message.params?.frameId === transition.nativeTargetId) {
+      message.params.frameId = transition.clientFrameId;
+    }
+    message.sessionId = route.clientSessionId;
+    this.#deliverEvent(message);
+    return true;
   }
 
   #rebindDetachedRoute(message: any) {
@@ -1193,6 +1307,12 @@ export class EgoCdpTransport {
       const { sessionId: newSessionId } =
         await this.#attachNativeTarget(newTargetId);
       replacementSessionId = newSessionId;
+      route.transition = {
+        nativeSessionId: newSessionId,
+        nativeTargetId: newTargetId,
+        clientFrameId,
+        announcedRequests: new Set(),
+      };
       for (const command of route.replayCommands.values()) {
         if (
           command.method === "Runtime.runIfWaitingForDebugger" ||
@@ -1219,6 +1339,10 @@ export class EgoCdpTransport {
       );
       const replacementFrameId =
         typeof frame.id === "string" ? frame.id : newTargetId;
+      // From here on the swapped route handles the session's events itself;
+      // this block runs synchronously, so there is no delivery gap.
+      const transition = route.transition;
+      route.transition = undefined;
       route.clientMainFrameId = clientFrameId;
       this.#replaceNativeRoute(
         route,
@@ -1239,6 +1363,7 @@ export class EgoCdpTransport {
         url,
         frame,
         documentState,
+        transition,
       );
       this.#flushDeferredEvents();
 
@@ -1296,6 +1421,7 @@ export class EgoCdpTransport {
       this.#completePassiveNavigation(route, frame, navigationKey);
     })()
       .catch((error) => {
+        route.transition = undefined;
         if (route.nativeSessionId === previousNativeSessionId) {
           this.#retiredNativeSessions.delete(previousNativeSessionId);
         }
@@ -1333,14 +1459,21 @@ export class EgoCdpTransport {
     requestedUrl: string,
     frame: any,
     documentState: any,
+    transition?: NavigationTransition,
   ) {
     if (typeof frame.loaderId !== "string") return true;
-    const deferredRequest = this.#deferredEvents.some(
-      (message) =>
-        message.sessionId === route.nativeSessionId &&
-        message.method === "Network.requestWillBeSent" &&
-        message.params?.requestId === frame.loaderId,
-    );
+    // The document request may have been announced to the client already —
+    // deferred and about to flush, or synthesized by the transition bridge
+    // when interception paused it — in which case announcing it again here
+    // would hand Playwright a duplicate.
+    const deferredRequest =
+      transition?.announcedRequests.has(frame.loaderId) === true ||
+      this.#deferredEvents.some(
+        (message) =>
+          message.sessionId === route.nativeSessionId &&
+          message.method === "Network.requestWillBeSent" &&
+          message.params?.requestId === frame.loaderId,
+      );
     const deferredResponse = this.#deferredEvents.some(
       (message) =>
         message.sessionId === route.nativeSessionId &&

--- a/package/ego-browser/src/playwright/routing.ts
+++ b/package/ego-browser/src/playwright/routing.ts
@@ -69,6 +69,17 @@ type PageRoute = {
   state: "attached" | "navigating" | "rebinding" | "closed";
   replayCommands: Map<string, ReplayCommand>;
   heldMessages?: any[];
+  // Set while the route's current native session cannot receive commands: it
+  // was internally detached (same-target navigation replacement) or its native
+  // detach started a rebind. Forwarding would only fail with "Session not
+  // found", so send() holds everything until the transition settles.
+  nativeSessionDetached?: boolean;
+  // A newer client Page.navigate supersedes an older one (stock browser
+  // semantics). Each client navigation bumps the epoch; a queued navigation
+  // that starts with a stale epoch answers "superseded" without doing any
+  // native work, and abortNavigation cancels the one already in flight.
+  navigationEpoch: number;
+  abortNavigation?: (reason: string) => void;
   pendingTransition?: Promise<void>;
   transition?: NavigationTransition;
   passiveNavigation?: {
@@ -250,7 +261,9 @@ export class EgoCdpTransport {
         // race where a createTab issued while another fresh tab's
         // initialization is still in flight returns a tab whose CDP
         // passthrough never answers. The route stays "attached" throughout —
-        // no holds, no synthetic events.
+        // no holds, no synthetic events — and a newer client navigation is
+        // superseded natively by Chromium, so the epoch is not bumped and no
+        // in-flight replacement is aborted for this path.
         if (
           route.state === "attached" &&
           isBlankPageUrl(route.currentMainFrameUrl)
@@ -258,7 +271,16 @@ export class EgoCdpTransport {
           this.#runInPlaceNavigation(message, route);
           return;
         }
-        const run = () => this.#runNavigationReplacement(message, route);
+        // A newer navigation supersedes the pending one (stock browser
+        // semantics): abort the in-flight transition so this one starts as
+        // soon as its cleanup finishes. The chaining stays — it is the
+        // ordering guarantee that lets cleanup complete first.
+        route.navigationEpoch += 1;
+        const epoch = route.navigationEpoch;
+        route.abortNavigation?.(
+          "navigation was superseded by a newer navigation",
+        );
+        const run = () => this.#runNavigationReplacement(message, route, epoch);
         const previous = route.pendingTransition ?? Promise.resolve();
         route.pendingTransition = previous.then(run, run);
         return;
@@ -282,12 +304,24 @@ export class EgoCdpTransport {
         // Interception responses must reach the in-flight replacement session
         // now: its paused document request is what the commit is waiting on.
         transitionSessionId = route.transition.nativeSessionId;
-      } else {
-        // The native session is being swapped; hold the command and replay it
-        // against the replacement session once the transition settles.
+      } else if (
+        isReplayableSessionCommand(message.method) ||
+        route.nativeSessionDetached
+      ) {
+        // Replayable commands mutate session domain state, and the replacement
+        // session took its replay snapshot when the transition started — a
+        // mid-transition command must be held and re-processed after the swap
+        // or the new session would silently miss it. Everything is held once
+        // the old native session is detached: forwarding would only fail with
+        // "Session not found".
         (route.heldMessages ??= []).push(message);
         return;
       }
+      // Everything else keeps operating on the old document through the still
+      // attached native session, matching stock browser semantics during a
+      // pending navigation. If the navigation later commits and destroys the
+      // context, in-flight commands fail with context-destroyed-style errors
+      // exactly as stock Playwright surfaces them.
     }
     const attachTargetId =
       message.method === "Target.attachToTarget" &&
@@ -692,6 +726,9 @@ export class EgoCdpTransport {
 
     this.#rejectPendingSessionCommands(nativeSessionId, route.clientSessionId);
     route.state = "rebinding";
+    // The native session is already gone (its detach started this rebind);
+    // nothing can be forwarded to it until the replacement is in place.
+    route.nativeSessionDetached = true;
     this.#retiredNativeSessions.add(nativeSessionId);
     this.#activeOperations += 1;
     this.#updatePendingWork();
@@ -738,6 +775,7 @@ export class EgoCdpTransport {
         this.#deliverDetachedRoute(route);
       }
     })().finally(() => {
+      route.nativeSessionDetached = false;
       this.#endOperation();
       this.#flushHeldMessages(route);
     });
@@ -1211,6 +1249,7 @@ export class EgoCdpTransport {
       currentMainFrameUrl:
         typeof targetInfo.url === "string" ? targetInfo.url : "",
       generation: 0,
+      navigationEpoch: 0,
       state: "attached",
       replayCommands: new Map(),
     };
@@ -1358,7 +1397,11 @@ export class EgoCdpTransport {
       });
   }
 
-  async #runNavigationReplacement(message: any, route: PageRoute) {
+  async #runNavigationReplacement(
+    message: any,
+    route: PageRoute,
+    epoch: number,
+  ) {
     const clientFrameId = message.params?.frameId;
     const url = message.params?.url;
     if (typeof clientFrameId !== "string" || typeof url !== "string") {
@@ -1383,6 +1426,20 @@ export class EgoCdpTransport {
       });
       return;
     }
+    if (epoch !== route.navigationEpoch) {
+      // A newer navigation arrived while this one was still queued; it never
+      // started, so there is nothing to clean up — just answer the caller.
+      this.#emit({
+        id: message.id,
+        error: {
+          code: -32_000,
+          message: "navigation was superseded by a newer navigation",
+        },
+        sessionId: route.clientSessionId,
+      });
+      return;
+    }
+
     route.state = "navigating";
     this.#activeOperations += 1;
     this.#updatePendingWork();
@@ -1391,6 +1448,25 @@ export class EgoCdpTransport {
     this.#retiredNativeSessions.add(previousNativeSessionId);
     let replacementTargetId: string | undefined;
     let replacementSessionId: string | undefined;
+    // CDP has no cancel message, so an abort can only reject our own awaits:
+    // the long waits below race against this promise, and the in-flight
+    // native command is left to settle on its own (already marked handled).
+    let abortReason: string | undefined;
+    let rejectAbort!: (error: Error) => void;
+    const abortPromise = new Promise<never>((_, reject) => {
+      rejectAbort = reject;
+    });
+    void abortPromise.catch(() => undefined);
+    const abort = (reason: string) => {
+      if (abortReason !== undefined) return;
+      abortReason = reason;
+      rejectAbort(new Error(reason));
+    };
+    route.abortNavigation = abort;
+    const raceAbort = <T>(work: Promise<T>): Promise<T> => {
+      void work.catch(() => undefined);
+      return Promise.race([work, abortPromise]);
+    };
 
     await (async () => {
       // The replacement tab is created blank on purpose: the enable commands
@@ -1410,6 +1486,10 @@ export class EgoCdpTransport {
 
       route.state = "rebinding";
       if (newTargetId === previousNativeTargetId) {
+        // The reused tab's old session is detached before the replacement
+        // attach; from here until the transition settles no command can be
+        // forwarded to it, so send() must hold everything.
+        route.nativeSessionDetached = true;
         this.#internallyDetachedSessions.add(route.nativeSessionId);
         await this.#sendNativeCommand("Target.detachFromTarget", {
           sessionId: route.nativeSessionId,
@@ -1442,6 +1522,9 @@ export class EgoCdpTransport {
         {},
         newSessionId,
       );
+      // An abort during the setup awaits above means the navigation is
+      // already doomed; do not dispatch it natively at all.
+      if (abortReason !== undefined) throw new Error(abortReason);
       // Only now start the real navigation, natively on the armed session.
       // Page.navigate responds when the navigation commits (or fails), which
       // can hinge on the client: a replayed Fetch.enable pauses the document
@@ -1449,11 +1532,13 @@ export class EgoCdpTransport {
       // flowing so the client can resume it while this await is pending.
       let navigateResult: any;
       try {
-        navigateResult = await this.#sendNativeCommand(
-          "Page.navigate",
-          { url },
-          newSessionId,
-          this.#navigationCommitTimeoutMs,
+        navigateResult = await raceAbort(
+          this.#sendNativeCommand(
+            "Page.navigate",
+            { url },
+            newSessionId,
+            this.#navigationCommitTimeoutMs,
+          ),
         );
       } catch (error) {
         const message = (error as Error)?.message || String(error);
@@ -1476,13 +1561,20 @@ export class EgoCdpTransport {
         // promptly instead of burning the whole commit timeout.
         throw new Error("net::ERR_ABORTED; maybe frame was detached?");
       }
-      const { frame, documentState } = await this.#waitForNavigationCommit(
-        newSessionId,
-        url,
-        typeof navigateResult?.loaderId === "string"
-          ? navigateResult.loaderId
-          : undefined,
-        this.#navigationCommitTimeoutMs,
+      const { frame, documentState } = await raceAbort(
+        this.#waitForNavigationCommit(
+          newSessionId,
+          url,
+          typeof navigateResult?.loaderId === "string"
+            ? navigateResult.loaderId
+            : undefined,
+          this.#navigationCommitTimeoutMs,
+          // The race already rejects the transition; this stops the poll loop
+          // itself so an aborted commit wait does not keep probing natively.
+          () => {
+            if (abortReason !== undefined) throw new Error(abortReason);
+          },
+        ),
       );
       const replacementFrameId =
         typeof frame.id === "string" ? frame.id : newTargetId;
@@ -1633,6 +1725,14 @@ export class EgoCdpTransport {
         });
       })
       .finally(() => {
+        // Settled either way: on success the route now points at the usable
+        // replacement session; on failure of the same-target branch the route
+        // is restored to "attached", where the flag is never consulted.
+        // Dropping the abort hook here keeps a stale abort from ever firing
+        // after its transition settled (the next navigation installs its own
+        // hook only after this settles, via the pendingTransition chain).
+        if (route.abortNavigation === abort) route.abortNavigation = undefined;
+        route.nativeSessionDetached = false;
         this.#endOperation();
         this.#flushHeldMessages(route);
       });
@@ -1776,11 +1876,13 @@ export class EgoCdpTransport {
     requestedUrl: string,
     expectedLoaderId: string | undefined,
     timeoutMs: number,
+    throwIfAborted?: () => void,
   ) {
     const deadline = Date.now() + timeoutMs;
     let lastFrame: any;
     do {
       if (this.closed) throw new Error("Ego CDP transport is closed");
+      throwIfAborted?.();
       const frameTree = await this.#sendNativeCommand(
         "Page.getFrameTree",
         {},

--- a/package/ego-browser/src/playwright/routing.ts
+++ b/package/ego-browser/src/playwright/routing.ts
@@ -41,6 +41,8 @@ type PageRoute = {
   generation: number;
   state: "attached" | "navigating" | "rebinding" | "closed";
   replayCommands: Map<string, ReplayCommand>;
+  heldMessages?: any[];
+  pendingTransition?: Promise<void>;
   passiveNavigation?: {
     key: string;
     generation: number;
@@ -97,6 +99,11 @@ export class EgoCdpTransport {
   readonly #unsubscribe: () => void;
   #connecting = true;
   #discoveringOpenedTargets = false;
+  readonly #popupDiscoveryQueue: Array<{
+    openerTargetId?: string;
+    expectedUrl?: string;
+  }> = [];
+  #popupDiscoveryDeadline = 0;
   #activeOperations = 0;
   #lastPendingWork = 0;
 
@@ -116,12 +123,8 @@ export class EgoCdpTransport {
     if (options.targetIds) this.#targetIds = new Set(options.targetIds);
     this.#unsubscribe = subscribeEgoCdpTransport(runtime, {
       message: (payload) => this.#dispatch(payload),
-      error: (message, errorCode) => {
-        this.close(
-          [errorCode, message].filter(Boolean).join(": ") ||
-            "native CDP send failed",
-        );
-      },
+      error: (message, errorCode) =>
+        this.#handleNativeSendError(message, errorCode),
     });
     this.#updatePendingWork();
   }
@@ -189,11 +192,7 @@ export class EgoCdpTransport {
             },
           });
         })
-        .finally(() => {
-          this.#activeOperations -= 1;
-          if (this.#activeOperations === 0) this.#deferredEvents.length = 0;
-          this.#updatePendingWork();
-        });
+        .finally(() => this.#endOperation());
       return;
     }
     if (message.method === "Target.closeTarget") {
@@ -206,8 +205,19 @@ export class EgoCdpTransport {
       typeof this.#runtime.createTab === "function"
     ) {
       const route = this.#routesByClientSession.get(message.sessionId);
-      if (route) {
-        this.#replaceTaskSpaceTargetForNavigation(message, route);
+      // Only main-frame navigations need the TaskSpace tab-replacement flow;
+      // subframe navigations commit natively on the existing target.
+      const navigateFrameId = message.params?.frameId;
+      const mainFrameId = route
+        ? (route.clientMainFrameId ?? route.clientTargetId)
+        : undefined;
+      if (
+        route &&
+        (typeof navigateFrameId !== "string" || navigateFrameId === mainFrameId)
+      ) {
+        const run = () => this.#runNavigationReplacement(message, route);
+        const previous = route.pendingTransition ?? Promise.resolve();
+        route.pendingTransition = previous.then(run, run);
         return;
       }
     }
@@ -216,6 +226,15 @@ export class EgoCdpTransport {
     const route = clientSessionId
       ? this.#routesByClientSession.get(clientSessionId)
       : undefined;
+    if (
+      route &&
+      (route.state === "navigating" || route.state === "rebinding")
+    ) {
+      // The native session is being swapped; hold the command and replay it
+      // against the replacement session once the transition settles.
+      (route.heldMessages ??= []).push(message);
+      return;
+    }
     const attachTargetId =
       message.method === "Target.attachToTarget" &&
       typeof message.params?.targetId === "string"
@@ -239,10 +258,12 @@ export class EgoCdpTransport {
         : undefined;
     if (route && isReplayableSessionCommand(message.method)) {
       const params = message.params || {};
-      route.replayCommands.set(`${message.method}:${JSON.stringify(params)}`, {
-        method: message.method,
-        params,
-      });
+      const replayKey = `${message.method}:${JSON.stringify(params)}`;
+      // Delete before set so a repeated command moves to the end of the replay
+      // order; toggle sequences (enable → disable → enable) then replay to the
+      // client's final state instead of the first-seen order.
+      route.replayCommands.delete(replayKey);
+      route.replayCommands.set(replayKey, { method: message.method, params });
     }
     const nativeId = this.#allocateMessageId();
     this.#pendingIds.set(nativeId, {
@@ -273,9 +294,16 @@ export class EgoCdpTransport {
         JSON.stringify(nativeMessage),
       );
       void Promise.resolve(result).catch((error) => {
-        this.#pendingIds.delete(nativeId);
+        if (!this.#pendingIds.delete(nativeId)) return;
         this.#updatePendingWork();
-        this.close((error as Error)?.message || String(error));
+        this.#emit({
+          id: message.id,
+          error: {
+            code: -32_000,
+            message: (error as Error)?.message || String(error),
+          },
+          ...(clientSessionId ? { sessionId: clientSessionId } : {}),
+        });
       });
     } catch (error) {
       this.#pendingIds.delete(nativeId);
@@ -320,6 +348,54 @@ export class EgoCdpTransport {
     if (!this.#connecting) return;
     this.#connecting = false;
     this.#updatePendingWork();
+  }
+
+  // Native send errors are task-level (the callback carries no request id and
+  // once the task space is inactive every in-flight send fails alike), so all
+  // in-flight requests are rejected. The transport stays open: the condition
+  // is transient (e.g. the user took control) and commands succeed again after
+  // the task space is handed back.
+  #handleNativeSendError(message: unknown, errorCode?: string) {
+    if (this.closed) return;
+    const description =
+      [errorCode, typeof message === "string" ? message : undefined]
+        .filter(Boolean)
+        .join(": ") || "native CDP send failed";
+    for (const pending of this.#internalRequests.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error(description));
+    }
+    this.#internalRequests.clear();
+    const pendingEntries = [...this.#pendingIds.values()];
+    this.#pendingIds.clear();
+    for (const pending of pendingEntries) {
+      this.#emit({
+        id: pending.clientId,
+        error: { code: -32_000, message: description },
+        ...(pending.clientSessionId
+          ? { sessionId: pending.clientSessionId }
+          : {}),
+      });
+    }
+    this.#updatePendingWork();
+  }
+
+  #endOperation() {
+    this.#activeOperations -= 1;
+    if (this.#activeOperations === 0) this.#deferredEvents.length = 0;
+    this.#updatePendingWork();
+  }
+
+  #flushHeldMessages(route: PageRoute) {
+    const held = route.heldMessages?.splice(0) ?? [];
+    for (const message of held) {
+      if (this.closed) return;
+      try {
+        this.send(message);
+      } catch {
+        // The command's own error handling already reported the failure.
+      }
+    }
   }
 
   async closeAndWait() {
@@ -408,8 +484,20 @@ export class EgoCdpTransport {
       return;
     }
     if (this.#isRetiredSessionEvent(message)) return;
-    if (this.#isInternalTargetCloseEvent(message)) return;
+    if (this.#isInternalTargetCloseEvent(message)) {
+      // The tombstone has served its purpose once the close event arrives.
+      this.#internallyClosedTargets.delete(message.params.targetId);
+      return;
+    }
     if (this.#rebindDetachedRoute(message)) return;
+    if (
+      message.method === "Target.detachedFromTarget" &&
+      typeof message.params?.sessionId === "string"
+    ) {
+      // A detached session emits no further events; drop its tombstone so the
+      // retired set does not grow for the lifetime of the transport.
+      this.#retiredNativeSessions.delete(message.params.sessionId);
+    }
     if (this.#deliverPassthroughDetach(message)) return;
     if (!this.#acceptEvent(message)) {
       if (
@@ -419,6 +507,8 @@ export class EgoCdpTransport {
         this.#deferredEvents.length < 10_000
       ) {
         this.#deferredEvents.push(message);
+      } else if (this.#isInternalDetachEvent(message)) {
+        this.#internallyDetachedSessions.delete(message.params.sessionId);
       }
       return;
     }
@@ -509,8 +599,8 @@ export class EgoCdpTransport {
         this.#deliverDetachedRoute(route);
       }
     })().finally(() => {
-      this.#activeOperations -= 1;
-      this.#updatePendingWork();
+      this.#endOperation();
+      this.#flushHeldMessages(route);
     });
     return true;
   }
@@ -557,7 +647,10 @@ export class EgoCdpTransport {
     const session = this.#passthroughSessions.get(sessionId);
     if (!session) return false;
     this.#passthroughSessions.delete(sessionId);
-    if (this.#internallyDetachedSessions.has(sessionId)) return true;
+    if (this.#internallyDetachedSessions.has(sessionId)) {
+      this.#internallyDetachedSessions.delete(sessionId);
+      return true;
+    }
     if (
       [...this.#pendingIds.values()].some(
         (pending) => pending.detachedSessionId === sessionId,
@@ -701,10 +794,7 @@ export class EgoCdpTransport {
         }
         await new Promise<void>((resolve) => setTimeout(resolve, 10));
       } while (Date.now() < deadline);
-    })().finally(() => {
-      this.#activeOperations -= 1;
-      this.#updatePendingWork();
-    });
+    })().finally(() => this.#endOperation());
   }
 
   #deliverEvent(message: any) {
@@ -891,53 +981,56 @@ export class EgoCdpTransport {
           error: { code: -32_000, message: error?.message || String(error) },
         });
       })
-      .finally(() => {
-        this.#activeOperations -= 1;
-        if (this.#activeOperations === 0) this.#deferredEvents.length = 0;
-        this.#updatePendingWork();
-      });
+      .finally(() => this.#endOperation());
   }
 
   #discoverOpenedTargets(openerTargetId?: string, expectedUrl?: string) {
-    if (
-      !this.#targetIds ||
-      typeof this.#runtime.listTabs !== "function" ||
-      this.#discoveringOpenedTargets
-    ) {
+    if (!this.#targetIds || typeof this.#runtime.listTabs !== "function") {
       return;
     }
+    // Every windowOpen queues its own discovery entry; a single scan loop
+    // serves the whole queue so concurrently opened popups are all attached.
+    this.#popupDiscoveryQueue.push({ openerTargetId, expectedUrl });
+    this.#popupDiscoveryDeadline = Date.now() + 2_000;
+    if (this.#discoveringOpenedTargets) return;
     this.#discoveringOpenedTargets = true;
     this.#activeOperations += 1;
     this.#updatePendingWork();
     void (async () => {
-      const deadline = Date.now() + 2_000;
       do {
         const listed = await this.#runtime.listTabs!();
         const tabs = listed?.tabs || listed?.targetInfos || [];
-        const openedTargetIds = tabs
-          .filter(
-            (tab) => typeof expectedUrl !== "string" || tab.url === expectedUrl,
-          )
-          .map((tab) => tab.targetId)
-          .filter(
-            (targetId): targetId is string =>
-              typeof targetId === "string" && !this.#targetIds!.has(targetId),
-          );
-        if (openedTargetIds.length > 0) {
-          for (const targetId of openedTargetIds) {
-            this.#targetIds.add(targetId);
-            await this.#attachTaskSpaceTarget(targetId, openerTargetId);
+        for (const tab of tabs) {
+          const targetId = tab.targetId;
+          if (typeof targetId !== "string" || this.#targetIds!.has(targetId)) {
+            continue;
           }
-          return;
+          const queue = this.#popupDiscoveryQueue;
+          if (queue.length === 0) break;
+          let index = queue.findIndex(
+            (entry) =>
+              typeof entry.expectedUrl === "string" &&
+              entry.expectedUrl === tab.url,
+          );
+          if (index === -1) {
+            index = queue.findIndex(
+              (entry) => typeof entry.expectedUrl !== "string",
+            );
+          }
+          if (index === -1) continue;
+          const [entry] = queue.splice(index, 1);
+          this.#targetIds!.add(targetId);
+          await this.#attachTaskSpaceTarget(targetId, entry.openerTargetId);
         }
+        if (this.#popupDiscoveryQueue.length === 0) return;
         await new Promise<void>((resolve) => setTimeout(resolve, 20));
-      } while (!this.closed && Date.now() < deadline);
+      } while (!this.closed && Date.now() < this.#popupDiscoveryDeadline);
+      this.#popupDiscoveryQueue.length = 0;
     })()
       .catch(() => undefined)
       .finally(() => {
         this.#discoveringOpenedTargets = false;
-        this.#activeOperations -= 1;
-        this.#updatePendingWork();
+        this.#endOperation();
       });
   }
 
@@ -1037,7 +1130,7 @@ export class EgoCdpTransport {
     this.#targetsBySession.set(nativeSessionId, nativeTargetId);
   }
 
-  #replaceTaskSpaceTargetForNavigation(message: any, route: PageRoute) {
+  async #runNavigationReplacement(message: any, route: PageRoute) {
     const clientFrameId = message.params?.frameId;
     const url = message.params?.url;
     if (typeof clientFrameId !== "string" || typeof url !== "string") {
@@ -1051,6 +1144,17 @@ export class EgoCdpTransport {
       });
       return;
     }
+    if (this.closed || route.state === "closed") {
+      this.#emit({
+        id: message.id,
+        error: {
+          code: -32_000,
+          message: "Cannot navigate: the page has been closed",
+        },
+        sessionId: route.clientSessionId,
+      });
+      return;
+    }
 
     route.state = "navigating";
     this.#activeOperations += 1;
@@ -1058,13 +1162,10 @@ export class EgoCdpTransport {
     const previousNativeTargetId = route.nativeTargetId;
     const previousNativeSessionId = route.nativeSessionId;
     this.#retiredNativeSessions.add(previousNativeSessionId);
-    this.#emit({
-      method: "Runtime.executionContextsCleared",
-      params: {},
-      sessionId: route.clientSessionId,
-    });
+    let replacementTargetId: string | undefined;
+    let replacementSessionId: string | undefined;
 
-    void (async () => {
+    await (async () => {
       const previousFrameTree = await this.#sendNativeCommand(
         "Page.getFrameTree",
         {},
@@ -1073,24 +1174,25 @@ export class EgoCdpTransport {
       ).catch(() => undefined);
       const previousFrame = previousFrameTree?.frameTree?.frame;
       const created: any = await this.#runtime.createTab!(url);
-      const replacementTargetId =
-        created?.targetId || created?.result?.targetId;
-      if (created?.error || typeof replacementTargetId !== "string") {
+      const newTargetId = created?.targetId || created?.result?.targetId;
+      if (created?.error || typeof newTargetId !== "string") {
         throw new Error(
           created?.error ||
             "ego.createTab did not return a replacement targetId",
         );
       }
+      replacementTargetId = newTargetId;
 
       route.state = "rebinding";
-      if (replacementTargetId === previousNativeTargetId) {
+      if (newTargetId === previousNativeTargetId) {
         this.#internallyDetachedSessions.add(route.nativeSessionId);
         await this.#sendNativeCommand("Target.detachFromTarget", {
           sessionId: route.nativeSessionId,
         }).catch(() => undefined);
       }
-      const { sessionId: replacementSessionId } =
-        await this.#attachNativeTarget(replacementTargetId);
+      const { sessionId: newSessionId } =
+        await this.#attachNativeTarget(newTargetId);
+      replacementSessionId = newSessionId;
       for (const command of route.replayCommands.values()) {
         if (
           command.method === "Runtime.runIfWaitingForDebugger" ||
@@ -1101,29 +1203,37 @@ export class EgoCdpTransport {
         this.#sendNativeFireAndForget(
           command.method,
           command.params,
-          replacementSessionId,
+          newSessionId,
         );
       }
       this.#sendNativeFireAndForget(
         "Runtime.runIfWaitingForDebugger",
         {},
-        replacementSessionId,
+        newSessionId,
       );
       const { frame, documentState } = await this.#waitForNavigationCommit(
-        replacementSessionId,
+        newSessionId,
         url,
         previousFrame,
         this.#navigationCommitTimeoutMs,
       );
       const replacementFrameId =
-        typeof frame.id === "string" ? frame.id : replacementTargetId;
+        typeof frame.id === "string" ? frame.id : newTargetId;
       route.clientMainFrameId = clientFrameId;
       this.#replaceNativeRoute(
         route,
-        replacementTargetId,
-        replacementSessionId,
+        newTargetId,
+        newSessionId,
         replacementFrameId,
       );
+      // The old document's execution contexts are gone only once the
+      // replacement target has committed; announcing it earlier would brick
+      // the page when the navigation fails.
+      this.#emit({
+        method: "Runtime.executionContextsCleared",
+        params: {},
+        sessionId: route.clientSessionId,
+      });
       const requestFinished = this.#emitNavigationResponse(
         route,
         url,
@@ -1132,7 +1242,7 @@ export class EgoCdpTransport {
       );
       this.#flushDeferredEvents();
 
-      if (replacementTargetId !== previousNativeTargetId) {
+      if (newTargetId !== previousNativeTargetId) {
         this.#sendNativeFireAndForget("Target.closeTarget", {
           targetId: previousNativeTargetId,
         });
@@ -1165,7 +1275,7 @@ export class EgoCdpTransport {
         this.#sendNativeFireAndForget(
           command.method,
           rewriteOutgoingProtocolParams(command.params, route),
-          replacementSessionId,
+          newSessionId,
         );
       }
 
@@ -1189,6 +1299,22 @@ export class EgoCdpTransport {
         if (route.nativeSessionId === previousNativeSessionId) {
           this.#retiredNativeSessions.delete(previousNativeSessionId);
         }
+        // The replacement tab never became the route's target; close it so a
+        // failed navigation does not leak a stray tab into the TaskSpace.
+        if (
+          replacementTargetId !== undefined &&
+          replacementTargetId !== previousNativeTargetId &&
+          route.nativeTargetId !== replacementTargetId
+        ) {
+          this.#internallyClosedTargets.add(replacementTargetId);
+          if (replacementSessionId !== undefined) {
+            this.#internallyDetachedSessions.add(replacementSessionId);
+            this.#retiredNativeSessions.add(replacementSessionId);
+          }
+          this.#sendNativeFireAndForget("Target.closeTarget", {
+            targetId: replacementTargetId,
+          });
+        }
         route.state = "attached";
         this.#emit({
           id: message.id,
@@ -1197,8 +1323,8 @@ export class EgoCdpTransport {
         });
       })
       .finally(() => {
-        this.#activeOperations -= 1;
-        this.#updatePendingWork();
+        this.#endOperation();
+        this.#flushHeldMessages(route);
       });
   }
 
@@ -1289,9 +1415,12 @@ export class EgoCdpTransport {
   }
 
   #routeStorageCookieCommand(message: any) {
-    const route = [...this.#routesByClientSession.values()].find(
-      (candidate) => candidate.state !== "closed",
-    );
+    // Cookies are browser-global; prefer a route whose native session is
+    // usable right now over one that is mid-navigation or mid-rebind.
+    const routes = [...this.#routesByClientSession.values()];
+    const route =
+      routes.find((candidate) => candidate.state === "attached") ??
+      routes.find((candidate) => candidate.state !== "closed");
     if (!route) {
       this.#emit({
         id: message.id,
@@ -1443,8 +1572,7 @@ export class EgoCdpTransport {
     this.#updatePendingWork();
     void this.#waitForTargetClosed(nativeTargetId).finally(() => {
       complete();
-      this.#activeOperations -= 1;
-      this.#updatePendingWork();
+      this.#endOperation();
     });
   }
 
@@ -1603,11 +1731,23 @@ function isReplayableSessionCommand(method: unknown): method is string {
   return (
     typeof method === "string" &&
     [
+      "Emulation.setDeviceMetricsOverride",
+      "Emulation.setEmulatedMedia",
       "Emulation.setFocusEmulationEnabled",
+      "Emulation.setGeolocationOverride",
+      "Emulation.setLocaleOverride",
+      "Emulation.setScriptExecutionDisabled",
+      "Emulation.setTimezoneOverride",
+      "Emulation.setTouchEmulationEnabled",
+      "Emulation.setUserAgentOverride",
+      "Fetch.disable",
+      "Fetch.enable",
       "Log.enable",
       "Network.enable",
+      "Network.emulateNetworkConditions",
       "Network.setCacheDisabled",
       "Network.setExtraHTTPHeaders",
+      "Network.setUserAgentOverride",
       "Page.addScriptToEvaluateOnNewDocument",
       "Page.createIsolatedWorld",
       "Page.enable",
@@ -1617,6 +1757,7 @@ function isReplayableSessionCommand(method: unknown): method is string {
       "Runtime.addBinding",
       "Runtime.enable",
       "Runtime.runIfWaitingForDebugger",
+      "Security.setIgnoreCertificateErrors",
       "Target.setAutoAttach",
     ].includes(method)
   );

--- a/package/ego-browser/src/playwright/routing.ts
+++ b/package/ego-browser/src/playwright/routing.ts
@@ -770,6 +770,9 @@ export class EgoCdpTransport {
     const clientTargetId = route.clientTargetId;
     this.#removeRoute(route);
     this.#targetIds?.delete(clientTargetId);
+    // After a navigation replacement the native id differs from the client
+    // id; drop both so the dead tab cannot linger in the task-space set.
+    this.#targetIds?.delete(route.nativeTargetId);
     this.#deliverEvent({
       method: "Target.detachedFromTarget",
       params: {
@@ -1136,27 +1139,52 @@ export class EgoCdpTransport {
     this.#activeOperations += 1;
     this.#updatePendingWork();
     void (async () => {
+      // Consecutive polls each unclaimed tab has reported the same URL, used
+      // to tell committed navigations from in-flight ones (loop-local: the
+      // scan loop is single-flight per transport).
+      const urlStability = new Map<string, { url: unknown; polls: number }>();
       do {
         const listed = await this.#runtime.listTabs!();
         const tabs = listed?.tabs || listed?.targetInfos || [];
+        const deadlineImminent =
+          this.#popupDiscoveryDeadline - Date.now() < 300;
         for (const tab of tabs) {
           const targetId = tab.targetId;
-          if (typeof targetId !== "string" || this.#targetIds!.has(targetId)) {
+          if (
+            typeof targetId !== "string" ||
+            this.#targetIds!.has(targetId) ||
+            // A tab that already backs a route is never a popup candidate,
+            // regardless of any drift in the task-space target set.
+            this.#routesByNativeTarget.has(targetId)
+          ) {
             continue;
           }
           const queue = this.#popupDiscoveryQueue;
           if (queue.length === 0) break;
+          const seen = urlStability.get(targetId);
+          const polls = seen && seen.url === tab.url ? seen.polls + 1 : 1;
+          urlStability.set(targetId, { url: tab.url, polls });
           let index = queue.findIndex(
             (entry) =>
               typeof entry.expectedUrl === "string" &&
               entry.expectedUrl === tab.url,
           );
+          // A popup's URL can change before discovery (server redirect, or a
+          // scripted location assignment after window.open()), so an exact
+          // URL miss must not leave a queued entry unspent while an unclaimed
+          // tab exists. Fall back to the oldest entry, but only once the
+          // tab's URL has settled — attaching mid-navigation races the
+          // client's page init against the commit and can leave the page
+          // stuck on a stale URL — or once the deadline is imminent, so
+          // popups that never navigate (bare window.open()) are not lost.
+          // Concurrent redirecting popups may then pair with the wrong
+          // opener, which is still better than losing the popup.
           if (index === -1) {
-            index = queue.findIndex(
-              (entry) => typeof entry.expectedUrl !== "string",
-            );
+            const settled =
+              typeof tab.url === "string" && tab.url !== "" && polls >= 3;
+            if (!settled && !deadlineImminent) continue;
+            index = 0;
           }
-          if (index === -1) continue;
           const [entry] = queue.splice(index, 1);
           this.#targetIds!.add(targetId);
           await this.#attachTaskSpaceTarget(targetId, entry.openerTargetId);
@@ -1261,10 +1289,16 @@ export class EgoCdpTransport {
     this.#routesByNativeTarget.delete(route.nativeTargetId);
     this.#sessionsByTarget.delete(route.nativeTargetId);
     this.#targetsBySession.delete(route.nativeSessionId);
+    // The task-space target set must follow the swap: the replacement tab is
+    // ours now, and the retired tab must not linger as an admission ticket.
+    // Without this, popup discovery mistakes the route's own new tab for an
+    // unclaimed popup.
+    this.#targetIds?.delete(route.nativeTargetId);
     route.nativeTargetId = nativeTargetId;
     route.nativeSessionId = nativeSessionId;
     route.nativeMainFrameId = nativeMainFrameId;
     route.generation += 1;
+    this.#targetIds?.add(nativeTargetId);
     this.#routesByNativeSession.set(nativeSessionId, route);
     this.#routesByNativeTarget.set(nativeTargetId, route);
     this.#sessionsByTarget.set(nativeTargetId, nativeSessionId);
@@ -1807,6 +1841,9 @@ export class EgoCdpTransport {
       if (route) this.#removeRoute(route);
       if (typeof nativeTargetId === "string") {
         this.#sessionsByTarget.delete(nativeTargetId);
+        // After a navigation replacement the native id differs from the
+        // client id; drop both from the task-space set.
+        this.#targetIds?.delete(nativeTargetId);
       }
       if (nativeSessionId) this.#targetsBySession.delete(nativeSessionId);
       if (typeof clientTargetId === "string") {

--- a/package/ego-browser/src/playwright/taskspace.test.mjs
+++ b/package/ego-browser/src/playwright/taskspace.test.mjs
@@ -165,11 +165,48 @@ test("the Playwright connector creates a fresh Browser connection for each selec
 
   assert.equal(first.page, firstPage);
   assert.equal(second.page, secondPage);
-  assert.equal(first.close, second.close);
   assert.equal(connectCalls, 2);
   assert.equal(browserCloseCalls, 1);
   await second.close();
   assert.equal(browserCloseCalls, 2);
+});
+
+test("closing a superseded session does not close the current one", async () => {
+  const closes = [];
+  let browserSeq = 0;
+  const connector = playwrightTaskSpace.createPlaywrightTaskSpaceConnector({
+    runtime: () => ({
+      async listTabs() {
+        return { tabs: [{ targetId: "target-1", active: true }] };
+      },
+    }),
+    transport: async () => ({ connectToken: "ws+ego://transport/test" }),
+    connectOverCDP: async () => {
+      const id = ++browserSeq;
+      return {
+        contexts() {
+          return [{ pages: () => [{ id }] }];
+        },
+        async close() {
+          closes.push(`browser-${id}`);
+        },
+      };
+    },
+  });
+
+  const first = await connector({ id: 1 });
+  const second = await connector({ id: 1 });
+  assert.deepEqual(closes, ["browser-1"]);
+
+  await first.close();
+  assert.deepEqual(
+    closes,
+    ["browser-1"],
+    "a stale session close must not close the current session's browser",
+  );
+
+  await second.close();
+  assert.deepEqual(closes, ["browser-1", "browser-2"]);
 });
 
 test("the Playwright connector recreates the transport when the same TaskSpace is selected again", async () => {

--- a/package/ego-browser/src/playwright/taskspace.ts
+++ b/package/ego-browser/src/playwright/taskspace.ts
@@ -66,24 +66,10 @@ let patchedSetTimeout: typeof globalThis.setTimeout | undefined;
 export function createPlaywrightTaskSpaceConnector(
   dependencies: PlaywrightConnectorDependencies,
 ): PlaywrightTaskSpaceConnector {
-  let browser: Browser | undefined;
-  let closeTransport: (() => Promise<void>) | undefined;
-
-  const close = async () => {
-    const currentBrowser = browser;
-    const currentTransportClose = closeTransport;
-    browser = undefined;
-    closeTransport = undefined;
-    if (currentTransportClose) {
-      try {
-        await currentTransportClose();
-      } finally {
-        await currentBrowser?.close();
-      }
-    } else {
-      await currentBrowser?.close();
-    }
-  };
+  // The closer of the session currently owning the connection. Each session
+  // gets its own close closure over its own browser/transport, so a stale
+  // session handle can never tear down a newer session's resources.
+  let closeCurrent: (() => Promise<void>) | undefined;
 
   return async (space) => {
     const runtime = dependencies.runtime();
@@ -91,11 +77,36 @@ export function createPlaywrightTaskSpaceConnector(
       throw new Error("Playwright TaskSpace requires ego.listTabs");
     }
 
+    if (closeCurrent) {
+      const closePrevious = closeCurrent;
+      closeCurrent = undefined;
+      await closePrevious();
+    }
+
+    let browser: Browser | undefined;
+    let closeTransport: (() => Promise<void>) | undefined;
+    const closeSession = async () => {
+      if (closeCurrent === closeSession) closeCurrent = undefined;
+      const currentBrowser = browser;
+      const currentTransportClose = closeTransport;
+      browser = undefined;
+      closeTransport = undefined;
+      if (currentTransportClose) {
+        try {
+          await currentTransportClose();
+        } finally {
+          await currentBrowser?.close();
+        }
+      } else {
+        await currentBrowser?.close();
+      }
+    };
+
     try {
-      if (browser) await close();
       const transport = await dependencies.transport(runtime, space);
       closeTransport = transport.close;
       browser = await dependencies.connectOverCDP(transport.connectToken);
+      closeCurrent = closeSession;
       transport.connected?.();
       const listed = await runtime.listTabs();
       const nativeTabs = listed.tabs || listed.targetInfos || [];
@@ -109,10 +120,10 @@ export function createPlaywrightTaskSpaceConnector(
       return {
         page: located.page,
         context: located.context,
-        close,
+        close: closeSession,
       };
     } catch (error) {
-      await close();
+      await closeSession();
       throw error;
     }
   };
@@ -153,9 +164,13 @@ function installPlaywrightFrameTimerUnref() {
   if (playwrightTimerPatchUsers === 1) {
     originalSetTimeout = globalThis.setTimeout;
     patchedSetTimeout = ((callback, delay, ...args) => {
-      const stack = new Error().stack;
       const timer = originalSetTimeout!(callback, delay, ...args);
-      if (isPlaywrightFrameThrottlerTimer(delay, stack)) timer.unref?.();
+      // Capture the stack only for candidate delays; unconditional capture
+      // taxes every setTimeout in the process while the patch is installed.
+      if (delay === 35 || delay === 200) {
+        const stack = new Error().stack;
+        if (isPlaywrightFrameThrottlerTimer(delay, stack)) timer.unref?.();
+      }
       return timer;
     }) as typeof globalThis.setTimeout;
     globalThis.setTimeout = patchedSetTimeout;

--- a/package/ego-browser/src/taskspace-lease.test.mjs
+++ b/package/ego-browser/src/taskspace-lease.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -167,15 +167,104 @@ test("re-acquiring the TaskSpace already held by this session is a no-op", async
   }
 });
 
-test("an incomplete lease directory is reclaimed without an audit trail", async () => {
+test("an abandoned incomplete lease directory is reclaimed without an audit trail", async () => {
   const lockRoot = await mkdtemp(
     join(tmpdir(), "ego-browser-incomplete-lease-test-"),
   );
   const id = 2_147_483_005;
+  const leasePath = join(lockRoot, String(id));
+  await mkdir(leasePath);
+  // Backdate the directory past any grace window: this is a crashed acquire's
+  // leftover, not an acquire that is still publishing its owner file.
+  const past = new Date(Date.now() - 60_000);
+  await utimes(leasePath, past, past);
+
+  try {
+    const started = Date.now();
+    assert.equal(await acquireTaskSpaceLease(id, { lockRoot }), true);
+    assert.ok(
+      Date.now() - started < 2_000,
+      "an abandoned incomplete directory is reclaimed promptly",
+    );
+    assert.equal(readOwnerFile(lockRoot, id).takenOverFrom, undefined);
+  } finally {
+    releaseTaskSpaceLease();
+    await rm(lockRoot, { recursive: true, force: true });
+  }
+});
+
+test("an acquire caught between mkdir and publish is taken over, not destroyed", async () => {
+  const lockRoot = await mkdtemp(
+    join(tmpdir(), "ego-browser-inflight-lease-test-"),
+  );
+  const id = 2_147_483_009;
+  const leasePath = join(lockRoot, String(id));
+  // Another session's acquire has created the directory but not yet written
+  // owner.json — the window between mkdirSync and the owner publish.
+  await mkdir(leasePath);
+  const publishDelayMs = 150;
+  const publisher = setTimeout(() => {
+    writeFile(
+      join(leasePath, "owner.json"),
+      JSON.stringify({
+        heartbeatIntervalMs: 25,
+        pid: process.pid,
+        staleAfterMs: 3_000,
+        threadId: 0,
+        token: "publisher-token",
+      }),
+    ).catch(() => {});
+    writeFile(join(leasePath, "heartbeat-publisher-token"), "").catch(() => {});
+  }, publishDelayMs);
+
+  try {
+    const started = Date.now();
+    assert.equal(
+      await acquireTaskSpaceLease(id, {
+        lockRoot,
+        heartbeatIntervalMs: 25,
+        staleAfterMs: 3_000,
+      }),
+      true,
+    );
+    assert.ok(
+      Date.now() - started >= publishDelayMs - 50,
+      "the contender waits for the in-flight publish instead of racing it",
+    );
+    assert.equal(
+      readOwnerFile(lockRoot, id).takenOverFrom?.token,
+      "publisher-token",
+      "the settled owner is taken over with an audit trail, not silently destroyed",
+    );
+  } finally {
+    clearTimeout(publisher);
+    releaseTaskSpaceLease();
+    await rm(lockRoot, { recursive: true, force: true });
+  }
+});
+
+test("a fresh incomplete lease directory is reclaimed only after the grace window", async () => {
+  const lockRoot = await mkdtemp(
+    join(tmpdir(), "ego-browser-grace-lease-test-"),
+  );
+  const id = 2_147_483_010;
   await mkdir(join(lockRoot, String(id)));
 
   try {
-    assert.equal(await acquireTaskSpaceLease(id, { lockRoot }), true);
+    const started = Date.now();
+    assert.equal(
+      await acquireTaskSpaceLease(id, {
+        lockRoot,
+        heartbeatIntervalMs: 25,
+        staleAfterMs: 200,
+      }),
+      true,
+    );
+    const elapsed = Date.now() - started;
+    assert.ok(
+      elapsed >= 150,
+      `a fresh incomplete directory gets the grace window (elapsed ${elapsed}ms)`,
+    );
     assert.equal(readOwnerFile(lockRoot, id).takenOverFrom, undefined);
   } finally {
     releaseTaskSpaceLease();

--- a/package/ego-browser/src/taskspace-lease.test.mjs
+++ b/package/ego-browser/src/taskspace-lease.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,7 +22,11 @@ const modulePath = fileURLToPath(
   new URL("../dist/src/taskspace-lease.js", import.meta.url),
 );
 
-test("a live process exclusively owns a TaskSpace lease and a dead owner is recoverable", async () => {
+function readOwnerFile(lockRoot, id) {
+  return JSON.parse(readFileSync(join(lockRoot, String(id), "owner.json")));
+}
+
+test("an acquire takes over a live holder in another process and notifies it", async () => {
   const lockRoot = await mkdtemp(join(tmpdir(), "ego-browser-lease-test-"));
   const child = spawn(
     process.execPath,
@@ -29,8 +34,16 @@ test("a live process exclusively owns a TaskSpace lease and a dead owner is reco
       "--input-type=module",
       "-e",
       `
-        import { acquireTaskSpaceLease } from ${JSON.stringify(modulePath)};
-        await acquireTaskSpaceLease(622, { lockRoot: ${JSON.stringify(lockRoot)} });
+        import { acquireTaskSpaceLease, onTaskSpaceLeaseLost } from ${JSON.stringify(modulePath)};
+        onTaskSpaceLeaseLost(({ id }) => {
+          process.stdout.write("lost:" + id + "\\n");
+          process.exit(43);
+        });
+        await acquireTaskSpaceLease(622, {
+          heartbeatIntervalMs: 25,
+          lockRoot: ${JSON.stringify(lockRoot)},
+          staleAfterMs: 200,
+        });
         process.stdout.write("ready\\n");
         setInterval(() => {}, 1000);
       `,
@@ -40,16 +53,15 @@ test("a live process exclusively owns a TaskSpace lease and a dead owner is reco
 
   try {
     await waitForLine(child.stdout, "ready");
+    const lostNotice = waitForLine(child.stdout, "lost:622");
 
-    await assert.rejects(
-      () => acquireTaskSpaceLease(622, { lockRoot }),
-      /TaskSpace 622 is already controlled by another ego-browser process/,
-    );
+    assert.equal(await acquireTaskSpaceLease(622, { lockRoot }), true);
+    const owner = readOwnerFile(lockRoot, 622);
+    assert.equal(owner.takenOverFrom?.pid, child.pid);
 
-    child.kill("SIGKILL");
-    await new Promise((resolve) => child.once("close", resolve));
-
-    await assert.doesNotReject(() => acquireTaskSpaceLease(622, { lockRoot }));
+    await lostNotice;
+    const code = await new Promise((resolve) => child.once("close", resolve));
+    assert.equal(code, 43);
   } finally {
     child.kill("SIGKILL");
     releaseTaskSpaceLease();
@@ -57,7 +69,7 @@ test("a live process exclusively owns a TaskSpace lease and a dead owner is reco
   }
 });
 
-test("a dead worker lease is recoverable while the shared host process stays alive", async () => {
+test("an acquire takes over a worker holder inside the shared host process", async () => {
   const lockRoot = await mkdtemp(
     join(tmpdir(), "ego-browser-worker-lease-test-"),
   );
@@ -66,7 +78,8 @@ test("a dead worker lease is recoverable while the shared host process stays ali
     `
       const { parentPort } = require("node:worker_threads");
       (async () => {
-        const { acquireTaskSpaceLease } = await import(${JSON.stringify(modulePath)});
+        const { acquireTaskSpaceLease, onTaskSpaceLeaseLost } = await import(${JSON.stringify(modulePath)});
+        onTaskSpaceLeaseLost((lost) => parentPort.postMessage({ lost: lost.id }));
         await acquireTaskSpaceLease(${id}, {
           heartbeatIntervalMs: 20,
           lockRoot: ${JSON.stringify(lockRoot)},
@@ -87,17 +100,11 @@ test("a dead worker lease is recoverable while the shared host process stays ali
     if (ready.error) throw new Error(ready.error);
     assert.equal(ready.pid, process.pid);
 
-    await assert.rejects(
-      async () => acquireTaskSpaceLease(id, { lockRoot }),
-      /already controlled by another ego-browser process/,
-    );
+    assert.equal(await acquireTaskSpaceLease(id, { lockRoot }), true);
+    assert.equal(readOwnerFile(lockRoot, id).takenOverFrom?.pid, process.pid);
 
-    await worker.terminate();
-    await new Promise((resolve) => setTimeout(resolve, 150));
-
-    await assert.doesNotReject(async () =>
-      acquireTaskSpaceLease(id, { lockRoot }),
-    );
+    const lost = await waitForWorkerMessage(worker);
+    assert.equal(lost.lost, id);
   } finally {
     await worker.terminate();
     releaseTaskSpaceLease();
@@ -105,7 +112,7 @@ test("a dead worker lease is recoverable while the shared host process stays ali
   }
 });
 
-test("a live but busy worker does not lose its TaskSpace lease", async () => {
+test("a busy holder is taken over and notified once it unblocks", async () => {
   const lockRoot = await mkdtemp(
     join(tmpdir(), "ego-browser-busy-lease-test-"),
   );
@@ -114,10 +121,15 @@ test("a live but busy worker does not lose its TaskSpace lease", async () => {
     `
       const { parentPort } = require("node:worker_threads");
       (async () => {
-        const { acquireTaskSpaceLease } = await import(${JSON.stringify(modulePath)});
-        await acquireTaskSpaceLease(${id}, { lockRoot: ${JSON.stringify(lockRoot)} });
+        const { acquireTaskSpaceLease, onTaskSpaceLeaseLost } = await import(${JSON.stringify(modulePath)});
+        onTaskSpaceLeaseLost((lost) => parentPort.postMessage({ lost: lost.id }));
+        await acquireTaskSpaceLease(${id}, {
+          heartbeatIntervalMs: 20,
+          lockRoot: ${JSON.stringify(lockRoot)},
+          staleAfterMs: 100,
+        });
         parentPort.postMessage("ready");
-        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10_000);
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
         setInterval(() => {}, 1_000);
       })().catch((error) => {
         parentPort.postMessage({ error: error?.stack || String(error) });
@@ -128,10 +140,9 @@ test("a live but busy worker does not lose its TaskSpace lease", async () => {
 
   try {
     assert.equal(await waitForWorkerMessage(worker), "ready");
-    await assert.rejects(
-      () => acquireTaskSpaceLease(id, { lockRoot }),
-      /already controlled by another ego-browser process/,
-    );
+    assert.equal(await acquireTaskSpaceLease(id, { lockRoot }), true);
+    const lost = await waitForWorkerMessage(worker);
+    assert.equal(lost.lost, id);
   } finally {
     await worker.terminate();
     releaseTaskSpaceLease();
@@ -139,58 +150,56 @@ test("a live but busy worker does not lose its TaskSpace lease", async () => {
   }
 });
 
-test("a live isolated worker keeps its lease without cross-worker messaging", async () => {
+test("re-acquiring the TaskSpace already held by this session is a no-op", async () => {
   const lockRoot = await mkdtemp(
-    join(tmpdir(), "ego-browser-isolated-lease-test-"),
+    join(tmpdir(), "ego-browser-reacquire-lease-test-"),
   );
   const id = 2_147_483_004;
-  const worker = new Worker(
-    `
-      const { parentPort } = require("node:worker_threads");
-      (async () => {
-        const { acquireTaskSpaceLease } = await import(${JSON.stringify(modulePath)});
-        await acquireTaskSpaceLease(${id}, { lockRoot: ${JSON.stringify(lockRoot)} });
-        process.removeAllListeners("workerMessage");
-        parentPort.postMessage("ready");
-        setInterval(() => {}, 1_000);
-      })().catch((error) => {
-        parentPort.postMessage({ error: error?.stack || String(error) });
-      });
-    `,
-    { eval: true },
-  );
 
   try {
-    assert.equal(await waitForWorkerMessage(worker), "ready");
-    await assert.rejects(
-      () => acquireTaskSpaceLease(id, { lockRoot }),
-      /already controlled by another ego-browser process/,
-    );
+    assert.equal(await acquireTaskSpaceLease(id, { lockRoot }), true);
+    const owner = readOwnerFile(lockRoot, id);
+    assert.equal(await acquireTaskSpaceLease(id, { lockRoot }), false);
+    assert.equal(readOwnerFile(lockRoot, id).token, owner.token);
   } finally {
-    await worker.terminate();
     releaseTaskSpaceLease();
     await rm(lockRoot, { recursive: true, force: true });
   }
 });
 
-test("a live pre-heartbeat lease is not reclaimed during an SDK upgrade", async () => {
+test("an incomplete lease directory is reclaimed without an audit trail", async () => {
+  const lockRoot = await mkdtemp(
+    join(tmpdir(), "ego-browser-incomplete-lease-test-"),
+  );
+  const id = 2_147_483_005;
+  await mkdir(join(lockRoot, String(id)));
+
+  try {
+    assert.equal(await acquireTaskSpaceLease(id, { lockRoot }), true);
+    assert.equal(readOwnerFile(lockRoot, id).takenOverFrom, undefined);
+  } finally {
+    releaseTaskSpaceLease();
+    await rm(lockRoot, { recursive: true, force: true });
+  }
+});
+
+test("a legacy pre-heartbeat lease is taken over with an audit trail", async () => {
   const lockRoot = await mkdtemp(
     join(tmpdir(), "ego-browser-legacy-lease-test-"),
   );
-  const id = 2_147_483_005;
+  const id = 2_147_483_006;
   const leasePath = join(lockRoot, String(id));
   await mkdir(leasePath);
   await writeFile(
     join(leasePath, "owner.json"),
     JSON.stringify({ pid: process.pid, threadId: 0, token: "legacy-owner" }),
   );
-  const old = new Date(Date.now() - 60_000);
-  await utimes(leasePath, old, old);
 
   try {
-    await assert.rejects(
-      () => acquireTaskSpaceLease(id, { lockRoot }),
-      /already controlled by another ego-browser process/,
+    assert.equal(await acquireTaskSpaceLease(id, { lockRoot }), true);
+    assert.equal(
+      readOwnerFile(lockRoot, id).takenOverFrom?.token,
+      "legacy-owner",
     );
   } finally {
     releaseTaskSpaceLease();
@@ -198,7 +207,7 @@ test("a live pre-heartbeat lease is not reclaimed during an SDK upgrade", async 
   }
 });
 
-test("switchTaskSpace rejects a concurrent process before native selection", async () => {
+test("switchTaskSpace takes over a concurrent session before native selection", async () => {
   const id = 2_147_483_001;
   const child = spawn(
     process.execPath,
@@ -206,8 +215,9 @@ test("switchTaskSpace rejects a concurrent process before native selection", asy
       "--input-type=module",
       "-e",
       `
-        import { acquireTaskSpaceLease } from ${JSON.stringify(modulePath)};
-        await acquireTaskSpaceLease(${id});
+        import { acquireTaskSpaceLease, onTaskSpaceLeaseLost } from ${JSON.stringify(modulePath)};
+        onTaskSpaceLeaseLost(() => process.exit(43));
+        await acquireTaskSpaceLease(${id}, { heartbeatIntervalMs: 25, staleAfterMs: 200 });
         process.stdout.write("ready\\n");
         setInterval(() => {}, 1000);
       `,
@@ -237,22 +247,20 @@ test("switchTaskSpace rejects a concurrent process before native selection", asy
       },
     };
 
-    await assert.rejects(
-      () => switchTaskSpace(id),
-      /already controlled by another ego-browser process/,
-    );
-    assert.equal(nativeSelections, 0);
+    await switchTaskSpace(id);
+    assert.equal(nativeSelections, 1);
+
+    const code = await new Promise((resolve) => child.once("close", resolve));
+    assert.equal(code, 43);
   } finally {
     globalThis.ego = previousEgo;
     child.kill("SIGKILL");
-    await new Promise((resolve) => child.once("close", resolve));
-    await acquireTaskSpaceLease(id);
     releaseTaskSpaceLease(id);
   }
 });
 
 test("a failed Playwright reconnect releases the selected TaskSpace lease", async () => {
-  const id = 2_147_483_006;
+  const id = 2_147_483_007;
   const previousEgo = globalThis.ego;
   const restoreConnector = __testing.setPlaywrightTaskSpaceConnector(
     async () => {
@@ -284,7 +292,16 @@ test("a failed Playwright reconnect releases the selected TaskSpace lease", asyn
 
     const child = await runChild(`
       import { acquireTaskSpaceLease, releaseTaskSpaceLease } from ${JSON.stringify(modulePath)};
+      import { readFileSync } from "node:fs";
+      import { tmpdir } from "node:os";
+      import { join } from "node:path";
       await acquireTaskSpaceLease(${id});
+      const root = join(tmpdir(), "ego-browser-taskspace-leases-" + process.getuid());
+      const owner = JSON.parse(readFileSync(join(root, "${id}", "owner.json")));
+      if (owner.takenOverFrom) {
+        console.error("lease was not released: " + JSON.stringify(owner.takenOverFrom));
+        process.exit(7);
+      }
       releaseTaskSpaceLease(${id});
     `);
     assert.equal(child.code, 0, child.stderr);
@@ -296,7 +313,7 @@ test("a failed Playwright reconnect releases the selected TaskSpace lease", asyn
 });
 
 test("a failed same-TaskSpace reselection releases the previous lease", async () => {
-  const id = 2_147_483_007;
+  const id = 2_147_483_008;
   const previousEgo = globalThis.ego;
   let selectionCount = 0;
   const restoreConnector = __testing.setPlaywrightTaskSpaceConnector(
@@ -334,7 +351,16 @@ test("a failed same-TaskSpace reselection releases the previous lease", async ()
 
     const child = await runChild(`
       import { acquireTaskSpaceLease, releaseTaskSpaceLease } from ${JSON.stringify(modulePath)};
+      import { readFileSync } from "node:fs";
+      import { tmpdir } from "node:os";
+      import { join } from "node:path";
       await acquireTaskSpaceLease(${id});
+      const root = join(tmpdir(), "ego-browser-taskspace-leases-" + process.getuid());
+      const owner = JSON.parse(readFileSync(join(root, "${id}", "owner.json")));
+      if (owner.takenOverFrom) {
+        console.error("lease was not released: " + JSON.stringify(owner.takenOverFrom));
+        process.exit(7);
+      }
       releaseTaskSpaceLease(${id});
     `);
     assert.equal(child.code, 0, child.stderr);

--- a/package/ego-browser/src/taskspace-lease.ts
+++ b/package/ego-browser/src/taskspace-lease.ts
@@ -89,21 +89,42 @@ export async function acquireTaskSpaceLease(
     );
   }
   let takenOverFrom: TakenOverFrom | undefined;
-  for (let round = 0; ; round += 1) {
+  let reclaimRounds = 0;
+  let incompleteWaitDeadline: number | undefined;
+  while (true) {
     try {
       mkdirSync(path, { mode: 0o700 });
     } catch (error) {
       if (error?.code !== "EEXIST") throw error;
-      if (round >= MAX_TAKEOVER_ROUNDS) {
+      if (reclaimRounds >= MAX_TAKEOVER_ROUNDS) {
         throw new Error(
           `TaskSpace ${id} lease takeover did not settle after ${MAX_TAKEOVER_ROUNDS} rounds`,
         );
+      }
+      const owner = readOwner(path);
+      if (!owner) {
+        // A directory without owner.json is another acquire caught between
+        // mkdir and its owner publish. Give it staleAfterMs to finish before
+        // treating it as abandoned — reclaiming mid-publish strands both
+        // sessions: this one deletes the directory the other is writing into.
+        const age = leaseDirAgeMs(path);
+        incompleteWaitDeadline ??= Date.now() + staleAfterMs;
+        if (
+          age !== undefined &&
+          age < staleAfterMs &&
+          Date.now() < incompleteWaitDeadline
+        ) {
+          await new Promise<void>((resolve) =>
+            setTimeout(resolve, Math.min(50, heartbeatIntervalMs)),
+          );
+          continue;
+        }
       }
       // Newest session wins: reclaim whatever is there, keeping the previous
       // owner as an audit trail. The previous session's heartbeat notices the
       // foreign token within one interval and stops itself through the
       // lease-lost handler.
-      const owner = readOwner(path);
+      reclaimRounds += 1;
       const heartbeatAgeMs = ownerHeartbeatAgeMs(path, owner);
       if (reclaim(path) && owner) {
         takenOverFrom = {
@@ -144,7 +165,11 @@ export async function acquireTaskSpaceLease(
       releaseHeldLease();
       heldLease = { heartbeatPath, id, path, timer, token };
     } catch (error) {
-      rmSync(path, { recursive: true, force: true });
+      // Clean up only if our own owner file made it in: a failed publish must
+      // not delete a lease directory another session owns by now.
+      if (readOwner(path)?.token === token) {
+        rmSync(path, { recursive: true, force: true });
+      }
       throw error;
     }
 
@@ -202,6 +227,14 @@ function ownerHeartbeatAgeMs(path: string, owner: LeaseOwner | undefined) {
   try {
     const heartbeat = statSync(join(path, `heartbeat-${owner.token}`));
     return Math.max(0, Date.now() - heartbeat.mtimeMs);
+  } catch {
+    return undefined;
+  }
+}
+
+function leaseDirAgeMs(path: string) {
+  try {
+    return Math.max(0, Date.now() - statSync(path).mtimeMs);
   } catch {
     return undefined;
   }

--- a/package/ego-browser/src/taskspace-lease.ts
+++ b/package/ego-browser/src/taskspace-lease.ts
@@ -34,11 +34,32 @@ type LeaseOwner = {
   token: string;
 };
 
-const INCOMPLETE_LEASE_GRACE_MS = 5000;
+type TakenOverFrom = {
+  heartbeatAgeMs?: number;
+  pid: number;
+  threadId?: number;
+  token: string;
+};
+
+type LeaseLostHandler = (lost: { id: number }) => void;
+
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 1000;
 const DEFAULT_STALE_AFTER_MS = 5000;
+// A takeover normally needs exactly one reclaim round; more means another
+// session is racing us for the same TaskSpace, and the last writer wins.
+const MAX_TAKEOVER_ROUNDS = 5;
 let heldLease: HeldLease | undefined;
 let exitHookInstalled = false;
+let leaseLostHandler: LeaseLostHandler | undefined;
+
+/**
+ * Register the handler invoked when a newer session takes over this session's
+ * TaskSpace lease. The heartbeat detects the foreign owner within one
+ * interval; the handler must stop this session from driving the TaskSpace.
+ */
+export function onTaskSpaceLeaseLost(handler?: LeaseLostHandler) {
+  leaseLostHandler = handler;
+}
 
 export async function acquireTaskSpaceLease(
   id: number,
@@ -67,17 +88,30 @@ export async function acquireTaskSpaceLease(
       "TaskSpace lease requires staleAfterMs greater than heartbeatIntervalMs",
     );
   }
-  while (true) {
+  let takenOverFrom: TakenOverFrom | undefined;
+  for (let round = 0; ; round += 1) {
     try {
       mkdirSync(path, { mode: 0o700 });
     } catch (error) {
       if (error?.code !== "EEXIST") throw error;
-      const owner = readOwner(path);
-      if (!(await isStale(path, owner)) || !reclaim(path)) {
-        const ownerLabel = owner?.pid ? ` (pid ${owner.pid})` : "";
+      if (round >= MAX_TAKEOVER_ROUNDS) {
         throw new Error(
-          `TaskSpace ${id} is already controlled by another ego-browser process${ownerLabel}`,
+          `TaskSpace ${id} lease takeover did not settle after ${MAX_TAKEOVER_ROUNDS} rounds`,
         );
+      }
+      // Newest session wins: reclaim whatever is there, keeping the previous
+      // owner as an audit trail. The previous session's heartbeat notices the
+      // foreign token within one interval and stops itself through the
+      // lease-lost handler.
+      const owner = readOwner(path);
+      const heartbeatAgeMs = ownerHeartbeatAgeMs(path, owner);
+      if (reclaim(path) && owner) {
+        takenOverFrom = {
+          ...(heartbeatAgeMs === undefined ? {} : { heartbeatAgeMs }),
+          pid: owner.pid,
+          threadId: owner.threadId,
+          token: owner.token,
+        };
       }
       continue;
     }
@@ -88,7 +122,9 @@ export async function acquireTaskSpaceLease(
         JSON.stringify({
           heartbeatIntervalMs,
           pid: process.pid,
+          since: new Date().toISOString(),
           staleAfterMs,
+          ...(takenOverFrom ? { takenOverFrom } : {}),
           threadId,
           token,
         }),
@@ -112,6 +148,19 @@ export async function acquireTaskSpaceLease(
       throw error;
     }
 
+    if (takenOverFrom) {
+      const age =
+        takenOverFrom.heartbeatAgeMs === undefined
+          ? ""
+          : ` (heartbeat ${Math.round(takenOverFrom.heartbeatAgeMs / 1000)}s old)`;
+      // console.log, not console.error: in SDK mode only console.log is routed
+      // to the agent-visible output channel; stderr never leaves the runtime.
+      console.log(
+        `[ego-browser] TaskSpace ${id}: took over the lease from session ` +
+          `${takenOverFrom.token.slice(0, 8)}${age}; if that session is still ` +
+          "running it will stop shortly.",
+      );
+    }
     installExitHook();
     return true;
   }
@@ -148,40 +197,13 @@ function readOwner(path: string): LeaseOwner | undefined {
   return undefined;
 }
 
-async function isStale(path: string, owner: LeaseOwner | undefined) {
-  if (owner) {
-    if (!isProcessAlive(owner.pid)) return true;
-    if (
-      owner.heartbeatIntervalMs === undefined ||
-      owner.staleAfterMs === undefined
-    ) {
-      return false;
-    }
-    const staleAfterMs = owner.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
-    try {
-      const heartbeat = statSync(join(path, `heartbeat-${owner.token}`));
-      return Date.now() - heartbeat.mtimeMs > staleAfterMs;
-    } catch {
-      try {
-        return Date.now() - statSync(path).mtimeMs > staleAfterMs;
-      } catch {
-        return true;
-      }
-    }
-  }
+function ownerHeartbeatAgeMs(path: string, owner: LeaseOwner | undefined) {
+  if (!owner) return undefined;
   try {
-    return Date.now() - statSync(path).mtimeMs > INCOMPLETE_LEASE_GRACE_MS;
+    const heartbeat = statSync(join(path, `heartbeat-${owner.token}`));
+    return Math.max(0, Date.now() - heartbeat.mtimeMs);
   } catch {
-    return true;
-  }
-}
-
-function isProcessAlive(pid: number) {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return error?.code !== "ESRCH";
+    return undefined;
   }
 }
 
@@ -206,16 +228,25 @@ function releaseHeldLease() {
   rmSync(lease.path, { recursive: true, force: true });
 }
 
+function loseHeldLease(token: string) {
+  if (heldLease?.token !== token) return;
+  const { id } = heldLease;
+  releaseHeldLease();
+  try {
+    leaseLostHandler?.({ id });
+  } catch {}
+}
+
 function refreshHeartbeat(path: string, heartbeatPath: string, token: string) {
   if (readOwner(path)?.token !== token) {
-    if (heldLease?.token === token) releaseHeldLease();
+    loseHeldLease(token);
     return;
   }
   try {
     const now = new Date();
     utimesSync(heartbeatPath, now, now);
   } catch {
-    if (heldLease?.token === token) releaseHeldLease();
+    loseHeldLease(token);
   }
 }
 

--- a/package/ego-browser/test/real-browser-e2e/ego-source.mjs
+++ b/package/ego-browser/test/real-browser-e2e/ego-source.mjs
@@ -19,6 +19,7 @@ export function egoSource(body, context) {
     ffprobePath,
     metadataPath,
     xmlParserUrl,
+    pixelToolsUrl,
     keepTaskSpace,
     caseResultPath,
     commandCancelPath,
@@ -42,6 +43,7 @@ export function egoSource(body, context) {
     const ffprobePath = ${JSON.stringify(ffprobePath)};
     const metadataPath = ${JSON.stringify(metadataPath)};
     const xmlParserUrl = ${JSON.stringify(xmlParserUrl)};
+    const pixelToolsUrl = ${JSON.stringify(pixelToolsUrl)};
     const keepTaskSpace = ${JSON.stringify(keepTaskSpace)};
     const caseResultPath = ${JSON.stringify(caseResultPath)};
     const commandCancelPath = ${JSON.stringify(commandCancelPath)};

--- a/package/ego-browser/test/real-browser-e2e/policy.test.js
+++ b/package/ego-browser/test/real-browser-e2e/policy.test.js
@@ -7,6 +7,7 @@ import { TEST_CASES } from "./site/test-cases.mjs";
 import { e2eCases } from "./suites/index.mjs";
 import { taskSpaceControlCase } from "./suites/platform/taskspace-control.mjs";
 import { scenarioCases } from "./suites/scenarios/index.mjs";
+import { visualPathScenarioCase } from "./suites/scenarios/visual-path.mjs";
 import * as runner from "./runner.mjs";
 
 const expectedWebTestRoutes = TEST_CASES.map((testCase) => testCase.route);
@@ -305,6 +306,20 @@ test("every scenario observes page state before a mutating browser action", () =
     assert.doesNotMatch(operations, directLocatorAction, testCase.name);
     assert.doesNotMatch(operations, directInputAction, testCase.name);
   }
+});
+
+test("the visual-path journey takes every coordinate from screenshot pixels", () => {
+  const source = visualPathScenarioCase.body();
+  const operations = source.slice(source.indexOf("/* scenario operations */"));
+
+  assert.match(operations, /locateSwatch\(/);
+  assert.match(operations, /toCssPoint\(/);
+  // Reading a result back through a test id is fine; asking the layout where a
+  // target sits is not, because that turns this into another semantic case.
+  assert.doesNotMatch(
+    operations,
+    /boundingBox\(|getBoundingClientRect\(|scrollIntoView/,
+  );
 });
 
 test("task-space keep mode does not create a destructively closed scratch space", () => {

--- a/package/ego-browser/test/real-browser-e2e/policy.test.js
+++ b/package/ego-browser/test/real-browser-e2e/policy.test.js
@@ -424,15 +424,15 @@ test("native task-space close regression remains a dedicated opt-in e2e", () => 
   assert.match(source, /restoredOriginal\.page\.goto/);
 });
 
-test("TaskSpace process contention covers live rejection and timeout recovery", () => {
+test("TaskSpace process contention covers a live takeover and recovery", () => {
   const contention = e2eCases.find(
     (testCase) => testCase.name === "TaskSpace process contention",
   );
 
   assert.ok(contention);
-  assert.equal(contention.optIn, true);
+  assert.notEqual(contention.optIn, true);
   assert.equal(contention.processContention, true);
-  assert.equal(contention.holderTimeoutMs, 8_000);
+  assert.equal(contention.holderTimeoutMs, 10_000);
   assert.equal(contention.rounds.length, 4);
 
   const [setup, holder, contender, recovery] = contention.rounds.map((round) =>
@@ -442,16 +442,19 @@ test("TaskSpace process contention covers live rejection and timeout recovery", 
   assert.match(setup, /process-contention-ready\.json/);
   assert.match(holder, /switchTaskSpace/);
   assert.match(holder, /process-contention-holder-ready\.json/);
-  assert.match(
-    holder,
-    /new Promise\(\(resolve\) => setTimeout\(resolve, 10_000\)\)/,
-  );
-  assert.doesNotMatch(holder, /process-contention-release/);
+  assert.match(holder, /new Promise\(\(\) => \{\}\)/);
+  // The keep-alive interval is load-bearing: a bare unsettled top-level await
+  // exits the process (code 13) and releases the lease before the contender.
+  assert.match(holder, /setInterval/);
+  assert.doesNotMatch(holder, /setTimeout/);
   assert.match(contender, /switchTaskSpace/);
-  assert.match(contender, /already controlled by another ego-browser process/);
-  assert.match(contender, /fails promptly/);
+  assert.doesNotMatch(contender, /already controlled/);
+  assert.match(contender, /takeover completes promptly/);
+  // The audit assert is what separates a real takeover from a free acquire
+  // of an already-released lease.
+  assert.match(contender, /takenOverFrom/);
   assert.match(recovery, /switchTaskSpace/);
-  assert.match(recovery, /recovery timed out/);
+  assert.match(recovery, /remains addressable after the takeover/);
   assert.match(recovery, /accepts new page operations/);
 });
 

--- a/package/ego-browser/test/real-browser-e2e/runner.mjs
+++ b/package/ego-browser/test/real-browser-e2e/runner.mjs
@@ -30,6 +30,7 @@ const runnerDir = dirname(fileURLToPath(import.meta.url));
 const packageDir = join(runnerDir, "..", "..");
 const egoBrowserSdkPath = join(packageDir, "dist", "out", "index.js");
 const xmlParserUrl = import.meta.resolve("fast-xml-parser");
+const pixelToolsUrl = import.meta.resolve("./suites/scenarios/pixel-tools.mjs");
 const egoBrowserArgs = ["nodejs", "--sdk-path", egoBrowserSdkPath];
 const execFileAsync = promisify(execFile);
 export const WEB_LANE_COUNT = 1;
@@ -801,6 +802,7 @@ export async function runRealBrowserE2e() {
       ffprobePath,
       metadataPath,
       xmlParserUrl,
+      pixelToolsUrl,
       taskName,
       tempDir,
       uploadPath,

--- a/package/ego-browser/test/real-browser-e2e/runner.mjs
+++ b/package/ego-browser/test/real-browser-e2e/runner.mjs
@@ -605,12 +605,20 @@ export async function runRealBrowserE2e() {
         });
         holderOutput += holderResult.output || "";
       }
-      if (
-        holderResult.timed_out !== true ||
-        !Number.isInteger(holderResult.exit_code)
-      ) {
+      if (holderResult.timed_out === true) {
         throw new Error(
-          `TaskSpace holder completed without the expected timeout: ${JSON.stringify(holderResult)}`,
+          "TaskSpace holder was still running at its timeout; the takeover did not stop it",
+        );
+      }
+      if (holderResult.exit_code !== 1) {
+        throw new Error(
+          `TaskSpace holder exited with ${holderResult.exit_code} instead of the takeover hard stop`,
+        );
+      }
+      if (!/taken over by a newer ego-browser session/.test(holderOutput)) {
+        throw new Error(
+          "TaskSpace holder output is missing the takeover notice; holder " +
+            `output was: ${JSON.stringify(holderOutput.slice(-2000))}`,
         );
       }
       if (/NodeRuntime disconnected/.test(holderOutput)) {
@@ -618,7 +626,7 @@ export async function runRealBrowserE2e() {
           "holder leaked a raw NodeRuntime disconnect diagnostic",
         );
       }
-      assertionCount += 1;
+      assertionCount += 3;
 
       await waitForNodeRoundToSettle(1_000);
 

--- a/package/ego-browser/test/real-browser-e2e/site/src/components/layout.jsx
+++ b/package/ego-browser/test/real-browser-e2e/site/src/components/layout.jsx
@@ -22,6 +22,7 @@ const interactiveScenarios = new Set([
   "collaborative-docs",
   "spreadsheet",
   "rich-text",
+  "visual-path",
 ]);
 
 export function scenarioModulePath(slug) {

--- a/package/ego-browser/test/real-browser-e2e/site/src/scenarios/index.jsx
+++ b/package/ego-browser/test/real-browser-e2e/site/src/scenarios/index.jsx
@@ -15,6 +15,7 @@ import RichTextSurface from "./rich-text/view.jsx";
 import ScrollSurface from "./scroll/view.jsx";
 import SpreadsheetSurface from "./spreadsheet/view.jsx";
 import UploadsSurface from "./uploads/view.jsx";
+import VisualPathSurface from "./visual-path/view.jsx";
 
 export const surfaces = {
   clicks: ClicksSurface,
@@ -34,4 +35,5 @@ export const surfaces = {
   "collaborative-docs": CollaborativeDocsSurface,
   spreadsheet: SpreadsheetSurface,
   "rich-text": RichTextSurface,
+  "visual-path": VisualPathSurface,
 };

--- a/package/ego-browser/test/real-browser-e2e/site/src/scenarios/visual-path/client.js
+++ b/package/ego-browser/test/real-browser-e2e/site/src/scenarios/visual-path/client.js
@@ -1,0 +1,119 @@
+import {
+  ALL_TARGETS,
+  CANVAS_INK,
+  CANVAS_PAPER,
+  swatchColor,
+  targetById,
+} from "./targets.mjs";
+
+const canvas = document.querySelector("#visual-canvas");
+const context = canvas.getContext("2d");
+const out = (name) => document.querySelector(`[data-testid="${name}"]`);
+const targetsDone = out("visual-targets-done");
+const clickCount = out("visual-click-count");
+const missCount = out("visual-miss-count");
+const strokeCount = out("visual-canvas-strokes");
+const lastClick = out("visual-last-click");
+const viewportReadout = out("visual-viewport");
+
+const marks = document.createElement("div");
+marks.className = "visual-marks";
+marks.dataset.testid = "visual-marks";
+document.body.append(marks);
+
+let clicks = 0;
+let misses = 0;
+let strokes = 0;
+
+function paintCanvas() {
+  context.fillStyle = swatchColor(CANVAS_PAPER);
+  context.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+function render() {
+  const done = document.querySelectorAll('[data-state="done"]').length;
+  targetsDone.textContent = `${done} / ${ALL_TARGETS.length}`;
+  clickCount.textContent = String(clicks);
+  missCount.textContent = String(misses);
+  strokeCount.textContent = String(strokes);
+  viewportReadout.textContent = `${innerWidth}×${innerHeight} · dpr ${devicePixelRatio}`;
+}
+
+function addMark(pageX, pageY, hit) {
+  const mark = document.createElement("div");
+  mark.className = "visual-mark";
+  mark.style.left = `${pageX}px`;
+  mark.style.top = `${pageY}px`;
+  mark.innerHTML = `
+    <svg width="26" height="26" viewBox="0 0 26 26" aria-hidden="true">
+      <circle cx="13" cy="13" r="11" fill="none" stroke="#e5241a" stroke-width="2"
+              ${hit ? "" : 'stroke-dasharray="3 3"'} />
+      <path d="M13 5v6M13 15v6M5 13h6M15 13h6" stroke="#e5241a" stroke-width="2" />
+    </svg>
+    <span class="visual-mark-index">${clicks}</span>`;
+  marks.append(mark);
+}
+
+document.addEventListener(
+  "click",
+  (event) => {
+    if (event.target.closest("#reset-visual")) return;
+    if (!event.target.closest(".visual-path-layout")) return;
+    clicks += 1;
+    const swatch = event.target.closest("[data-target-id]");
+    let hit = null;
+    if (swatch) {
+      hit = swatch.dataset.targetId;
+      const target = targetById(hit);
+      swatch.dataset.state = "done";
+      swatch.style.background = swatchColor(target.done);
+    } else if (event.target === canvas) {
+      hit = "canvas";
+    } else {
+      misses += 1;
+    }
+    addMark(event.pageX, event.pageY, hit);
+    lastClick.textContent = `${event.clientX},${event.clientY} ${hit || "miss"}`;
+    render();
+  },
+  true,
+);
+
+let drawing = false;
+canvas.addEventListener("pointerdown", (event) => {
+  drawing = true;
+  strokes += 1;
+  context.strokeStyle = swatchColor(CANVAS_INK);
+  context.lineWidth = 4;
+  context.lineCap = "round";
+  context.beginPath();
+  context.moveTo(event.offsetX, event.offsetY);
+  render();
+});
+canvas.addEventListener("pointermove", (event) => {
+  if (!drawing) return;
+  context.lineTo(event.offsetX, event.offsetY);
+  context.stroke();
+});
+addEventListener("pointerup", () => {
+  drawing = false;
+});
+
+document.querySelector("#reset-visual").addEventListener("click", () => {
+  marks.replaceChildren();
+  paintCanvas();
+  for (const target of ALL_TARGETS) {
+    const swatch = document.querySelector(`#swatch-${target.id}`);
+    swatch.dataset.state = "pending";
+    swatch.style.background = swatchColor(target.pending);
+  }
+  clicks = 0;
+  misses = 0;
+  strokes = 0;
+  lastClick.textContent = "No click yet";
+  render();
+});
+
+addEventListener("resize", render);
+paintCanvas();
+render();

--- a/package/ego-browser/test/real-browser-e2e/site/src/scenarios/visual-path/targets.mjs
+++ b/package/ego-browser/test/real-browser-e2e/site/src/scenarios/visual-path/targets.mjs
@@ -1,0 +1,87 @@
+// Shared by the rendered fixture and by the visual-path e2e case. That case
+// locates every target from screenshot pixels alone, so both sides have to agree
+// on the exact swatch colours.
+//
+// The colours are near-gray on purpose. Display colour management leaves R=G=B
+// (and values within a step or two of it) byte-identical in a screenshot, while
+// saturated colours drift far: rgb(255,0,0) reads back as rgb(233,46,32) on a P3
+// display. The -1 on the blue channel keeps each swatch distinct from the pure
+// grays that text antialiasing scatters across the page.
+
+export function swatchColor(value) {
+  return `rgb(${value}, ${value}, ${value - 1})`;
+}
+
+export function swatchRgb(value) {
+  return [value, value, value - 1];
+}
+
+// width/height are CSS pixels, gap is the margin before the swatch. Sizes and
+// gaps are deliberately uneven: coordinate error surfaces on the small ones
+// first, and a regular grid would let a wrong-but-consistent offset still land.
+export const PRIMARY_TARGETS = [
+  {
+    id: "alpha",
+    label: "Alpha",
+    width: 208,
+    height: 68,
+    gap: 0,
+    pending: 214,
+    done: 34,
+  },
+  {
+    id: "bravo",
+    label: "Bravo",
+    width: 118,
+    height: 48,
+    gap: 18,
+    pending: 210,
+    done: 38,
+  },
+  {
+    id: "charlie",
+    label: "Charlie",
+    width: 74,
+    height: 34,
+    gap: 92,
+    pending: 206,
+    done: 42,
+  },
+  {
+    id: "delta",
+    label: "Delta",
+    width: 44,
+    height: 24,
+    gap: 34,
+    pending: 202,
+    done: 46,
+  },
+];
+
+export const PRECISION_CHIPS = [
+  { id: "chip-1", edge: 40, gap: 0, pending: 198, done: 50 },
+  { id: "chip-2", edge: 26, gap: 14, pending: 194, done: 54 },
+  { id: "chip-3", edge: 8, gap: 56, pending: 190, done: 58 },
+  { id: "chip-4", edge: 32, gap: 10, pending: 186, done: 62 },
+  { id: "chip-5", edge: 12, gap: 30, pending: 182, done: 66 },
+  { id: "chip-6", edge: 20, gap: 64, pending: 178, done: 70 },
+  { id: "chip-7", edge: 10, gap: 18, pending: 174, done: 74 },
+  { id: "chip-8", edge: 16, gap: 40, pending: 170, done: 78 },
+].map((chip) => ({
+  ...chip,
+  label: chip.id.replace("chip-", "Chip "),
+  width: chip.edge,
+  height: chip.edge,
+}));
+
+export const ALL_TARGETS = [...PRIMARY_TARGETS, ...PRECISION_CHIPS];
+
+// Ink the canvas draws with, and the canvas surface it draws on.
+export const CANVAS_INK = 60;
+export const CANVAS_PAPER = 252;
+export const CANVAS_WIDTH = 620;
+export const CANVAS_HEIGHT = 240;
+
+export function targetById(id) {
+  return ALL_TARGETS.find((target) => target.id === id);
+}

--- a/package/ego-browser/test/real-browser-e2e/site/src/scenarios/visual-path/view.jsx
+++ b/package/ego-browser/test/real-browser-e2e/site/src/scenarios/visual-path/view.jsx
@@ -1,0 +1,121 @@
+import Stat from "../../components/stat.jsx";
+
+import {
+  ALL_TARGETS,
+  CANVAS_HEIGHT,
+  CANVAS_WIDTH,
+  PRECISION_CHIPS,
+  PRIMARY_TARGETS,
+  swatchColor,
+} from "./targets.mjs";
+
+function Swatch({ target }) {
+  return (
+    <div class="visual-cell" style={`margin-left:${target.gap}px`}>
+      <button
+        type="button"
+        id={`swatch-${target.id}`}
+        class="visual-swatch"
+        data-target-id={target.id}
+        data-state="pending"
+        aria-label={`${target.label} calibration target`}
+        style={`width:${target.width}px;height:${target.height}px;background:${swatchColor(target.pending)}`}
+      />
+      <span class="visual-caption">
+        {target.label} · {target.width}×{target.height}
+      </span>
+    </div>
+  );
+}
+
+export default function VisualPathSurface() {
+  return (
+    <section class="surface card visual-path-layout">
+      <div class="visual-stack">
+        <section class="visual-block">
+          <div class="panel-heading">
+            <span>01 / PRIMARY TARGETS</span>
+            <small>Uneven sizes and gaps</small>
+          </div>
+          <p class="visual-note">
+            Each swatch carries its own gray. Hitting one repaints it to a
+            second gray, so the image itself reports the result.
+          </p>
+          <div class="visual-row" data-testid="primary-targets">
+            {PRIMARY_TARGETS.map((target) => (
+              <Swatch target={target} />
+            ))}
+          </div>
+        </section>
+
+        <section class="visual-block">
+          <div class="panel-heading">
+            <span>02 / PRECISION CHIPS</span>
+            <small>40px down to 8px</small>
+          </div>
+          <p class="visual-note">
+            The small chips fail first when a coordinate is off by a pixel or
+            two.
+          </p>
+          <div class="visual-row" data-testid="precision-chips">
+            {PRECISION_CHIPS.map((chip) => (
+              <Swatch target={chip} />
+            ))}
+          </div>
+        </section>
+
+        <section class="visual-block">
+          <div class="panel-heading">
+            <span>03 / CANVAS STAGE</span>
+            <small>No structure to read</small>
+          </div>
+          <p class="visual-note">
+            The stage exposes no elements at all. Press and drag to leave a
+            stroke; the drawn pixels are the only record.
+          </p>
+          <canvas
+            id="visual-canvas"
+            class="visual-canvas"
+            data-testid="visual-canvas"
+            width={CANVAS_WIDTH}
+            height={CANVAS_HEIGHT}
+            aria-label="Calibration drawing stage"
+          />
+        </section>
+      </div>
+
+      <aside class="stat-stack visual-panel" aria-label="Aim readback">
+        <div class="panel-heading">
+          <span>AIM READBACK</span>
+          <small>Reported by the page</small>
+        </div>
+        <Stat
+          label="targets hit"
+          value={`0 / ${ALL_TARGETS.length}`}
+          testId="visual-targets-done"
+        />
+        <Stat label="clicks" value="0" testId="visual-click-count" />
+        <Stat label="misses" value="0" testId="visual-miss-count" />
+        <Stat label="canvas strokes" value="0" testId="visual-canvas-strokes" />
+        <p class="activity-note mb-2">
+          Last click:{" "}
+          <output data-testid="visual-last-click">No click yet</output>
+        </p>
+        <p class="activity-note mb-2">
+          Environment: <output data-testid="visual-viewport">unmeasured</output>
+        </p>
+        <button
+          id="reset-visual"
+          type="button"
+          class="btn btn-sm btn-outline-secondary"
+        >
+          Reset targets
+        </button>
+        <p class="activity-note">
+          Every click leaves a red ring and crosshair at the pixel it landed on.
+          A dashed ring means the click hit nothing.
+        </p>
+      </aside>
+    </section>
+  );
+}

--- a/package/ego-browser/test/real-browser-e2e/site/src/styles.css
+++ b/package/ego-browser/test/real-browser-e2e/site/src/styles.css
@@ -546,7 +546,8 @@ select:focus-visible,
 .request-layout,
 .editorial-layout,
 .asset-layout,
-.tracker-layout {
+.tracker-layout,
+.visual-path-layout {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(17rem, 22rem);
 }
@@ -2192,6 +2193,81 @@ select:focus-visible,
   font-size: 0.8rem;
   font-weight: 600;
   text-decoration: none;
+}
+
+.visual-stack {
+  min-width: 0;
+}
+
+.visual-block {
+  padding: 1rem;
+  border-bottom: 1px solid var(--ui-border);
+}
+
+.visual-note {
+  margin: 0.75rem 0 1rem;
+  color: var(--ui-muted);
+  font-size: 0.78rem;
+}
+
+.visual-row {
+  display: flex;
+  align-items: flex-end;
+  padding-bottom: 0.5rem;
+}
+
+.visual-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+/* The swatch stays a single flat colour: the e2e case locates it by matching
+   that exact value in a screenshot, so no border, gradient or label may bleed
+   into it. The outline sits outside the box and does not disturb the fill. */
+.visual-swatch {
+  display: block;
+  padding: 0;
+  border: 0;
+  outline: 1px solid var(--ui-border);
+  cursor: pointer;
+}
+
+.visual-caption {
+  color: var(--ui-muted);
+  font-size: 0.62rem;
+  white-space: nowrap;
+}
+
+.visual-canvas {
+  display: block;
+  max-width: 100%;
+  border: 1px solid var(--ui-border);
+  touch-action: none;
+}
+
+.visual-marks {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  pointer-events: none;
+}
+
+.visual-mark {
+  position: absolute;
+  width: 26px;
+  height: 26px;
+  margin: -13px 0 0 -13px;
+}
+
+.visual-mark-index {
+  position: absolute;
+  top: 4px;
+  left: 30px;
+  color: #e5241a;
+  font-size: 0.62rem;
+  font-weight: 700;
 }
 
 @media (max-width: 74rem) {

--- a/package/ego-browser/test/real-browser-e2e/site/test-cases.mjs
+++ b/package/ego-browser/test/real-browser-e2e/site/test-cases.mjs
@@ -152,6 +152,15 @@ export const TEST_CASES = [
     description:
       "Write and format a release article, inspect its semantic HTML, and persist the editorial draft.",
   },
+  {
+    slug: "visual-path",
+    route: "/tests/visual-path",
+    number: "18",
+    title: "Alignment board",
+    eyebrow: "Visual path / coordinate calibration",
+    description:
+      "Find calibration targets in the rendered image alone, then confirm every hit lands where it was aimed.",
+  },
 ];
 
 export function findTestCase(slug) {

--- a/package/ego-browser/test/real-browser-e2e/site/vite.config.js
+++ b/package/ego-browser/test/real-browser-e2e/site/vite.config.js
@@ -22,6 +22,7 @@ const clientEntries = [
   "collaborative-docs",
   "spreadsheet",
   "rich-text",
+  "visual-path",
 ];
 
 export default defineConfig(({ command, mode }) => {

--- a/package/ego-browser/test/real-browser-e2e/suites/platform/process-contention.mjs
+++ b/package/ego-browser/test/real-browser-e2e/suites/platform/process-contention.mjs
@@ -1,9 +1,8 @@
 export const taskSpaceProcessContentionCase = {
   name: "TaskSpace process contention",
   kind: "platform",
-  optIn: true,
   processContention: true,
-  holderTimeoutMs: 8_000,
+  holderTimeoutMs: 10_000,
   rounds: [
     () => `
       const readyPath = join(tempDir, "process-contention-ready.json");
@@ -48,7 +47,13 @@ export const taskSpaceProcessContentionCase = {
         join(tempDir, "process-contention-holder-ready.json"),
         JSON.stringify({ id: holder.id }),
       );
-      await new Promise((resolve) => setTimeout(resolve, 10_000));
+      // The orphaned-holder shape behind real lease deadlocks: an await that
+      // never resolves while pending work keeps the event loop alive. The
+      // interval stands in for that pending native work — without it Node
+      // treats the unsettled top-level await as a clean exit (code 13) and
+      // the lease is released before any contender arrives.
+      setInterval(() => {}, 1_000);
+      await new Promise(() => {});
     `,
     () => `
       const { readFile } = await import("node:fs/promises");
@@ -59,21 +64,36 @@ export const taskSpaceProcessContentionCase = {
         ),
       );
       const startedAt = Date.now();
-      let contentionError;
-      try {
-        await egoBrowser.switchTaskSpace(saved.id);
-      } catch (error) {
-        contentionError = error;
-      }
-      assertIncludes(
-        String(contentionError?.message || contentionError),
-        "already controlled by another ego-browser process",
-        "a concurrent heredoc is rejected before selecting the live holder's TaskSpace",
+      const contender = await egoBrowser.switchTaskSpace(saved.id);
+      assertEqual(
+        Date.now() - startedAt < 5_000,
+        true,
+        "the takeover completes promptly instead of waiting behind the holder",
       );
       assertEqual(
-        Date.now() - startedAt < 3_000,
-        true,
-        "TaskSpace contention fails promptly instead of waiting behind an abandoned command",
+        contender.page.url(),
+        saved.ownerUrl,
+        "the contender takes over the holder's TaskSpace with its page intact",
+      );
+      // Without this the round also passes when the holder died early and
+      // released the lease — a free acquire, not a takeover.
+      const { readFileSync } = await import("node:fs");
+      const { tmpdir } = await import("node:os");
+      const owner = JSON.parse(
+        readFileSync(
+          join(
+            tmpdir(),
+            "ego-browser-taskspace-leases-" + process.getuid(),
+            String(saved.id),
+            "owner.json",
+          ),
+          "utf8",
+        ),
+      );
+      assertEqual(
+        typeof owner.takenOverFrom,
+        "object",
+        "the contender's lease records the takenOverFrom audit",
       );
     `,
     () => `
@@ -84,34 +104,11 @@ export const taskSpaceProcessContentionCase = {
           "utf8",
         ),
       );
-      const deadline = Date.now() + 15_000;
-      let recovered;
-      while (!recovered) {
-        try {
-          recovered = await egoBrowser.switchTaskSpace(saved.id);
-        } catch (error) {
-          if (
-            !String(error?.message || error).includes(
-              "already controlled by another ego-browser process",
-            )
-          ) {
-            throw error;
-          }
-          if (Date.now() >= deadline) {
-            throw new Error("TaskSpace recovery timed out after holder timeout");
-          }
-          await new Promise((resolve) => setTimeout(resolve, 50));
-        }
-      }
-      assertEqual(
-        recovered.page.url(),
-        saved.ownerUrl,
-        "the timed-out holder preserved the TaskSpace page",
-      );
+      const recovered = await egoBrowser.switchTaskSpace(saved.id);
       assertEqual(
         recovered.name,
         saved.name,
-        "the TaskSpace remains recoverable after the holder exits",
+        "the TaskSpace remains addressable after the takeover",
       );
       const recoveryUrl = baseUrl + "/tests/clicks?process-contention=recovered";
       await recovered.page.goto(recoveryUrl, {

--- a/package/ego-browser/test/real-browser-e2e/suites/scenarios/index.mjs
+++ b/package/ego-browser/test/real-browser-e2e/suites/scenarios/index.mjs
@@ -15,6 +15,7 @@ import { reviewWorkflowScenarioCase } from "./review-workflow.mjs";
 import { collaborativeDocsScenarioCase } from "./collaborative-docs.mjs";
 import { spreadsheetScenarioCase } from "./spreadsheet.mjs";
 import { richTextScenarioCase } from "./rich-text.mjs";
+import { visualPathScenarioCase } from "./visual-path.mjs";
 
 export const scenarioCases = [
   clicksScenarioCase,
@@ -34,4 +35,5 @@ export const scenarioCases = [
   collaborativeDocsScenarioCase,
   spreadsheetScenarioCase,
   richTextScenarioCase,
+  visualPathScenarioCase,
 ];

--- a/package/ego-browser/test/real-browser-e2e/suites/scenarios/pixel-tools.mjs
+++ b/package/ego-browser/test/real-browser-e2e/suites/scenarios/pixel-tools.mjs
@@ -1,0 +1,154 @@
+// Screenshot reading for the visual-path case: it has to find its targets in the
+// image the browser produced, the same way an agent on the visual path would,
+// instead of asking the DOM where they are.
+//
+// The decoder is written out here rather than pulled from a package because
+// Chromium screenshots are a narrow slice of the format — 8-bit, non-interlaced,
+// RGB or RGBA — and node:zlib already supplies the only hard part.
+
+import { inflateSync } from "node:zlib";
+
+const CHANNELS_BY_COLOR_TYPE = { 0: 1, 2: 3, 4: 2, 6: 4 };
+
+export function decodePng(buffer) {
+  if (buffer.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a") {
+    throw new Error("not a PNG image");
+  }
+  let offset = 8;
+  let width = 0;
+  let height = 0;
+  let bitDepth = 0;
+  let colorType = 0;
+  let interlace = 0;
+  const parts = [];
+  while (offset < buffer.length) {
+    const length = buffer.readUInt32BE(offset);
+    const type = buffer.toString("ascii", offset + 4, offset + 8);
+    const data = buffer.subarray(offset + 8, offset + 8 + length);
+    if (type === "IHDR") {
+      width = data.readUInt32BE(0);
+      height = data.readUInt32BE(4);
+      bitDepth = data[8];
+      colorType = data[9];
+      interlace = data[12];
+    } else if (type === "IDAT") {
+      parts.push(data);
+    } else if (type === "IEND") {
+      break;
+    }
+    offset += 12 + length;
+  }
+  const channels = CHANNELS_BY_COLOR_TYPE[colorType] ?? 0;
+  if (bitDepth !== 8 || !channels || interlace !== 0) {
+    throw new Error(
+      `unsupported PNG: bitDepth=${bitDepth} colorType=${colorType} interlace=${interlace}`,
+    );
+  }
+  const raw = inflateSync(Buffer.concat(parts));
+  const stride = width * channels;
+  const pixels = Buffer.alloc(height * stride);
+  let read = 0;
+  for (let y = 0; y < height; y += 1) {
+    const filter = raw[read];
+    read += 1;
+    const line = raw.subarray(read, read + stride);
+    read += stride;
+    const row = pixels.subarray(y * stride, (y + 1) * stride);
+    const previous =
+      y > 0 ? pixels.subarray((y - 1) * stride, y * stride) : null;
+    for (let x = 0; x < stride; x += 1) {
+      const left = x >= channels ? row[x - channels] : 0;
+      const up = previous ? previous[x] : 0;
+      const upLeft = previous && x >= channels ? previous[x - channels] : 0;
+      let value = line[x];
+      if (filter === 1) value = (value + left) & 255;
+      else if (filter === 2) value = (value + up) & 255;
+      else if (filter === 3) value = (value + ((left + up) >> 1)) & 255;
+      else if (filter === 4) {
+        const estimate = left + up - upLeft;
+        const dLeft = Math.abs(estimate - left);
+        const dUp = Math.abs(estimate - up);
+        const dUpLeft = Math.abs(estimate - upLeft);
+        const nearest =
+          dLeft <= dUp && dLeft <= dUpLeft
+            ? left
+            : dUp <= dUpLeft
+              ? up
+              : upLeft;
+        value = (value + nearest) & 255;
+      } else if (filter !== 0) {
+        throw new Error(`unsupported PNG row filter: ${filter}`);
+      }
+      row[x] = value;
+    }
+  }
+  return { width, height, channels, pixels };
+}
+
+export function pixelAt(image, x, y) {
+  const index = (y * image.width + x) * image.channels;
+  return [
+    image.pixels[index],
+    image.pixels[index + 1],
+    image.pixels[index + 2],
+  ];
+}
+
+function scan(image, rgb, region, visit) {
+  const x0 = Math.max(0, region?.x0 ?? 0);
+  const y0 = Math.max(0, region?.y0 ?? 0);
+  const x1 = Math.min(image.width, region?.x1 ?? image.width);
+  const y1 = Math.min(image.height, region?.y1 ?? image.height);
+  const [r, g, b] = rgb;
+  for (let y = y0; y < y1; y += 1) {
+    for (let x = x0; x < x1; x += 1) {
+      const index = (y * image.width + x) * image.channels;
+      if (image.pixels[index] !== r) continue;
+      if (image.pixels[index + 1] !== g) continue;
+      if (image.pixels[index + 2] !== b) continue;
+      visit(x, y);
+    }
+  }
+}
+
+// Finds the one region painted in `rgb` and reports it in device pixels. `fill`
+// is how much of the bounding box actually carries the colour: a solid
+// rectangle reports 1, and anything materially lower means stray pixels of the
+// same value widened the box and the centre can no longer be trusted.
+export function locateSwatch(image, rgb, region) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -1;
+  let maxY = -1;
+  let count = 0;
+  scan(image, rgb, region, (x, y) => {
+    count += 1;
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+  });
+  if (!count) return null;
+  const width = maxX - minX + 1;
+  const height = maxY - minY + 1;
+  return {
+    count,
+    minX,
+    minY,
+    maxX,
+    maxY,
+    width,
+    height,
+    fill: count / (width * height),
+    // +1 because minX/maxX are pixel indices: a swatch covering columns 240..319
+    // spans the geometry from 240 to 320, whose centre is 280, not 279.5.
+    centerX: (minX + maxX + 1) / 2,
+    centerY: (minY + maxY + 1) / 2,
+  };
+}
+
+// Screenshots are device pixels; page.mouse takes CSS pixels. This is the whole
+// conversion the visual path depends on.
+export function toCssPoint(box, ratio) {
+  return { x: box.centerX / ratio, y: box.centerY / ratio };
+}

--- a/package/ego-browser/test/real-browser-e2e/suites/scenarios/scenario-case.mjs
+++ b/package/ego-browser/test/real-browser-e2e/suites/scenarios/scenario-case.mjs
@@ -145,6 +145,11 @@ export function scenarioCase(slug, body) {
         return action(pointer);
       }
 
+      async function observedPixelClick(scope, label, point) {
+        await observedScreenshot(scope, label);
+        return scope.mouse.click(point.x, point.y);
+      }
+
       async function observedDragTo(scope, source, target) {
         await observedScreenshot(scope, "drag-and-drop target context");
         return source.dragTo(target);

--- a/package/ego-browser/test/real-browser-e2e/suites/scenarios/visual-path.mjs
+++ b/package/ego-browser/test/real-browser-e2e/suites/scenarios/visual-path.mjs
@@ -1,0 +1,306 @@
+import {
+  CANVAS_HEIGHT,
+  CANVAS_INK,
+  CANVAS_PAPER,
+  CANVAS_WIDTH,
+  PRECISION_CHIPS,
+  PRIMARY_TARGETS,
+  swatchRgb,
+} from "../../site/src/scenarios/visual-path/targets.mjs";
+
+import { scenarioCase } from "./scenario-case.mjs";
+
+// The fixture and this case have to agree on every swatch colour, so the case
+// reads the same module the page renders from instead of restating the values.
+function describe(target) {
+  return {
+    id: target.id,
+    width: target.width,
+    height: target.height,
+    pendingRgb: swatchRgb(target.pending),
+    doneRgb: swatchRgb(target.done),
+  };
+}
+
+const stage = {
+  width: CANVAS_WIDTH,
+  height: CANVAS_HEIGHT,
+  paperRgb: swatchRgb(CANVAS_PAPER),
+  inkRgb: swatchRgb(CANVAS_INK),
+};
+
+export const visualPathScenarioCase = scenarioCase(
+  "visual-path",
+  `
+      const { decodePng, locateSwatch, pixelAt, toCssPoint } =
+        await import(pixelToolsUrl);
+      const PRIMARY = ${JSON.stringify(PRIMARY_TARGETS.map(describe))};
+      const CHIPS = ${JSON.stringify(PRECISION_CHIPS.map(describe))};
+      const STAGE = ${JSON.stringify(stage)};
+
+      const environment = await page.evaluate(() => ({
+        innerWidth: window.innerWidth,
+        innerHeight: window.innerHeight,
+        ratio: window.devicePixelRatio,
+      }));
+      const ratio = environment.ratio;
+      assert(ratio >= 1, "the fixture reports a usable device pixel ratio");
+
+      async function shoot(label) {
+        return decodePng(await observedScreenshot(page, label));
+      }
+
+      async function shootWholePage() {
+        const image = await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          timeout: 60_000,
+        });
+        return decodePng(image);
+      }
+
+      async function scrollPageTo(top) {
+        await page.evaluate((value) => window.scrollTo(0, value), top);
+        await new Promise((resolve) => setTimeout(resolve, 120));
+        return page.evaluate(() => window.scrollY);
+      }
+
+      // Reads a target straight out of the image. Nothing here asks the DOM
+      // where anything is: that is the whole point of the visual path.
+      function sight(image, target) {
+        const box = locateSwatch(image, target.pendingRgb);
+        assert(box, target.id + " is visible in the screenshot");
+        assertEqual(
+          box.width,
+          Math.round(target.width * ratio),
+          target.id + " keeps its rendered width in the image",
+        );
+        assertEqual(
+          box.height,
+          Math.round(target.height * ratio),
+          target.id + " keeps its rendered height in the image",
+        );
+        assert(
+          box.fill > 0.98,
+          target.id + " reads back as one solid block of its own colour",
+        );
+        return toCssPoint(box, ratio);
+      }
+
+      async function aim(target, point) {
+        await observedPixelClick(page, "aiming at " + target.id, point);
+        const readback = await page
+          .getByTestId("visual-last-click")
+          .textContent();
+        const [coordinates, landedOn] = readback.split(" ");
+        assertEqual(
+          landedOn,
+          target.id,
+          "the click computed from pixels lands on " + target.id,
+        );
+        const [x, y] = coordinates.split(",").map(Number);
+        assert(
+          Math.abs(x - point.x) <= 1 && Math.abs(y - point.y) <= 1,
+          target.id +
+            " receives the aimed coordinate, off by at most a pixel: aimed " +
+            point.x +
+            "," +
+            point.y +
+            " received " +
+            coordinates,
+        );
+      }
+
+      await scrollPageTo(0);
+      const board = await shoot("alignment board at rest");
+      assertEqual(
+        board.width,
+        Math.round(environment.innerWidth * ratio),
+        "a viewport screenshot spans the CSS viewport scaled by the device pixel ratio",
+      );
+      assertEqual(
+        board.height,
+        Math.round(environment.innerHeight * ratio),
+        "a viewport screenshot is as tall as the CSS viewport scaled by the device pixel ratio",
+      );
+
+      // Records today's behaviour: Playwright would return CSS pixels here, and
+      // the visual path would need no conversion at all. Once scale is honoured
+      // this assertion fails and should be rewritten to expect CSS pixels.
+      const cssScaled = decodePng(
+        await page.screenshot({
+          animations: "disabled",
+          scale: "css",
+          timeout: 60_000,
+        }),
+      );
+      assertEqual(
+        cssScaled.width,
+        board.width,
+        "scale:'css' still returns device pixels, so callers convert by the device pixel ratio themselves",
+      );
+
+      const clipped = decodePng(
+        await page.screenshot({
+          animations: "disabled",
+          clip: { x: 0, y: 0, width: 80, height: 80 },
+          timeout: 60_000,
+        }),
+      );
+      assertEqual(
+        clipped.width,
+        Math.round(80 * ratio),
+        "a clipped screenshot is the requested CSS box in device pixels",
+      );
+      assertEqual(
+        pixelAt(clipped, Math.round(40 * ratio), Math.round(40 * ratio)).join(),
+        pixelAt(board, Math.round(40 * ratio), Math.round(40 * ratio)).join(),
+        "a clipped screenshot carries the same pixels as the matching part of the full screenshot",
+      );
+
+      // One clean image supplies every primary coordinate: click markers land on
+      // the targets already hit, and re-reading between clicks would let a
+      // marker eat into the neighbour that is measured next.
+      const primaryPoints = PRIMARY.map((target) => sight(board, target));
+      for (const [index, target] of PRIMARY.entries()) {
+        await aim(target, primaryPoints[index]);
+      }
+      assertEqual(
+        await page.getByTestId("visual-targets-done").textContent(),
+        PRIMARY.length + " / " + (PRIMARY.length + CHIPS.length),
+        "every primary target reports a hit",
+      );
+
+      const repainted = await shoot("primary targets marked");
+      assert(
+        locateSwatch(repainted, PRIMARY[0].doneRgb),
+        "a hit target repaints itself in the very next screenshot",
+      );
+      assertEqual(
+        locateSwatch(repainted, PRIMARY[0].pendingRgb),
+        null,
+        "the colour a hit target used to carry is gone from the image",
+      );
+
+      const missesBefore = await page.getByTestId("visual-miss-count").textContent();
+      const lastBefore = await page.getByTestId("visual-last-click").textContent();
+      await observedPixelClick(page, "aiming past the bottom of the viewport", {
+        x: 40,
+        y: environment.innerHeight + 200,
+      });
+      assertEqual(
+        await page.getByTestId("visual-last-click").textContent(),
+        lastBefore,
+        "a coordinate below the viewport reaches no target",
+      );
+      assertEqual(
+        await page.getByTestId("visual-miss-count").textContent(),
+        missesBefore,
+        "a coordinate below the viewport is not reported as a miss either",
+      );
+
+      const wholePage = await shootWholePage();
+      assert(
+        wholePage.height > board.height,
+        "the fixture is taller than one viewport, so the page has to be scrolled",
+      );
+      const scrollbar = (board.width - wholePage.width) / ratio;
+      assert(
+        scrollbar >= 0 && scrollbar < 24,
+        "a full-page screenshot drops only the scrollbar column, measured " +
+          scrollbar +
+          "px",
+      );
+      const chipOnPage = locateSwatch(wholePage, CHIPS[0].pendingRgb);
+      assert(chipOnPage, "the first chip is visible in the full-page screenshot");
+      const chipPageY = chipOnPage.centerY / ratio;
+      const scrolled = await scrollPageTo(
+        Math.max(0, Math.round(chipPageY - environment.innerHeight / 2)),
+      );
+      assert(scrolled > 0, "the page scrolled towards the precision chips");
+
+      const chipBoard = await shoot("precision chips in view");
+      const chipInView = locateSwatch(chipBoard, CHIPS[0].pendingRgb);
+      assert(chipInView, "the first chip is visible after scrolling");
+      assertEqual(
+        Math.round(chipInView.centerY / ratio + scrolled),
+        Math.round(chipPageY),
+        "full-page screenshot coordinates are page coordinates, viewport screenshot coordinates are not",
+      );
+
+      const chipPoints = CHIPS.map((chip) => sight(chipBoard, chip));
+      for (const [index, chip] of CHIPS.entries()) {
+        await aim(chip, chipPoints[index]);
+      }
+      assertEqual(
+        await page.getByTestId("visual-targets-done").textContent(),
+        PRIMARY.length + CHIPS.length + " / " + (PRIMARY.length + CHIPS.length),
+        "every calibration target down to the smallest chip reports a hit",
+      );
+
+      const stalePoint = chipPoints[chipPoints.length - 1];
+      await scrollPageTo(scrolled + 140);
+      await observedPixelClick(page, "aiming with a stale coordinate", stalePoint);
+      const staleReadback = await page
+        .getByTestId("visual-last-click")
+        .textContent();
+      assert(
+        !staleReadback.endsWith(" " + CHIPS[CHIPS.length - 1].id),
+        "a coordinate read before scrolling no longer points at its target: " +
+          staleReadback,
+      );
+
+      const stageBoard = await shoot("canvas stage in view");
+      const paper = locateSwatch(stageBoard, STAGE.paperRgb);
+      assert(paper, "the canvas surface is visible in the screenshot");
+      assertEqual(
+        paper.width,
+        Math.round(STAGE.width * ratio),
+        "the canvas surface reads back at its rendered width",
+      );
+      const stageLeft = paper.minX / ratio;
+      const stageTop = paper.minY / ratio;
+      const stageWidth = paper.width / ratio;
+      const stageHeight = paper.height / ratio;
+      const from = {
+        x: stageLeft + stageWidth * 0.15,
+        y: stageTop + stageHeight * 0.25,
+      };
+      const via = {
+        x: stageLeft + stageWidth * 0.5,
+        y: stageTop + stageHeight * 0.7,
+      };
+      const to = {
+        x: stageLeft + stageWidth * 0.82,
+        y: stageTop + stageHeight * 0.4,
+      };
+      await observedGesture(page, "canvas before the stroke", async (pointer) => {
+        await pointer.move(from.x, from.y);
+        await pointer.down();
+        await pointer.move(via.x, via.y, { steps: 8 });
+        await pointer.move(to.x, to.y, { steps: 8 });
+        await pointer.up();
+      });
+      assertEqual(
+        await page.getByTestId("visual-canvas-strokes").textContent(),
+        "1",
+        "a pressed pointer path draws one stroke on a surface with no structure to read",
+      );
+
+      const inked = await shoot("canvas after the stroke");
+      const ink = locateSwatch(inked, STAGE.inkRgb);
+      assert(ink, "the stroke is visible in the screenshot");
+      assert(
+        Math.abs(ink.minX / ratio - from.x) <= 4,
+        "the stroke starts at the pixel the pointer pressed on",
+      );
+      assert(
+        Math.abs(ink.maxX / ratio - to.x) <= 4,
+        "the stroke ends at the pixel the pointer released on",
+      );
+      assert(
+        ink.height / ratio > stageHeight * 0.3,
+        "the stroke follows the whole dragged path instead of joining two points",
+      );
+    `,
+);


### PR DESCRIPTION
Hardens the Playwright routing layer, replaces lease contention errors with takeover semantics, and adds regression coverage for the visual (screenshot → coordinate) path.

## Playwright routing state management (`f81de89`)

Empirically verified failures in the CDP routing layer, each covered by a new regression test before the fix:

- Subframe `Page.navigate` is routed as native passthrough; only main-frame navigations take the tab-replacement path, so `frame.goto` no longer destroys the whole tab.
- The session replay allowlist covers `Fetch`, `Emulation`, `Network` and `Security`, so `page.route` handlers and viewport/UA overrides survive navigation and rebind.
- Concurrent navigations are serialized per route, and the replacement tab is cleaned up when a navigation fails instead of leaking zombie tabs.
- `executionContextsCleared` is emitted only after the replacement target commits, so `page.evaluate` cannot hang forever on a failed navigation.
- Commands arriving during navigating/rebinding windows are held and replayed once the route settles, instead of being sent to a dead session.
- A native send error no longer tears down the transport: all in-flight requests are rejected (the error channel carries no request id) while the connection stays alive.
- Popup discovery is queued so two concurrently opened popups both attach.
- Storage/cookie commands prefer attached routes when resolving.
- Tombstone sets (internally closed targets, retired and detached sessions) are pruned once their terminal events are observed.
- The connector close closure is scoped per session, so a stale handle can no longer tear down a newer session's browser/transport.
- The frame-throttler timer patch captures `setTimeout` stacks only for candidate delays; unconditional capture taxed every timer in the process.
- `completeTaskSpace` waits until the closed TaskSpace disappears from `listTaskSpaces`; native close resolves before the space is actually removed while a Playwright connection is attached.

Adds a scriptable fake-native CDP harness (`fake-native-harness.mjs`) modeling real-Chromium invariants (main frame id == targetId, `browserContextId` present), plus integration tests driving a real `playwright-core` client over it.

## Lease takeover instead of contention errors (`09fee18`)

Acquire now takes over a held lease rather than throwing: the newest session wins, records a `takenOverFrom` audit entry in `owner.json`, and the previous holder's heartbeat detects the foreign token, disconnects Playwright and exits. This unblocks leases orphaned by killed CLI clients, whose scripts previously kept the lease alive forever inside the shared NodeService host (pid check useless, heartbeat never stale). Both takeover notices go through `console.log`, the only channel bridged back to the agent in SDK mode.

The process-contention e2e holder is now a never-resolving await kept alive by a ref'd interval — the real orphan shape, since a bare unsettled top-level await exits Node with code 13 and releases the lease. The contender proves a real takeover via the `takenOverFrom` audit, the holder must self-exit with the takeover notice, and the case runs by default instead of opt-in.

## Visual fallback path e2e coverage (`019f138`)

Every scenario drove the fixture through the semantic path, leaving the visual path — screenshot in, coordinate out — without a regression behind it. Adds an alignment-board fixture and a journey that locates each target in the screenshot, converts by the device pixel ratio, clicks, and checks the page's own report of where the click landed.

Targets are flat near-gray blocks on purpose: display colour management leaves R=G=B byte-identical in a screenshot, while saturated colours drift far enough to break an exact match — `rgb(255,0,0)` reads back as `rgb(233,46,32)` on a P3 display.

The journey also pins the contracts around that conversion: a viewport screenshot is the CSS viewport scaled by the device pixel ratio, a full-page screenshot carries page coordinates without the scrollbar column, a coordinate read before scrolling no longer points at its target, and a coordinate past the viewport neither lands nor raises. A policy test keeps the journey from quietly falling back to layout queries.

## Test plan

- `routing.test.mjs`, `taskspace.test.mjs`, `helpers.test.mjs`, `taskspace-lease.test.mjs` — unit/regression coverage added alongside each fix.
- `playwright-client.test.mjs` — real `playwright-core` client driven over the fake-native harness.
- real-browser e2e: the visual-path journey and the process-contention case both run by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
