### PR TITLE
fix: anchor viewport screenshot clip to the current scroll offset

### DIFF
--- a/package/ego-browser/src/driver/observe.test.mjs
+++ b/package/ego-browser/src/driver/observe.test.mjs
@@ -36,7 +36,21 @@ function withCdpRuntime(fn) {
       } else if (request.method === "Page.captureScreenshot") {
         result = { data: Buffer.from("png").toString("base64") };
       } else if (request.method === "Runtime.evaluate") {
-        result = { result: { value: "1" } };
+        const value = request.params.expression.includes(
+          "document.documentElement",
+        )
+          ? JSON.stringify({
+              url: "https://example.com/",
+              title: "Example",
+              w: 1280,
+              h: 720,
+              sx: 32,
+              sy: 8192,
+              pw: 1280,
+              ph: 12000,
+            })
+          : "2";
+        result = { result: { value } };
       }
       queueMicrotask(() =>
         runtime.onCDPMessage(JSON.stringify({ id: request.id, result })),
@@ -109,6 +123,34 @@ test("screenshot creates a missing parent directory", async () => {
     assert.equal((await readFile(path)).toString(), "png");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("screenshot clips the viewport at the current document scroll offset", async () => {
+  const restore = setOverrides({
+    async writeFile() {},
+  });
+  try {
+    await withCdpRuntime(async ({ sent }) => {
+      await screenshot({ path: "/tmp/ego-browser-scrolled-shot.png" });
+
+      const shot = sent.find(
+        (request) => request.method === "Page.captureScreenshot",
+      );
+      assert.deepEqual(shot.params, {
+        format: "png",
+        captureBeyondViewport: false,
+        clip: {
+          x: 32,
+          y: 8192,
+          width: 1280,
+          height: 720,
+          scale: 0.5,
+        },
+      });
+    });
+  } finally {
+    restore();
   }
 });
 

--- a/package/ego-browser/src/driver/observe.ts
+++ b/package/ego-browser/src/driver/observe.ts
@@ -123,8 +123,8 @@ export async function screenshot(options: ScreenshotOptions = {}) {
           return screenshot({ ...options, path, raw: true });
         }
         params.clip = {
-          x: 0,
-          y: 0,
+          x: full ? 0 : info.sx,
+          y: full ? 0 : info.sy,
           width: full ? info.pw : info.w,
           height: full ? info.ph : info.h,
           scale: cssScale,


### PR DESCRIPTION
## Summary

`captureScreenshot()` returns a uniform gray frame once the page is scrolled past one viewport height. The non-fullPage path builds its CDP clip at document `(0, 0)` while `captureBeyondViewport` stays `false`, so the clip loses overlap with the rasterized viewport as `scrollY` grows and hits zero overlap at `scrollY >= viewportHeight`. This anchors the clip to the `sx`/`sy` document coordinates `pageInfo()` already reports. Two lines in `observe.ts`; full-page captures keep the `(0, 0)` origin.

## Related issue

Closes #163. Credit to @JakeB-5 for first isolating the clip parameter as the culprit; this PR lands that diagnosis with a regression test, plus scroll-depth measurements confirming the failure is geometric (overlap loss), not a compositor or texture-size limit.

## Changes

- `src/driver/observe.ts`: anchor the viewport screenshot clip at `info.sx` / `info.sy` for the non-fullPage case.
- `src/driver/observe.test.mjs`: parameter-level regression test at `scrollX = 32`, `scrollY = 8192`, DPR 2, asserting the emitted `Page.captureScreenshot` clip.

## Verification

```text
npm test                     # 312 passed, 0 failed (red before fix: expected clip x:32/y:8192, got x:0/y:0)
npm run validate:site-skills # exit 0
```

Reproduced on ego lite 0.4.5.9 (macOS arm64, Chrome/150): at `scrollY = 8865` on an ~11,449px page, the shipped helper returned an 8,175-byte gray PNG while the same capture with a scroll-anchored clip returned the correct viewport. Byte sizes of a fixed-origin clip decay monotonically with scroll depth (185,993 B at `scrollY = 0` → 8,175 B fully gray at exactly `scrollY = 1129` = viewport height), matching the overlap model.

## Impact

- [x] Public helper API or behavior
- [ ] Agent skill or instructions
- [ ] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

Behavior change is limited to non-fullPage screenshots while scrolled: they now capture the visible viewport instead of a gray frame. Unscrolled and full-page captures emit identical CDP parameters as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)