### PR TITLE
fix(learning): resolve tool paths with path.relative so learned tools run on Windows

### DIFF
--- a/package/ego-browser/src/learning/index.test.mjs
+++ b/package/ego-browser/src/learning/index.test.mjs
@@ -4,7 +4,11 @@ import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { loadLearnedContext } from "../../dist/src/learning/index.js";
+import {
+  loadBrowserToolSource,
+  loadLearnedContext,
+  runNodeSiteTool,
+} from "../../dist/src/learning/index.js";
 
 test("loadLearnedContext includes declared tool return schemas", async () => {
   const root = await mkdtemp(join(tmpdir(), "ego-learning-"));
@@ -70,5 +74,55 @@ test("loadLearnedContext includes declared tool return schemas", async () => {
   assert.deepEqual(
     context.tools.find((tool) => tool.toolName === "active_item").returns,
     { type: "object", description: "Active item object." },
+  );
+});
+
+test("runNodeSiteTool and loadBrowserToolSource resolve in-directory tool paths", async () => {
+  const root = await mkdtemp(join(tmpdir(), "ego-learning-"));
+  const siteDir = join(root, "example");
+  await mkdir(join(siteDir, "tools"), { recursive: true });
+  await mkdir(join(siteDir, "browser-tools"), { recursive: true });
+  await writeFile(
+    join(siteDir, "manifest.json"),
+    JSON.stringify({
+      id: "example",
+      name: "Example",
+      domains: ["example.com"],
+      notes: [],
+      nodeTools: {
+        read_items: {
+          description: "Read items.",
+          path: "tools/read-items.js",
+          callable: "readItems",
+          args: {},
+          returns: { type: "array", description: "Array of items." },
+        },
+      },
+      browserTools: {
+        active_item: {
+          description: "Read the active item.",
+          path: "browser-tools/active-item.js",
+          args: {},
+          returns: { type: "object", description: "Active item." },
+        },
+      },
+    }),
+  );
+  await writeFile(
+    join(siteDir, "tools/read-items.js"),
+    "export async function readItems() { return ['ok']; }\n",
+  );
+  const browserSource = "async () => ({ active: true })\n";
+  await writeFile(join(siteDir, "browser-tools/active-item.js"), browserSource);
+
+  // These resolve schema.path via relativeSitePath, which must accept a valid
+  // in-directory path on every OS (it rejected all of them on Windows).
+  assert.deepEqual(
+    await runNodeSiteTool("example", "read_items", {}, {}, { root }),
+    ["ok"],
+  );
+  assert.equal(
+    await loadBrowserToolSource("example", "active_item", { root }),
+    browserSource,
   );
 });

--- a/package/ego-browser/src/learning/index.ts
+++ b/package/ego-browser/src/learning/index.ts
@@ -230,7 +230,12 @@ function relativeSitePath(siteDir, manifestPath, label) {
   }
   const resolved = resolve(siteDir, manifestPath);
   const siteRoot = resolve(siteDir);
-  if (resolved !== siteRoot && !resolved.startsWith(`${siteRoot}/`)) {
+  // Compare with path.relative rather than a hard-coded "/": resolve() returns
+  // OS-separated paths, so on Windows `${siteRoot}/` never prefixes a resolved
+  // path (the separator is "\"), which rejected every valid in-directory tool
+  // path and made every learned tool unrunnable on Windows.
+  const rel = relative(siteRoot, resolved);
+  if (rel.startsWith("..") || isAbsolute(rel)) {
     throw new Error(`${label} path must stay inside the site skill directory`);
   }
   return resolved;


### PR DESCRIPTION
## Summary

On Windows, every learned site tool is unrunnable. `runNodeSiteTool` and `loadBrowserToolSource` (the `site.runTool` / `site.runBrowserTool` entry points) both resolve the tool path through `relativeSitePath`, whose containment check is hard-coded to a `/` separator. `path.resolve` returns OS-separated paths, so on Windows the check never matches and throws for every valid in-directory tool path.

## Root cause

`package/ego-browser/src/learning/index.ts` (`relativeSitePath`):

```ts
const resolved = resolve(siteDir, manifestPath);
const siteRoot = resolve(siteDir);
if (resolved !== siteRoot && !resolved.startsWith(`${siteRoot}/`)) {
  throw new Error(`${label} path must stay inside the site skill directory`);
}
```

For `manifestPath = "tools/read-items.js"` on Windows, `resolved` is `C:\...\example\tools\read-items.js` while the guard tests `startsWith("C:\...\example" + "/")`. The character after the site root is `\`, so `startsWith` is always false and the guard throws. On POSIX the separator happens to be `/`, so the bug is invisible there.

Reproduced against the built runtime on Windows:

```
resolved: C:\...\example\tools\read-items.js
siteRoot: C:\...\example
startsWith(`${siteRoot}/`) -> false   => guard throws for a valid nested path
```

`loadLearnedContext` does not call `relativeSitePath`, so the agent is still told the tools exist and given usage examples, then every invocation fails with a misleading "path escapes the directory" error.

## Fix

Use `path.relative` for the containment check instead of a hard-coded separator (`relative` is already imported). The earlier guards in the same function already reject `..`, absolute paths, and backslashes, so this only needed a separator-correct final check.

```ts
const rel = relative(siteRoot, resolved);
if (rel.startsWith("..") || isAbsolute(rel)) {
  throw new Error(`${label} path must stay inside the site skill directory`);
}
```

## Verification

- New test in `learning/index.test.mjs` writes a site skill with an in-directory node tool and browser tool and asserts `runNodeSiteTool` returns the tool result and `loadBrowserToolSource` returns the source. The existing tests only exercised `loadLearnedContext`, which never hits this path, so the execution path was untested.
- On Windows the new test fails before this change (both calls throw "path must stay inside the site skill directory") and passes after. On POSIX it passes either way.
- Full `npm test`, `tsc --noEmit`, and `prettier --check` are clean.

## Caveat

This is an OS-specific (Windows) bug, not browser-dependent. It is fully deterministic and unit-testable, but a Linux/macOS-only CI will not exercise the failing path (the new test still passes there and guards against regressions). Severity is high on Windows (the learning tool feature is entirely broken) and zero elsewhere.

## Impact

- [x] Public helper API or behavior (`site.runTool` / `site.runBrowserTool` on Windows)
- [x] No externally visible impact on POSIX
