### PR TITLE
fix(env): expand ~ relative to the home directory in resolvePath

### DIFF
--- a/package/ego-browser/src/env.test.mjs
+++ b/package/ego-browser/src/env.test.mjs
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { join, resolve } from "node:path";
+
+import { resolvePath } from "../dist/src/env.js";
+
+test("resolvePath expands ~ relative to the home directory", () => {
+  const prevHome = process.env.HOME;
+  const prevProfile = process.env.USERPROFILE;
+  const home =
+    process.platform === "win32" ? "C:\\Users\\ego-test" : "/home/ego-test";
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  try {
+    // "~/ws" must land inside home, not be dropped to an absolute "/ws".
+    assert.equal(resolvePath("~/workspace"), resolve(join(home, "workspace")));
+    assert.equal(resolvePath("~"), resolve(home));
+    assert.equal(resolvePath("~/a/b"), resolve(join(home, "a", "b")));
+  } finally {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    if (prevProfile === undefined) {
+      delete process.env.USERPROFILE;
+    } else {
+      process.env.USERPROFILE = prevProfile;
+    }
+  }
+});
+
+test("resolvePath resolves a non-tilde path to an absolute path", () => {
+  assert.equal(resolvePath("some/rel/dir"), resolve("some/rel/dir"));
+});

--- a/package/ego-browser/src/env.ts
+++ b/package/ego-browser/src/env.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const SRC_DIR = dirname(fileURLToPath(import.meta.url));
@@ -20,7 +20,11 @@ export function agentWorkspace() {
 
 export function resolvePath(path) {
   if (path.startsWith("~")) {
-    return resolve(process.env.HOME || process.env.USERPROFILE || ".", path.slice(1));
+    // Use join, not resolve: path.slice(1) of "~/ws" is "/ws", which resolve()
+    // would treat as an absolute path and return verbatim, dropping the home
+    // directory. join keeps it relative to home ("~" -> home, "~/ws" -> home/ws).
+    const home = process.env.HOME || process.env.USERPROFILE || ".";
+    return resolve(join(home, path.slice(1)));
   }
   return resolve(path);
 }
@@ -36,7 +40,10 @@ export function loadEnvFile(path) {
     }
     const index = line.indexOf("=");
     const key = line.slice(0, index).trim();
-    const value = line.slice(index + 1).trim().replace(/^['"]|['"]$/g, "");
+    const value = line
+      .slice(index + 1)
+      .trim()
+      .replace(/^['"]|['"]$/g, "");
     if (key && process.env[key] === undefined) {
       process.env[key] = value;
     }


### PR DESCRIPTION
## Summary

`resolvePath("~/workspace")` returns `/workspace` (the home directory is dropped) instead of `<home>/workspace`. The `~` expansion in `env.ts` is broken on every platform, so pointing `EGO_BROWSER_AGENT_WORKSPACE` at a `~`-relative path resolves the agent workspace (and therefore learnings, `.env` loading, and `agent_helpers.js`) to the wrong directory.

## Root cause

`package/ego-browser/src/env.ts`:

```ts
export function resolvePath(path) {
  if (path.startsWith("~")) {
    return resolve(process.env.HOME || process.env.USERPROFILE || ".", path.slice(1));
  }
  return resolve(path);
}
```

For `"~/workspace"`, `path.slice(1)` is `"/workspace"`. `path.resolve(home, "/workspace")` treats `/workspace` as an absolute path segment, so it returns `/workspace` and discards `home` entirely. This is `path.resolve`'s documented right-to-left absolute-segment behavior.

Verified against the built runtime (HOME set to `/home/ego-test`):

```
resolvePath("~/workspace") -> /workspace        (expected /home/ego-test/workspace)
```

`~` survives literally when `EGO_BROWSER_AGENT_WORKSPACE` is set in a `.env` file (`loadEnvFile` does not shell-expand), which is exactly what `resolvePath` exists to handle.

## Fix

Join the remainder to the home directory instead of resolving it as a fresh absolute path, so `~` stays home-relative:

```ts
const home = process.env.HOME || process.env.USERPROFILE || ".";
return resolve(join(home, path.slice(1)));
```

`join` keeps the leading slash from `path.slice(1)` relative (`"~" -> home`, `"~/ws" -> home/ws`); the outer `resolve` normalizes.

## Verification

- New `env.test.mjs`: `resolvePath("~/workspace")`, `"~"`, and `"~/a/b"` now resolve under the home directory; a non-tilde path still resolves to an absolute path. Fails before this change (`~/workspace` -> `/workspace`), passes after. Cross-platform (uses the current OS home/join).
- Full `npm test`, `tsc --noEmit`, and `prettier --check` are clean.

## Impact

- [x] Public helper API or behavior (`resolvePath` / `EGO_BROWSER_AGENT_WORKSPACE` with a `~` path)
- [x] No externally visible impact for absolute or non-tilde workspace paths
