### PR TITLE
fix(pointer): peek for drag evidence before re-synthesising the drag

### DIFF
--- a/package/ego-browser/src/driver/pointer.test.mjs
+++ b/package/ego-browser/src/driver/pointer.test.mjs
@@ -5,6 +5,7 @@ import { setOverrides } from "../../dist/src/state.js";
 import {
   click,
   down,
+  drag,
   hover,
   up,
   wheel,
@@ -377,4 +378,57 @@ test("click absorbs CDP timeout when probe fallback succeeds", async () => {
     probeEvaluateCount >= 2,
     "probe install and finish were called despite CDP timeout",
   );
+});
+
+test("drag waits for a late trusted mouseup instead of re-synthesising it", async () => {
+  // The canvas flake: the trusted mouseup can land after the first probe window
+  // when the machine is loaded (page load, screencast warm-up). Concluding from
+  // one look and re-synthesising delivers the drag twice — a canvas stroke gets
+  // drawn twice. The probe must be peeked at more than once before the fallback
+  // is allowed to fire.
+  const originalEgo = globalThis.ego;
+  globalThis.ego = { sendCDPMessage: () => {} };
+  let installs = 0;
+  let peeks = 0;
+  let finishes = 0;
+  const restore = setOverrides({
+    cdpOverride(method, params) {
+      if (method !== "Runtime.evaluate") return {};
+      const expression = params.expression ?? "";
+      if (!expression.includes("__egoBrowserInputProbes")) {
+        if (params.objectGroup === "ego-browser") {
+          return { result: { objectId: "object-1" } };
+        }
+        return { result: { value: { x: 100, y: 200 } } };
+      }
+      if (expression.includes("probe.handler = ")) {
+        installs += 1;
+        return { result: { value: true } };
+      }
+      if (expression.includes("dispatchEvent")) {
+        // The consuming call. `seen: true` means the real mouseup arrived, so
+        // no fallback events are synthesised.
+        finishes += 1;
+        return { result: { value: { seen: true, fallback: false } } };
+      }
+      // A non-consuming peek. The trusted event is late: absent on the first
+      // look, present on the second.
+      peeks += 1;
+      return { result: { value: peeks === 1 ? false : true } };
+    },
+  });
+  try {
+    await drag(["#from", "#to"]);
+  } finally {
+    restore();
+    if (originalEgo === undefined) delete globalThis.ego;
+    else globalThis.ego = originalEgo;
+  }
+
+  assert.equal(installs, 1, "the mouseup probe is installed once");
+  assert.ok(
+    peeks >= 2,
+    `the probe is peeked at again after the first miss (got ${peeks} peek(s))`,
+  );
+  assert.equal(finishes, 1, "the probe is consumed exactly once");
 });

--- a/package/ego-browser/src/driver/pointer.ts
+++ b/package/ego-browser/src/driver/pointer.ts
@@ -410,9 +410,32 @@ async function finishDragProbe(
   button: MouseButton,
 ) {
   if (!id) return false;
-  await inputEventDelay(50);
   const first = points[0];
   const last = points.at(-1);
+  // Trusted mouseup events can land later than one fixed window when the
+  // machine is loaded — and re-synthesising a drag that did arrive delivers it
+  // twice (canvas strokes count double). Peek for evidence a few times before
+  // concluding the input failed; only after the last peek may the fallback
+  // synthesise. Events that land promptly still resolve after the first 50ms.
+  const peek = `(() => {
+    const probe = (window.__egoBrowserInputProbes || {})[${JSON.stringify(id)}];
+    return probe ? probe.seen === true : null;
+  })()`;
+  for (const delay of [50, 100, 150]) {
+    await inputEventDelay(delay);
+    try {
+      const peeked = await cdp(
+        "Runtime.evaluate",
+        { expression: peek, returnByValue: true, awaitPromise: false },
+        last.sessionId ?? first.sessionId,
+      );
+      // true: the trusted mouseup landed; null: the probe is gone (navigation)
+      // — either way there is nothing left to wait for.
+      if (peeked.result?.value !== false) break;
+    } catch {
+      break;
+    }
+  }
   try {
     const result = await cdp(
       "Runtime.evaluate",


### PR DESCRIPTION
## The bug

`finishDragProbe` waits a fixed 50 ms for the trusted `mouseup`, and if it does not see one it re-synthesises the entire drag inside the page:

```ts
await inputEventDelay(50);
// ... one Runtime.evaluate that reads the probe, deletes it, and if
//     !probe.seen dispatches mousedown + mousemoves + mouseup itself
```

That is a single look. When the real events land later than that one window — page load, screencast warm-up, any loaded machine — they *do* arrive, but only after the fallback has already fired. The page then receives the drag **twice**.

On a canvas this is visible rather than theoretical: every stroke gets drawn twice. That is how it surfaced.

## The fix

Peek at the probe at 50/100/150 ms with a **non-consuming** expression, and break out as soon as there is an answer:

```ts
for (const delay of [50, 100, 150]) {
  await inputEventDelay(delay);
  const peeked = await cdp("Runtime.evaluate", { expression: peek, ... });
  // true: the trusted mouseup landed; null: the probe is gone (navigation)
  if (peeked.result?.value !== false) break;
}
```

The existing consuming call is unchanged and still runs afterwards — it just now sees `probe.seen === true` in the late case and returns without synthesising anything.

**What this costs.** An event that arrives promptly still resolves after the same first 50 ms as before. A genuinely failed input waits 250 ms longer for its fallback. That is the right way round: the fallback exists for rare failures, while double delivery hit every loaded run.

## Test

The new test in `pointer.test.mjs` pins the *behaviour*, not the timing — it stubs a probe that is absent on the first look and present on the second, then asserts the probe is peeked at again after the first miss and consumed exactly once.

It is a real regression test, not a restatement of the patch:

| | Result |
|---|---|
| Against unpatched `pointer.ts` | **Fails** — `the probe is peeked at again after the first miss (got 0 peek(s))` |
| Against patched `pointer.ts` | Passes |
| Full `package/ego-browser` suite | **300/300** (299 existing + the new one) |

Build and typecheck are clean; `npm test` runs both before the suite.

## Scope

Two files, no API change, no behaviour change for input that lands on time. Split out of a larger Linux-port branch deliberately — this one is platform-agnostic and stands on its own.
