### PR TITLE
feat(ego-browser): add macOS GPU compatibility controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ We benchmarked ego lite against Vercel's agent-browser on four complex browser a
 
 Tutorials, the full tool reference, and integration guides live at [lite.ego.app/document/](https://lite.ego.app/document/).
 
+- [macOS GPU compatibility modes](skills/ego-browser/references/gpu.md)
+
 ## Community
 
 - [Discord](https://discord.gg/5eGZVvHbTq), questions, setup help, and skill sharing

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ We benchmarked ego lite against Vercel's agent-browser on four complex browser a
 Tutorials, the full tool reference, and integration guides live at [lite.ego.app/document/](https://lite.ego.app/document/).
 
 - [macOS GPU compatibility modes](skills/ego-browser/references/gpu.md)
+- [In-browser GPU mode controller](skills/ego-browser/gpu-controller/README.md)
 
 ## Community
 

--- a/package/ego-browser/test/gpu-controller.test.js
+++ b/package/ego-browser/test/gpu-controller.test.js
@@ -1,0 +1,373 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  access,
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  GRAPHITE_DISABLED_EXPERIMENT,
+  applyModeToLocalState,
+  detectMode,
+  launchArguments,
+} from "../../../skills/ego-browser/gpu-controller/native-host/mode-state.mjs";
+import { acquireRestartLock } from "../../../skills/ego-browser/gpu-controller/native-host/restart-lock.mjs";
+
+const manifestPath = fileURLToPath(
+  new URL(
+    "../../../skills/ego-browser/gpu-controller/extension/manifest.json",
+    import.meta.url,
+  ),
+);
+const installerPath = fileURLToPath(
+  new URL(
+    "../../../skills/ego-browser/gpu-controller/install.sh",
+    import.meta.url,
+  ),
+);
+const applyScriptPath = fileURLToPath(
+  new URL(
+    "../../../skills/ego-browser/gpu-controller/native-host/apply-and-restart.mjs",
+    import.meta.url,
+  ),
+);
+const uninstallPath = fileURLToPath(
+  new URL(
+    "../../../skills/ego-browser/gpu-controller/uninstall.sh",
+    import.meta.url,
+  ),
+);
+const hostScriptPath = fileURLToPath(
+  new URL(
+    "../../../skills/ego-browser/gpu-controller/native-host/host.mjs",
+    import.meta.url,
+  ),
+);
+
+test("balanced mode persists the tested Graphite disabled experiment", () => {
+  const current = {
+    browser: {
+      enabled_labs_experiments: ["existing-feature@1", "skia-graphite@2"],
+    },
+    unrelated: { value: true },
+  };
+  const next = applyModeToLocalState(current, "balanced");
+
+  assert.deepEqual(next.browser.enabled_labs_experiments, [
+    "existing-feature@1",
+    GRAPHITE_DISABLED_EXPERIMENT,
+  ]);
+  assert.equal(next.hardware_acceleration_mode.enabled, true);
+  assert.deepEqual(next.unrelated, { value: true });
+  assert.notEqual(next, current);
+});
+
+test("software mode disables hardware acceleration and removes Graphite overrides", () => {
+  const next = applyModeToLocalState(
+    {
+      browser: {
+        enabled_labs_experiments: [
+          GRAPHITE_DISABLED_EXPERIMENT,
+          "existing-feature@1",
+        ],
+      },
+    },
+    "software",
+  );
+
+  assert.equal(next.hardware_acceleration_mode.enabled, false);
+  assert.deepEqual(next.browser.enabled_labs_experiments, [
+    "existing-feature@1",
+  ]);
+  assert.equal(detectMode(next), "software");
+});
+
+test("normal and low-power use the expected persistent and launch settings", () => {
+  const normal = applyModeToLocalState({}, "normal");
+  const lowPower = applyModeToLocalState({}, "low-power");
+
+  assert.equal(detectMode(normal), "normal");
+  assert.equal(lowPower.hardware_acceleration_mode.enabled, true);
+  assert.deepEqual(launchArguments("normal"), []);
+  assert.deepEqual(launchArguments("low-power"), ["--disable-webgl"]);
+});
+
+test("saved low-power mode takes precedence over Local State inference", () => {
+  assert.equal(
+    detectMode(
+      {
+        browser: {
+          enabled_labs_experiments: [GRAPHITE_DISABLED_EXPERIMENT],
+        },
+      },
+      "low-power",
+    ),
+    "low-power",
+  );
+});
+
+test("stale saved modes do not override persistent Chromium state", () => {
+  assert.equal(detectMode({}, "software"), "normal");
+  assert.equal(
+    detectMode({ hardware_acceleration_mode: { enabled: false } }, "normal"),
+    "software",
+  );
+});
+
+test("manifest key produces the native host allowlisted extension id", async () => {
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  const digest = createHash("sha256")
+    .update(Buffer.from(manifest.key, "base64"))
+    .digest("hex")
+    .slice(0, 32);
+  const extensionId = digest.replace(/[0-9a-f]/g, (digit) =>
+    String.fromCharCode(97 + Number.parseInt(digit, 16)),
+  );
+
+  assert.equal(extensionId, "iemmjhekmkccaghebaammoflapofhaik");
+});
+
+test("native host rejects messages larger than its protocol limit", async () => {
+  const header = Buffer.alloc(4);
+  header.writeUInt32LE(64 * 1024 + 1);
+  const response = await runNativeHost(header);
+
+  assert.equal(response.ok, false);
+  assert.match(response.error, /exceeds 65536 bytes/);
+});
+
+test("restart lock allows only one concurrent scheduler", async () => {
+  const root = await mkdtemp(join(tmpdir(), "ego-gpu-controller-lock-"));
+  const lockPath = join(root, "gpu_mode_restart.lock");
+  const results = await Promise.all([
+    acquireRestartLock(lockPath),
+    acquireRestartLock(lockPath),
+  ]);
+
+  assert.deepEqual(results.sort(), [false, true]);
+});
+
+test("installer writes the native host to the configured compatibility directory", async () => {
+  const root = await mkdtemp(join(tmpdir(), "ego-gpu-controller-install-"));
+  const bin = join(root, "bin");
+  const userData = join(root, "user-data");
+  const nativeHosts = join(root, "native-hosts");
+  await mkdir(bin);
+  await writeExecutable(join(bin, "open"), "#!/bin/sh\nexit 0\n");
+
+  const result = spawnSync("sh", [installerPath], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      EGO_LITE_NATIVE_MESSAGING_DIR: nativeHosts,
+      EGO_LITE_USER_DATA_DIR: userData,
+      PATH: `${bin}:${process.env.PATH}`,
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const manifest = JSON.parse(
+    await readFile(
+      join(nativeHosts, "com.citrolabs.ego.gpu_mode.json"),
+      "utf8",
+    ),
+  );
+  assert.equal(manifest.name, "com.citrolabs.ego.gpu_mode");
+  assert.deepEqual(manifest.allowed_origins, [
+    "chrome-extension://iemmjhekmkccaghebaammoflapofhaik/",
+  ]);
+  assert.match(manifest.path, /GpuModeController\/native-host\/host$/);
+});
+
+test("uninstaller removes controller files after normal mode is restored", async () => {
+  const root = await mkdtemp(join(tmpdir(), "ego-gpu-controller-uninstall-"));
+  const userData = join(root, "user-data");
+  const nativeHosts = join(root, "native-hosts");
+  const installDir = join(userData, "GpuModeController");
+  const manifestPath = join(nativeHosts, "com.citrolabs.ego.gpu_mode.json");
+  await mkdir(installDir, { recursive: true });
+  await mkdir(nativeHosts);
+  await writeFile(
+    join(userData, "Local State"),
+    JSON.stringify({ hardware_acceleration_mode: { enabled: true } }),
+  );
+  await writeFile(join(userData, "gpu_mode.json"), '{"mode":"normal"}');
+  await writeFile(join(userData, "gpu_mode_error.log"), "old error");
+  await writeFile(join(userData, "gpu_mode_restart.lock"), "old lock");
+  await writeFile(join(installDir, "installed.txt"), "fixture");
+  await writeFile(manifestPath, "{}");
+
+  const result = spawnSync("sh", [uninstallPath], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      EGO_LITE_NATIVE_MESSAGING_DIR: nativeHosts,
+      EGO_LITE_USER_DATA_DIR: userData,
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  await assertMissing(manifestPath);
+  await assertMissing(installDir);
+  await assertMissing(join(userData, "gpu_mode.json"));
+  await assertMissing(join(userData, "gpu_mode_error.log"));
+  await assertMissing(join(userData, "gpu_mode_restart.lock"));
+});
+
+test("uninstaller refuses to remove a non-normal persistent mode", async () => {
+  const root = await mkdtemp(join(tmpdir(), "ego-gpu-controller-uninstall-"));
+  const userData = join(root, "user-data");
+  const nativeHosts = join(root, "native-hosts");
+  const manifestPath = join(nativeHosts, "com.citrolabs.ego.gpu_mode.json");
+  await mkdir(userData);
+  await mkdir(nativeHosts);
+  await writeFile(
+    join(userData, "Local State"),
+    JSON.stringify({
+      browser: { enabled_labs_experiments: [GRAPHITE_DISABLED_EXPERIMENT] },
+    }),
+  );
+  await writeFile(manifestPath, "{}");
+
+  const result = spawnSync("sh", [uninstallPath], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      EGO_LITE_NATIVE_MESSAGING_DIR: nativeHosts,
+      EGO_LITE_USER_DATA_DIR: userData,
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /switch ego GPU Mode to Normal/);
+  await access(manifestPath);
+});
+
+test("apply script updates Local State atomically and launches balanced mode", async () => {
+  const fixture = await createApplyFixture({
+    localState: {
+      browser: {
+        enabled_labs_experiments: ["existing-feature@1"],
+      },
+      unrelated: { value: true },
+    },
+  });
+  const result = runApplyScript(fixture, "balanced");
+
+  assert.equal(result.status, 0, result.stderr);
+  const localState = JSON.parse(
+    await readFile(join(fixture.userData, "Local State"), "utf8"),
+  );
+  assert.deepEqual(localState.browser.enabled_labs_experiments, [
+    "existing-feature@1",
+    GRAPHITE_DISABLED_EXPERIMENT,
+  ]);
+  assert.equal(localState.hardware_acceleration_mode.enabled, true);
+  assert.deepEqual(localState.unrelated, { value: true });
+  assert.deepEqual(
+    (await readFile(fixture.openCapture, "utf8")).trim().split(/\r?\n/),
+    ["-na", fixture.appPath],
+  );
+});
+
+test("apply script preserves malformed Local State and still reopens ego lite", async () => {
+  const fixture = await createApplyFixture({ localState: "{not-json" });
+  const result = runApplyScript(fixture, "normal");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    await readFile(join(fixture.userData, "Local State"), "utf8"),
+    "{not-json",
+  );
+  assert.match(
+    await readFile(join(fixture.userData, "gpu_mode_error.log"), "utf8"),
+    /SyntaxError/,
+  );
+  assert.deepEqual(
+    (await readFile(fixture.openCapture, "utf8")).trim().split(/\r?\n/),
+    ["-na", fixture.appPath],
+  );
+});
+
+async function createApplyFixture({ localState }) {
+  const root = await mkdtemp(join(tmpdir(), "ego-gpu-controller-apply-"));
+  const bin = join(root, "bin");
+  const userData = join(root, "user-data");
+  const openCapture = join(root, "open-args.txt");
+  const appPath = join(root, "ego lite.app");
+  await mkdir(bin);
+  await mkdir(userData);
+  await mkdir(appPath);
+  await writeFile(
+    join(userData, "Local State"),
+    typeof localState === "string" ? localState : JSON.stringify(localState),
+  );
+  await writeExecutable(join(bin, "osascript"), "#!/bin/sh\nexit 0\n");
+  await writeExecutable(join(bin, "pgrep"), "#!/bin/sh\nexit 1\n");
+  await writeExecutable(join(bin, "pkill"), "#!/bin/sh\nexit 0\n");
+  await writeExecutable(
+    join(bin, "open"),
+    '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$OPEN_CAPTURE"\n',
+  );
+  return { appPath, bin, openCapture, root, userData };
+}
+
+function runApplyScript(fixture, mode) {
+  return spawnSync(process.execPath, [applyScriptPath, mode], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      EGO_LITE_APP_PATH: fixture.appPath,
+      EGO_LITE_OPEN_PATH: join(fixture.bin, "open"),
+      EGO_LITE_OSASCRIPT_PATH: join(fixture.bin, "osascript"),
+      EGO_LITE_PGREP_PATH: join(fixture.bin, "pgrep"),
+      EGO_LITE_PKILL_PATH: join(fixture.bin, "pkill"),
+      EGO_LITE_USER_DATA_DIR: fixture.userData,
+      OPEN_CAPTURE: fixture.openCapture,
+    },
+  });
+}
+
+function runNativeHost(input) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [hostScriptPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let output = Buffer.alloc(0);
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      output = Buffer.concat([output, chunk]);
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", () => {
+      if (output.length < 4) {
+        reject(new Error(stderr || "native host returned no response"));
+        return;
+      }
+      const length = output.readUInt32LE(0);
+      resolve(JSON.parse(output.subarray(4, 4 + length).toString("utf8")));
+    });
+    child.stdin.end(input);
+  });
+}
+
+async function assertMissing(path) {
+  await assert.rejects(access(path), { code: "ENOENT" });
+}
+
+async function writeExecutable(path, contents) {
+  await writeFile(path, contents);
+  await chmod(path, 0o755);
+}

--- a/package/ego-browser/test/gpu-controller.test.js
+++ b/package/ego-browser/test/gpu-controller.test.js
@@ -12,12 +12,14 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import {
   GRAPHITE_DISABLED_EXPERIMENT,
   applyModeToLocalState,
   detectMode,
   launchArguments,
+  unsupportedModesForAppVersion,
 } from "../../../skills/ego-browser/gpu-controller/native-host/mode-state.mjs";
 import { acquireRestartLock } from "../../../skills/ego-browser/gpu-controller/native-host/restart-lock.mjs";
 
@@ -48,6 +50,12 @@ const uninstallPath = fileURLToPath(
 const hostScriptPath = fileURLToPath(
   new URL(
     "../../../skills/ego-browser/gpu-controller/native-host/host.mjs",
+    import.meta.url,
+  ),
+);
+const watchdogScriptPath = fileURLToPath(
+  new URL(
+    "../../../skills/ego-browser/gpu-controller/native-host/low-power-watchdog.mjs",
     import.meta.url,
   ),
 );
@@ -97,7 +105,12 @@ test("normal and low-power use the expected persistent and launch settings", () 
   assert.equal(detectMode(normal), "normal");
   assert.equal(lowPower.hardware_acceleration_mode.enabled, true);
   assert.deepEqual(launchArguments("normal"), []);
-  assert.deepEqual(launchArguments("low-power"), ["--disable-webgl"]);
+  assert.deepEqual(launchArguments("low-power"), []);
+});
+
+test("software mode is blocked on the ego lite version that crashes", () => {
+  assert.deepEqual(unsupportedModesForAppVersion("0.4.6.12"), ["software"]);
+  assert.deepEqual(unsupportedModesForAppVersion("0.4.6.13"), []);
 });
 
 test("saved low-power mode takes precedence over Local State inference", () => {
@@ -153,6 +166,60 @@ test("restart lock allows only one concurrent scheduler", async () => {
   ]);
 
   assert.deepEqual(results.sort(), [false, true]);
+});
+
+test("low-power watchdog hides ego lite after it loses focus", async () => {
+  const root = await mkdtemp(join(tmpdir(), "ego-gpu-watchdog-"));
+  const osascript = join(root, "osascript");
+  const pidPath = join(root, "watchdog.pid");
+  const errorPath = join(root, "watchdog-error.log");
+  const startLockPath = join(root, "watchdog-start.lock");
+  const restartLockPath = join(root, "restart.lock");
+  const eventsPath = join(root, "events.txt");
+  await writeExecutable(
+    osascript,
+    `#!/bin/sh
+case "$*" in
+  *'return "running|"'*) printf 'running|true|false\\n' ;;
+  *) printf 'hide\\n' >> "$WATCHDOG_EVENTS" ;;
+esac
+`,
+  );
+  const env = {
+    ...process.env,
+    EGO_LITE_OSASCRIPT_PATH: osascript,
+    EGO_LITE_WATCHDOG_PID_PATH: pidPath,
+    EGO_LITE_WATCHDOG_ERROR_PATH: errorPath,
+    EGO_LITE_WATCHDOG_START_LOCK_PATH: startLockPath,
+    EGO_LITE_RESTART_LOCK_PATH: restartLockPath,
+    EGO_LITE_WATCHDOG_POLL_MS: "20",
+    EGO_LITE_WATCHDOG_UNFOCUSED_MS: "30",
+    WATCHDOG_EVENTS: eventsPath,
+  };
+
+  try {
+    const start = spawnSync(process.execPath, [watchdogScriptPath, "start"], {
+      env,
+      encoding: "utf8",
+    });
+    assert.equal(start.status, 0, start.stderr);
+    for (let attempt = 0; attempt < 50; attempt++) {
+      try {
+        await access(eventsPath);
+        break;
+      } catch {
+        await delay(40);
+      }
+    }
+    assert.match(await readFile(eventsPath, "utf8"), /hide/);
+    const status = spawnSync(process.execPath, [watchdogScriptPath, "status"], {
+      env,
+      encoding: "utf8",
+    });
+    assert.equal(status.stdout.trim(), "running");
+  } finally {
+    spawnSync(process.execPath, [watchdogScriptPath, "stop"], { env });
+  }
 });
 
 test("installer writes the native host to the configured compatibility directory", async () => {
@@ -276,6 +343,25 @@ test("apply script updates Local State atomically and launches balanced mode", a
     (await readFile(fixture.openCapture, "utf8")).trim().split(/\r?\n/),
     ["-na", fixture.appPath],
   );
+  assert.equal(
+    (await readFile(fixture.watchdogCapture, "utf8")).trim(),
+    "stop",
+  );
+});
+
+test("apply script starts the background watchdog for low-power mode", async () => {
+  const fixture = await createApplyFixture({ localState: {} });
+  const result = runApplyScript(fixture, "low-power");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(
+    (await readFile(fixture.openCapture, "utf8")).trim().split(/\r?\n/),
+    ["-na", fixture.appPath],
+  );
+  assert.deepEqual(
+    (await readFile(fixture.watchdogCapture, "utf8")).trim().split(/\r?\n/),
+    ["stop", "start"],
+  );
 });
 
 test("apply script preserves malformed Local State and still reopens ego lite", async () => {
@@ -302,6 +388,8 @@ async function createApplyFixture({ localState }) {
   const bin = join(root, "bin");
   const userData = join(root, "user-data");
   const openCapture = join(root, "open-args.txt");
+  const watchdogCapture = join(root, "watchdog-args.txt");
+  const watchdogPath = join(root, "watchdog.mjs");
   const appPath = join(root, "ego lite.app");
   await mkdir(bin);
   await mkdir(userData);
@@ -317,7 +405,19 @@ async function createApplyFixture({ localState }) {
     join(bin, "open"),
     '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$OPEN_CAPTURE"\n',
   );
-  return { appPath, bin, openCapture, root, userData };
+  await writeFile(
+    watchdogPath,
+    'import { appendFileSync } from "node:fs"; appendFileSync(process.env.WATCHDOG_CAPTURE, `${process.argv[2]}\\n`);\n',
+  );
+  return {
+    appPath,
+    bin,
+    openCapture,
+    root,
+    userData,
+    watchdogCapture,
+    watchdogPath,
+  };
 }
 
 function runApplyScript(fixture, mode) {
@@ -331,7 +431,10 @@ function runApplyScript(fixture, mode) {
       EGO_LITE_PGREP_PATH: join(fixture.bin, "pgrep"),
       EGO_LITE_PKILL_PATH: join(fixture.bin, "pkill"),
       EGO_LITE_USER_DATA_DIR: fixture.userData,
+      EGO_LITE_APP_VERSION: "test",
+      EGO_LITE_WATCHDOG_PATH: fixture.watchdogPath,
       OPEN_CAPTURE: fixture.openCapture,
+      WATCHDOG_CAPTURE: fixture.watchdogCapture,
     },
   });
 }

--- a/package/ego-browser/test/gpu-launcher.test.js
+++ b/package/ego-browser/test/gpu-launcher.test.js
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const launcher = fileURLToPath(
+  new URL(
+    "../../../skills/ego-browser/scripts/launch-gpu-mode.sh",
+    import.meta.url,
+  ),
+);
+
+async function createFixture({ running = false } = {}) {
+  const root = await mkdtemp(join(tmpdir(), "ego-gpu-launcher-"));
+  const bin = join(root, "bin");
+  const appPath = join(root, "ego lite.app");
+  const capturePath = join(root, "open-args.txt");
+  await mkdir(bin);
+  await mkdir(appPath);
+  await writeExecutable(join(bin, "uname"), "#!/bin/sh\nprintf 'Darwin\\n'\n");
+  await writeExecutable(
+    join(bin, "pgrep"),
+    running ? "#!/bin/sh\nexit 0\n" : "#!/bin/sh\nexit 1\n",
+  );
+  await writeExecutable(
+    join(bin, "open"),
+    '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$OPEN_CAPTURE"\n',
+  );
+  return {
+    appPath,
+    capturePath,
+    env: {
+      ...process.env,
+      EGO_LITE_APP_PATH: appPath,
+      OPEN_CAPTURE: capturePath,
+      PATH: `${bin}:${process.env.PATH}`,
+    },
+  };
+}
+
+async function writeExecutable(path, contents) {
+  await writeFile(path, contents);
+  await chmod(path, 0o755);
+}
+
+async function runLauncher(mode, options) {
+  const fixture = await createFixture(options);
+  const result = spawnSync("sh", [launcher, mode], {
+    env: fixture.env,
+    encoding: "utf8",
+  });
+  let args = [];
+  try {
+    args = (await readFile(fixture.capturePath, "utf8")).trim().split(/\r?\n/);
+  } catch {}
+  return { ...fixture, result, args };
+}
+
+for (const [mode, flag] of [
+  ["balanced", "--disable-skia-graphite"],
+  ["low-power", "--disable-webgl"],
+  ["software", "--disable-gpu"],
+]) {
+  test(`${mode} launches ego lite with the expected Chromium flag`, async () => {
+    const { appPath, result, args } = await runLauncher(mode);
+    assert.equal(result.status, 0);
+    assert.deepEqual(args, ["-n", appPath, "--args", flag]);
+  });
+}
+
+test("normal launches ego lite without Chromium flags", async () => {
+  const { appPath, result, args } = await runLauncher("normal");
+  assert.equal(result.status, 0);
+  assert.deepEqual(args, [appPath]);
+});
+
+test("launcher refuses to change graphics mode while ego lite is running", async () => {
+  const { result, args } = await runLauncher("low-power", { running: true });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /already running/);
+  assert.deepEqual(args, []);
+});
+
+test("launcher rejects unknown modes", async () => {
+  const { result, args } = await runLauncher("turbo");
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Usage:/);
+  assert.deepEqual(args, []);
+});

--- a/package/ego-browser/test/gpu-launcher.test.js
+++ b/package/ego-browser/test/gpu-launcher.test.js
@@ -60,7 +60,7 @@ async function runLauncher(mode, options) {
 }
 
 for (const [mode, flag] of [
-  ["balanced", "--disable-skia-graphite"],
+  ["balanced", "--disable-features=SkiaGraphite"],
   ["low-power", "--disable-webgl"],
   ["software", "--disable-gpu"],
 ]) {

--- a/package/ego-browser/test/gpu-launcher.test.js
+++ b/package/ego-browser/test/gpu-launcher.test.js
@@ -18,6 +18,8 @@ async function createFixture({ running = false } = {}) {
   const bin = join(root, "bin");
   const appPath = join(root, "ego lite.app");
   const capturePath = join(root, "open-args.txt");
+  const watchdogCapturePath = join(root, "watchdog-args.txt");
+  const watchdogPath = join(root, "watchdog.mjs");
   await mkdir(bin);
   await mkdir(appPath);
   await writeExecutable(join(bin, "uname"), "#!/bin/sh\nprintf 'Darwin\\n'\n");
@@ -29,13 +31,20 @@ async function createFixture({ running = false } = {}) {
     join(bin, "open"),
     '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$OPEN_CAPTURE"\n',
   );
+  await writeFile(
+    watchdogPath,
+    'import { appendFileSync } from "node:fs"; appendFileSync(process.env.WATCHDOG_CAPTURE, `${process.argv[2]}\\n`);\n',
+  );
   return {
     appPath,
     capturePath,
+    watchdogCapturePath,
     env: {
       ...process.env,
       EGO_LITE_APP_PATH: appPath,
+      EGO_LITE_WATCHDOG_PATH: watchdogPath,
       OPEN_CAPTURE: capturePath,
+      WATCHDOG_CAPTURE: watchdogCapturePath,
       PATH: `${bin}:${process.env.PATH}`,
     },
   };
@@ -53,15 +62,20 @@ async function runLauncher(mode, options) {
     encoding: "utf8",
   });
   let args = [];
+  let watchdogArgs = [];
   try {
     args = (await readFile(fixture.capturePath, "utf8")).trim().split(/\r?\n/);
   } catch {}
-  return { ...fixture, result, args };
+  try {
+    watchdogArgs = (await readFile(fixture.watchdogCapturePath, "utf8"))
+      .trim()
+      .split(/\r?\n/);
+  } catch {}
+  return { ...fixture, result, args, watchdogArgs };
 }
 
 for (const [mode, flag] of [
   ["balanced", "--disable-features=SkiaGraphite"],
-  ["low-power", "--disable-webgl"],
   ["software", "--disable-gpu"],
 ]) {
   test(`${mode} launches ego lite with the expected Chromium flag`, async () => {
@@ -70,6 +84,14 @@ for (const [mode, flag] of [
     assert.deepEqual(args, ["-n", appPath, "--args", flag]);
   });
 }
+
+test("low-power launches normally and starts the background watchdog", async () => {
+  const { appPath, result, args, watchdogArgs } =
+    await runLauncher("low-power");
+  assert.equal(result.status, 0);
+  assert.deepEqual(args, ["-n", appPath]);
+  assert.deepEqual(watchdogArgs, ["stop", "start"]);
+});
 
 test("normal launches ego lite without Chromium flags", async () => {
   const { appPath, result, args } = await runLauncher("normal");

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -194,8 +194,10 @@ Combine the paths within the same Bash invocation whenever their next inputs are
 - `page.snapshot()` defaults to full-page. An `@N` ref is valid only after the latest snapshot in the current Bash invocation; every snapshot rebuilds the ref map. If the command ends, re-snapshot next time or use a semantic/stable locator.
 - `page.evaluate(fn, arg)` runs in the page and returns the value directly; do not `JSON.parse` it or pass a function body as a string. Heredoc code runs in Node.js; `document` and `window` exist only inside page evaluation.
 - If `page.info()` returns `{ dialog: ... }`, handle it with `cdp('Page.handleJavaScriptDialog', { accept: true })` or `accept: false` before page JavaScript. If it reports `w: 0` or `h: 0`, stop screenshot/coordinate work until the real tab or viewport is restored and re-verified.
+- If the user reports sustained high GPU usage on macOS, read `references/gpu.md`. The compatibility launcher changes Chromium graphics features, so explain the trade-off and obtain approval before relaunching ego lite.
 - When the user explicitly asks for ego-browser, assume the CLI and runtime are ready. Do not preflight `which`, Node versions, package metadata, or help. Investigate only after the first real command errors; for a missing install, read `references/install.md`.
 
 # References:
 - [screencast video recording](references/video.md)
 - [install](references/install.md)
+- [macOS GPU compatibility modes](references/gpu.md)

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -194,7 +194,7 @@ Combine the paths within the same Bash invocation whenever their next inputs are
 - `page.snapshot()` defaults to full-page. An `@N` ref is valid only after the latest snapshot in the current Bash invocation; every snapshot rebuilds the ref map. If the command ends, re-snapshot next time or use a semantic/stable locator.
 - `page.evaluate(fn, arg)` runs in the page and returns the value directly; do not `JSON.parse` it or pass a function body as a string. Heredoc code runs in Node.js; `document` and `window` exist only inside page evaluation.
 - If `page.info()` returns `{ dialog: ... }`, handle it with `cdp('Page.handleJavaScriptDialog', { accept: true })` or `accept: false` before page JavaScript. If it reports `w: 0` or `h: 0`, stop screenshot/coordinate work until the real tab or viewport is restored and re-verified.
-- If the user reports sustained high GPU usage on macOS, read `references/gpu.md`. The compatibility launcher changes Chromium graphics features, so explain the trade-off and obtain approval before relaunching ego lite.
+- If the user reports sustained high GPU usage on macOS, read `references/gpu.md`. Prefer the optional in-browser GPU controller after its one-time installation; otherwise use the compatibility launcher. Explain the trade-off and obtain approval before relaunching ego lite.
 - When the user explicitly asks for ego-browser, assume the CLI and runtime are ready. Do not preflight `which`, Node versions, package metadata, or help. Investigate only after the first real command errors; for a missing install, read `references/install.md`.
 
 # References:

--- a/skills/ego-browser/gpu-controller/README.md
+++ b/skills/ego-browser/gpu-controller/README.md
@@ -1,0 +1,33 @@
+# ego GPU Mode controller
+
+This optional macOS integration adds a GPU mode selector to the ego lite toolbar without modifying or re-signing the browser application.
+
+## Install
+
+```bash
+sh skills/ego-browser/gpu-controller/install.sh
+```
+
+The installer opens `ego://extensions`. Enable Developer mode, choose **Load unpacked**, and select the extension directory printed by the installer. This is a one-time setup.
+
+After installation, pin **ego GPU Mode** from the extensions menu. Selecting a mode saves the configuration and restarts ego lite automatically. The restart ends active Agent tasks, so finish or pause important work before switching.
+
+The controller uses Chromium's own persistent `Local State` preference for normal, balanced, and software-rendering modes. Low-power mode requires the startup-only `--disable-webgl` switch, so the extension checks and reapplies it automatically after later normal launches.
+
+On macOS, ego lite stores profile data under `Citro Labs/ego lite`, but its current Chromium build resolves user-level native messaging manifests from the Google Chrome compatibility directory. The installer handles both paths separately, and the host manifest only allows this extension's fixed ID.
+
+## Security boundary
+
+- The integration never edits `/Applications/ego lite.app`.
+- The native messaging host only accepts the four predefined modes.
+- The fixed extension ID is an allowlist, not code signing. Only load the installer-copied extension directory.
+- The host preserves unrelated browser preferences and extension data.
+- Applying a mode requires a browser restart because Chromium graphics initialization happens at process startup.
+
+## Uninstall
+
+Select **Normal** and let ego lite restart. Then remove **ego GPU Mode** from `ego://extensions` and run:
+
+```bash
+sh skills/ego-browser/gpu-controller/uninstall.sh
+```

--- a/skills/ego-browser/gpu-controller/README.md
+++ b/skills/ego-browser/gpu-controller/README.md
@@ -1,6 +1,6 @@
 # ego GPU Mode controller
 
-This optional macOS integration adds a GPU mode selector to the ego lite toolbar without modifying or re-signing the browser application.
+This optional macOS integration adds a GPU and background-power selector to the ego lite toolbar without modifying or re-signing the browser application.
 
 ## Install
 
@@ -12,7 +12,9 @@ The installer opens `ego://extensions`. Enable Developer mode, choose **Load unp
 
 After installation, pin **ego GPU Mode** from the extensions menu. Selecting a mode saves the configuration and restarts ego lite automatically. The restart ends active Agent tasks, so finish or pause important work before switching.
 
-The controller uses Chromium's own persistent `Local State` preference for normal, balanced, and software-rendering modes. Low-power mode requires the startup-only `--disable-webgl` switch, so the extension checks and reapplies it automatically after later normal launches.
+The controller uses Chromium's own persistent `Local State` preference for normal and balanced modes. Low-power mode starts a local watchdog that hides ego lite after the browser loses focus. Clicking the ego lite Dock icon restores it, and the watchdog leaves it visible while it remains frontmost.
+
+Software rendering is disabled on ego lite `0.4.6.12`: both Chromium's hardware-acceleration preference and `--disable-gpu` cause that build to exit with `SIGTRAP`.
 
 On macOS, ego lite stores profile data under `Citro Labs/ego lite`, but its current Chromium build resolves user-level native messaging manifests from the Google Chrome compatibility directory. The installer handles both paths separately, and the host manifest only allows this extension's fixed ID.
 
@@ -22,7 +24,8 @@ On macOS, ego lite stores profile data under `Citro Labs/ego lite`, but its curr
 - The native messaging host only accepts the four predefined modes.
 - The fixed extension ID is an allowlist, not code signing. Only load the installer-copied extension directory.
 - The host preserves unrelated browser preferences and extension data.
-- Applying a mode requires a browser restart because Chromium graphics initialization happens at process startup.
+- Mode changes restart the browser to apply `Local State` safely and remove stale startup flags from older controller versions.
+- The low-power watchdog only reads ego lite's foreground/visibility state and hides that application after it loses focus.
 
 ## Uninstall
 

--- a/skills/ego-browser/gpu-controller/extension/background.js
+++ b/skills/ego-browser/gpu-controller/extension/background.js
@@ -1,0 +1,7 @@
+const nativeHost = "com.citrolabs.ego.gpu_mode";
+
+chrome.runtime.onStartup.addListener(() => {
+  chrome.runtime.sendNativeMessage(nativeHost, { action: "ensureMode" }, () => {
+    void chrome.runtime.lastError;
+  });
+});

--- a/skills/ego-browser/gpu-controller/extension/manifest.json
+++ b/skills/ego-browser/gpu-controller/extension/manifest.json
@@ -1,0 +1,15 @@
+{
+  "manifest_version": 3,
+  "name": "ego GPU Mode",
+  "version": "0.1.0",
+  "description": "Switch ego lite graphics compatibility modes from the browser toolbar.",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqW4a2IVMuVH1LK/arPNdBDXFOBbJfsV9nNEu3JAYNcPXTIy7zUOBKKubezuCVy5/1JTYIkIg4fwbbCO9NMh/i2Gl1jqshat02qWhw9uPeJ6YHjN8XZ1tkBjYIxb/qShtVWrUiXYgFBBD9z6tmPXj4KCFigj+l10pR3oxkzPYPmpJMCz7jK94PEsF/ze/+wVmjxYvutaZwPuY1PI3MKciVy0CqQneWSAuG5bmEsv8aExVKqW1w9mvfUuV1iaSrq2kxtP4JD4hRHNuBINQbfZwhmUggNsTPOr3g+5Q9o0jvqNoGBPsD0dmwYGp1tXfPjfZZdpRfOJ1AShEkqOanxq27wIDAQAB",
+  "permissions": ["nativeMessaging"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_title": "ego GPU Mode",
+    "default_popup": "popup.html"
+  }
+}

--- a/skills/ego-browser/gpu-controller/extension/manifest.json
+++ b/skills/ego-browser/gpu-controller/extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "ego GPU Mode",
-  "version": "0.1.0",
-  "description": "Switch ego lite graphics compatibility modes from the browser toolbar.",
+  "version": "0.2.0",
+  "description": "Switch ego lite GPU compatibility and background power modes from the browser toolbar.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqW4a2IVMuVH1LK/arPNdBDXFOBbJfsV9nNEu3JAYNcPXTIy7zUOBKKubezuCVy5/1JTYIkIg4fwbbCO9NMh/i2Gl1jqshat02qWhw9uPeJ6YHjN8XZ1tkBjYIxb/qShtVWrUiXYgFBBD9z6tmPXj4KCFigj+l10pR3oxkzPYPmpJMCz7jK94PEsF/ze/+wVmjxYvutaZwPuY1PI3MKciVy0CqQneWSAuG5bmEsv8aExVKqW1w9mvfUuV1iaSrq2kxtP4JD4hRHNuBINQbfZwhmUggNsTPOr3g+5Q9o0jvqNoGBPsD0dmwYGp1tXfPjfZZdpRfOJ1AShEkqOanxq27wIDAQAB",
   "permissions": ["nativeMessaging"],
   "background": {

--- a/skills/ego-browser/gpu-controller/extension/popup.css
+++ b/skills/ego-browser/gpu-controller/extension/popup.css
@@ -1,0 +1,150 @@
+:root {
+  color-scheme: light dark;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  width: 330px;
+  margin: 0;
+  color: #16181d;
+  background: #f5f6f8;
+}
+
+main {
+  padding: 18px;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+h1,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.eyebrow {
+  margin-bottom: 2px;
+  color: #6b7280;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.badge {
+  flex: none;
+  padding: 5px 9px;
+  border-radius: 999px;
+  color: #2459b3;
+  background: #e6efff;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.intro {
+  margin: 12px 0 14px;
+  color: #626975;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+#modes {
+  display: grid;
+  gap: 8px;
+}
+
+button {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 3px 12px;
+  padding: 11px 12px;
+  border: 1px solid #d9dde5;
+  border-radius: 12px;
+  color: inherit;
+  background: #ffffff;
+  text-align: left;
+  cursor: pointer;
+}
+
+button:hover {
+  border-color: #8fb4f4;
+  background: #f7faff;
+}
+
+button[aria-pressed="true"] {
+  border-color: #3977dd;
+  box-shadow: 0 0 0 1px #3977dd;
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+.mode-name {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.mode-detail {
+  grid-column: 1 / -1;
+  color: #69717e;
+  font-size: 12px;
+}
+
+.mode-result {
+  align-self: center;
+  color: #3977dd;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+#status {
+  min-height: 18px;
+  margin-top: 12px;
+  color: #626975;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+#status.error {
+  color: #b42318;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color: #f4f6f8;
+    background: #181a1f;
+  }
+
+  .eyebrow,
+  .intro,
+  .mode-detail,
+  #status {
+    color: #aeb4bf;
+  }
+
+  .badge {
+    color: #b9d2ff;
+    background: #263b61;
+  }
+
+  button {
+    border-color: #3b3f48;
+    background: #24272d;
+  }
+
+  button:hover {
+    border-color: #5f8edc;
+    background: #292e37;
+  }
+}

--- a/skills/ego-browser/gpu-controller/extension/popup.css
+++ b/skills/ego-browser/gpu-controller/extension/popup.css
@@ -86,7 +86,7 @@ button[aria-pressed="true"] {
 }
 
 button:disabled {
-  cursor: wait;
+  cursor: not-allowed;
   opacity: 0.6;
 }
 

--- a/skills/ego-browser/gpu-controller/extension/popup.html
+++ b/skills/ego-browser/gpu-controller/extension/popup.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ego GPU Mode</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <div>
+          <p class="eyebrow">ego lite</p>
+          <h1>GPU 模式</h1>
+        </div>
+        <span id="current-mode" class="badge">读取中</span>
+      </header>
+
+      <p class="intro">
+        选择后会结束正在运行的 Agent 任务，保存设置并自动重启浏览器。
+      </p>
+
+      <section id="modes" aria-label="GPU 模式">
+        <button type="button" data-mode="normal">
+          <span class="mode-name">正常</span>
+          <span class="mode-detail">原始渲染配置</span>
+        </button>
+        <button type="button" data-mode="balanced">
+          <span class="mode-name">均衡</span>
+          <span class="mode-detail">关闭 Graphite，保留 WebGL</span>
+          <span class="mode-result">实测约 46.9%</span>
+        </button>
+        <button type="button" data-mode="low-power">
+          <span class="mode-name">低功耗</span>
+          <span class="mode-detail">关闭 WebGL，部分视觉功能不可用</span>
+          <span class="mode-result">实测约 24.2%</span>
+        </button>
+        <button type="button" data-mode="software">
+          <span class="mode-name">软件渲染</span>
+          <span class="mode-detail">排障用，会增加 CPU 负载</span>
+          <span class="mode-result">实测约 33.9%</span>
+        </button>
+      </section>
+
+      <p id="status" role="status"></p>
+    </main>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/skills/ego-browser/gpu-controller/extension/popup.html
+++ b/skills/ego-browser/gpu-controller/extension/popup.html
@@ -17,7 +17,7 @@
       </header>
 
       <p class="intro">
-        选择后会结束正在运行的 Agent 任务，保存设置并自动重启浏览器。
+        选择后会结束正在运行的 Agent 任务并重启。低功耗会在切走后自动隐藏 Ego。
       </p>
 
       <section id="modes" aria-label="GPU 模式">
@@ -32,13 +32,11 @@
         </button>
         <button type="button" data-mode="low-power">
           <span class="mode-name">低功耗</span>
-          <span class="mode-detail">关闭 WebGL，部分视觉功能不可用</span>
-          <span class="mode-result">实测约 24.2%</span>
+          <span class="mode-detail">切到其他应用后自动隐藏 Ego，点 Dock 恢复</span>
         </button>
-        <button type="button" data-mode="software">
+        <button type="button" data-mode="software" disabled>
           <span class="mode-name">软件渲染</span>
-          <span class="mode-detail">排障用，会增加 CPU 负载</span>
-          <span class="mode-result">实测约 33.9%</span>
+          <span class="mode-detail">当前版本会意外退出，已禁用</span>
         </button>
       </section>
 

--- a/skills/ego-browser/gpu-controller/extension/popup.js
+++ b/skills/ego-browser/gpu-controller/extension/popup.js
@@ -1,0 +1,80 @@
+const nativeHost = "com.citrolabs.ego.gpu_mode";
+const modeNames = {
+  normal: "正常",
+  balanced: "均衡",
+  "low-power": "低功耗",
+  software: "软件渲染",
+};
+
+const currentMode = document.querySelector("#current-mode");
+const status = document.querySelector("#status");
+const buttons = [...document.querySelectorAll("[data-mode]")];
+let renderedMode = null;
+
+function send(message) {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendNativeMessage(nativeHost, message, (response) => {
+      const error = chrome.runtime.lastError;
+      if (error) {
+        reject(new Error(error.message));
+        return;
+      }
+      if (!response?.ok) {
+        reject(new Error(response?.error || "本地服务返回了未知错误"));
+        return;
+      }
+      resolve(response);
+    });
+  });
+}
+
+function renderMode(mode) {
+  renderedMode = mode;
+  currentMode.textContent = modeNames[mode] || "未知";
+  for (const button of buttons) {
+    button.setAttribute("aria-pressed", String(button.dataset.mode === mode));
+  }
+}
+
+function setBusy(busy) {
+  for (const button of buttons) {
+    button.disabled = busy;
+  }
+}
+
+async function loadStatus() {
+  try {
+    const response = await send({ action: "status" });
+    renderMode(response.mode);
+    if (response.mode === "low-power" && !response.active) {
+      status.textContent = "低功耗参数尚未生效，正在自动重启。";
+      await send({ action: "ensureMode" });
+    }
+  } catch (error) {
+    status.className = "error";
+    status.textContent = `无法连接本地服务：${error.message}`;
+  }
+}
+
+for (const button of buttons) {
+  button.addEventListener("click", async () => {
+    const mode = button.dataset.mode;
+    const previousMode = renderedMode;
+    setBusy(true);
+    status.className = "";
+    status.textContent = "正在保存设置，ego lite 将自动重启…";
+    try {
+      renderMode(mode);
+      await send({ action: "setMode", mode });
+    } catch (error) {
+      if (previousMode) {
+        renderMode(previousMode);
+      }
+      setBusy(false);
+      status.className = "error";
+      status.textContent = `切换失败：${error.message}`;
+    }
+  });
+}
+
+void loadStatus();

--- a/skills/ego-browser/gpu-controller/extension/popup.js
+++ b/skills/ego-browser/gpu-controller/extension/popup.js
@@ -10,6 +10,8 @@ const currentMode = document.querySelector("#current-mode");
 const status = document.querySelector("#status");
 const buttons = [...document.querySelectorAll("[data-mode]")];
 let renderedMode = null;
+let busy = false;
+let unsupportedModes = new Set(["software"]);
 
 function send(message) {
   return new Promise((resolve, reject) => {
@@ -36,18 +38,25 @@ function renderMode(mode) {
   }
 }
 
-function setBusy(busy) {
+function setBusy(nextBusy) {
+  busy = nextBusy;
   for (const button of buttons) {
-    button.disabled = busy;
+    button.disabled = nextBusy || unsupportedModes.has(button.dataset.mode);
   }
+}
+
+function setUnsupportedModes(modes) {
+  unsupportedModes = new Set(modes);
+  setBusy(busy);
 }
 
 async function loadStatus() {
   try {
     const response = await send({ action: "status" });
+    setUnsupportedModes(response.unsupportedModes || []);
     renderMode(response.mode);
     if (response.mode === "low-power" && !response.active) {
-      status.textContent = "低功耗参数尚未生效，正在自动重启。";
+      status.textContent = "低功耗后台服务尚未生效，正在自动修复。";
       await send({ action: "ensureMode" });
     }
   } catch (error) {

--- a/skills/ego-browser/gpu-controller/install.sh
+++ b/skills/ego-browser/gpu-controller/install.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+set -eu
+
+HOST_NAME="com.citrolabs.ego.gpu_mode"
+EXTENSION_ID="iemmjhekmkccaghebaammoflapofhaik"
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+USER_DATA_DIR="${EGO_LITE_USER_DATA_DIR:-$HOME/Library/Application Support/Citro Labs/ego lite}"
+NATIVE_HOST_DIR="${EGO_LITE_NATIVE_MESSAGING_DIR:-$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts}"
+INSTALL_DIR="$USER_DATA_DIR/GpuModeController"
+EXTENSION_DIR="$INSTALL_DIR/extension"
+HOST_DIR="$INSTALL_DIR/native-host"
+MANIFEST_PATH="$NATIVE_HOST_DIR/$HOST_NAME.json"
+NODE_PATH=$(command -v node || true)
+
+if [ "$(uname -s)" != "Darwin" ]; then
+	printf '%s\n' "error: the ego GPU controller currently supports macOS only" >&2
+	exit 1
+fi
+
+if [ -z "$NODE_PATH" ]; then
+	printf '%s\n' "error: Node.js 22 or newer is required" >&2
+	exit 1
+fi
+
+NODE_MAJOR=$("$NODE_PATH" -p 'Number(process.versions.node.split(".")[0])' 2>/dev/null || true)
+if [ -z "$NODE_MAJOR" ] || [ "$NODE_MAJOR" -lt 22 ] 2>/dev/null; then
+	printf '%s\n' "error: Node.js 22 or newer is required" >&2
+	exit 1
+fi
+
+mkdir -p "$EXTENSION_DIR" "$HOST_DIR" "$NATIVE_HOST_DIR"
+cp "$SCRIPT_DIR"/extension/* "$EXTENSION_DIR/"
+cp "$SCRIPT_DIR"/native-host/*.mjs "$HOST_DIR/"
+
+cat >"$HOST_DIR/host" <<EOF
+#!/bin/sh
+exec "$NODE_PATH" "$HOST_DIR/host.mjs"
+EOF
+chmod 755 "$HOST_DIR/host"
+
+"$NODE_PATH" - "$MANIFEST_PATH" "$HOST_DIR/host" "$HOST_NAME" "$EXTENSION_ID" <<'EOF'
+import { writeFileSync } from "node:fs";
+
+const [, , manifestPath, hostPath, hostName, extensionId] = process.argv;
+writeFileSync(
+  manifestPath,
+  `${JSON.stringify(
+    {
+      name: hostName,
+      description: "Switch ego lite GPU compatibility modes",
+      path: hostPath,
+      type: "stdio",
+      allowed_origins: [`chrome-extension://${extensionId}/`],
+    },
+    null,
+    2,
+  )}\n`,
+  { mode: 0o600 },
+);
+EOF
+
+for legacy_manifest in \
+	"$USER_DATA_DIR/NativeMessagingHosts/$HOST_NAME.json" \
+	"$HOME/Library/Application Support/Citro Labs/ego/NativeMessagingHosts/$HOST_NAME.json" \
+	"$HOME/Library/Application Support/Chromium/NativeMessagingHosts/$HOST_NAME.json"; do
+	if [ "$legacy_manifest" != "$MANIFEST_PATH" ] &&
+		[ -f "$legacy_manifest" ]; then
+		rm "$legacy_manifest"
+	fi
+done
+
+printf '%s\n' \
+	"Installed the native host." \
+	"Extension directory:" \
+	"$EXTENSION_DIR" \
+	"" \
+	"Open ego://extensions, enable Developer mode, choose Load unpacked, and select that directory." \
+	"After this one-time setup, GPU modes are changed from the ego toolbar."
+
+open -a "ego lite" "ego://extensions/" >/dev/null 2>&1 || true

--- a/skills/ego-browser/gpu-controller/native-host/apply-and-restart.mjs
+++ b/skills/ego-browser/gpu-controller/native-host/apply-and-restart.mjs
@@ -3,11 +3,13 @@
 import { execFile } from "node:child_process";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { readFile, rename, unlink, writeFile } from "node:fs/promises";
 import {
   applyModeToLocalState,
   assertGpuMode,
   launchArguments,
+  unsupportedModesForAppVersion,
 } from "./mode-state.mjs";
 
 const mode = assertGpuMode(process.argv[2]);
@@ -24,10 +26,18 @@ const localStatePath = join(userDataDirectory, "Local State");
 const controllerStatePath = join(userDataDirectory, "gpu_mode.json");
 const restartLockPath = join(userDataDirectory, "gpu_mode_restart.lock");
 const errorPath = join(userDataDirectory, "gpu_mode_error.log");
+const watchdogPath =
+  process.env.EGO_LITE_WATCHDOG_PATH ||
+  join(dirname(fileURLToPath(import.meta.url)), "low-power-watchdog.mjs");
+const plutilPath = process.env.EGO_LITE_PLUTIL_PATH || "/usr/bin/plutil";
 let browserLaunched = false;
+let browserRestartStarted = false;
 
 try {
+  await assertModeIsSupported();
   await delay(350);
+  browserRestartStarted = true;
+  await stopWatchdog();
   await quitBrowser();
   await waitForBrowserExit();
   await updateLocalState();
@@ -38,6 +48,10 @@ try {
   );
   await launchBrowser();
   browserLaunched = true;
+  if (mode === "low-power") {
+    await delay(2_000);
+    await startWatchdog();
+  }
   await unlinkIfPresent(errorPath);
 } catch (error) {
   await writeFile(
@@ -45,7 +59,7 @@ try {
     `${new Date().toISOString()} ${error.stack || error.message}\n`,
     { mode: 0o600 },
   );
-  if (!browserLaunched) {
+  if (browserRestartStarted && !browserLaunched) {
     try {
       await launchBrowser();
       browserLaunched = true;
@@ -110,6 +124,35 @@ async function launchBrowser() {
   await execFilePromise(openPath, args);
 }
 
+async function assertModeIsSupported() {
+  let version = process.env.EGO_LITE_APP_VERSION || "";
+  if (!version) {
+    try {
+      version = (
+        await execFileText(plutilPath, [
+          "-extract",
+          "CFBundleShortVersionString",
+          "raw",
+          join(appPath, "Contents", "Info.plist"),
+        ])
+      ).trim();
+    } catch {}
+  }
+  if (unsupportedModesForAppVersion(version).includes(mode)) {
+    throw new Error(
+      `GPU mode ${JSON.stringify(mode)} is disabled for ego lite ${version} because it causes the browser to exit`,
+    );
+  }
+}
+
+async function startWatchdog() {
+  await execFilePromise(process.execPath, [watchdogPath, "start"]);
+}
+
+async function stopWatchdog() {
+  await execFilePromise(process.execPath, [watchdogPath, "stop"]);
+}
+
 async function readLocalState() {
   const value = JSON.parse(await readFile(localStatePath, "utf8"));
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -126,6 +169,18 @@ function execFilePromise(command, args, options = {}) {
         return;
       }
       resolve();
+    });
+  });
+}
+
+function execFileText(command, args) {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { encoding: "utf8" }, (error, stdout) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(stdout);
     });
   });
 }

--- a/skills/ego-browser/gpu-controller/native-host/apply-and-restart.mjs
+++ b/skills/ego-browser/gpu-controller/native-host/apply-and-restart.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { readFile, rename, unlink, writeFile } from "node:fs/promises";
+import {
+  applyModeToLocalState,
+  assertGpuMode,
+  launchArguments,
+} from "./mode-state.mjs";
+
+const mode = assertGpuMode(process.argv[2]);
+const appPath = process.env.EGO_LITE_APP_PATH || "/Applications/ego lite.app";
+const openPath = process.env.EGO_LITE_OPEN_PATH || "/usr/bin/open";
+const osascriptPath =
+  process.env.EGO_LITE_OSASCRIPT_PATH || "/usr/bin/osascript";
+const pgrepPath = process.env.EGO_LITE_PGREP_PATH || "/usr/bin/pgrep";
+const pkillPath = process.env.EGO_LITE_PKILL_PATH || "/usr/bin/pkill";
+const userDataDirectory =
+  process.env.EGO_LITE_USER_DATA_DIR ||
+  join(homedir(), "Library", "Application Support", "Citro Labs", "ego lite");
+const localStatePath = join(userDataDirectory, "Local State");
+const controllerStatePath = join(userDataDirectory, "gpu_mode.json");
+const restartLockPath = join(userDataDirectory, "gpu_mode_restart.lock");
+const errorPath = join(userDataDirectory, "gpu_mode_error.log");
+let browserLaunched = false;
+
+try {
+  await delay(350);
+  await quitBrowser();
+  await waitForBrowserExit();
+  await updateLocalState();
+  await writeFile(
+    controllerStatePath,
+    `${JSON.stringify({ mode, updatedAt: new Date().toISOString() }, null, 2)}\n`,
+    { mode: 0o600 },
+  );
+  await launchBrowser();
+  browserLaunched = true;
+  await unlinkIfPresent(errorPath);
+} catch (error) {
+  await writeFile(
+    errorPath,
+    `${new Date().toISOString()} ${error.stack || error.message}\n`,
+    { mode: 0o600 },
+  );
+  if (!browserLaunched) {
+    try {
+      await launchBrowser();
+      browserLaunched = true;
+    } catch {}
+  }
+} finally {
+  await unlinkIfPresent(restartLockPath);
+}
+
+async function quitBrowser() {
+  try {
+    await execFilePromise(
+      osascriptPath,
+      ["-e", 'tell application id "com.citrolabs.ego.lite" to quit'],
+      { timeout: 3_000 },
+    );
+  } catch {}
+  await delay(1_000);
+  if (await browserIsRunning()) {
+    try {
+      await execFilePromise(pkillPath, ["-TERM", "-x", "ego lite"]);
+    } catch {}
+  }
+}
+
+async function waitForBrowserExit() {
+  for (let attempt = 0; attempt < 80; attempt++) {
+    if (!(await browserIsRunning())) {
+      return;
+    }
+    await delay(200);
+  }
+  throw new Error("ego lite did not exit within 16 seconds");
+}
+
+async function browserIsRunning() {
+  try {
+    await execFilePromise(pgrepPath, ["-x", "ego lite"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function updateLocalState() {
+  const current = await readLocalState();
+  const next = applyModeToLocalState(current, mode);
+  const temporaryPath = join(
+    dirname(localStatePath),
+    `.Local State.gpu-mode-${process.pid}`,
+  );
+  await writeFile(temporaryPath, JSON.stringify(next), { mode: 0o600 });
+  await rename(temporaryPath, localStatePath);
+}
+
+async function launchBrowser() {
+  const args = ["-na", appPath];
+  const graphicsArguments = launchArguments(mode);
+  if (graphicsArguments.length > 0) {
+    args.push("--args", ...graphicsArguments);
+  }
+  await execFilePromise(openPath, args);
+}
+
+async function readLocalState() {
+  const value = JSON.parse(await readFile(localStatePath, "utf8"));
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("ego lite Local State is not a JSON object");
+  }
+  return value;
+}
+
+function execFilePromise(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, options, (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function unlinkIfPresent(path) {
+  try {
+    await unlink(path);
+  } catch {}
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/skills/ego-browser/gpu-controller/native-host/host.mjs
+++ b/skills/ego-browser/gpu-controller/native-host/host.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+import { execFile, spawn } from "node:child_process";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFile } from "node:fs/promises";
+import { GPU_MODES, detectMode } from "./mode-state.mjs";
+import { acquireRestartLock } from "./restart-lock.mjs";
+
+const MAX_NATIVE_MESSAGE_BYTES = 64 * 1024;
+const hostDirectory = dirname(fileURLToPath(import.meta.url));
+const userDataDirectory =
+  process.env.EGO_LITE_USER_DATA_DIR ||
+  join(homedir(), "Library", "Application Support", "Citro Labs", "ego lite");
+const appPath = process.env.EGO_LITE_APP_PATH || "/Applications/ego lite.app";
+const localStatePath = join(userDataDirectory, "Local State");
+const controllerStatePath = join(userDataDirectory, "gpu_mode.json");
+const restartLockPath = join(userDataDirectory, "gpu_mode_restart.lock");
+const applyScriptPath = join(hostDirectory, "apply-and-restart.mjs");
+
+let input = Buffer.alloc(0);
+
+process.stdin.on("data", (chunk) => {
+  input = Buffer.concat([input, chunk]);
+  void consumeMessages();
+});
+
+process.stdin.on("error", (error) => {
+  send({ ok: false, error: error.message });
+});
+
+async function consumeMessages() {
+  while (input.length >= 4) {
+    const length = input.readUInt32LE(0);
+    if (length > MAX_NATIVE_MESSAGE_BYTES) {
+      input = Buffer.alloc(0);
+      send({
+        ok: false,
+        error: `native message exceeds ${MAX_NATIVE_MESSAGE_BYTES} bytes`,
+      });
+      process.stdin.destroy();
+      return;
+    }
+    if (input.length < length + 4) {
+      return;
+    }
+    const payload = input.subarray(4, length + 4);
+    input = input.subarray(length + 4);
+    try {
+      const message = JSON.parse(payload.toString("utf8"));
+      send(await handleMessage(message));
+    } catch (error) {
+      send({ ok: false, error: error.message });
+    }
+  }
+}
+
+async function handleMessage(message) {
+  switch (message?.action) {
+    case "status":
+      return await status();
+    case "setMode":
+      return await setMode(message.mode);
+    case "ensureMode":
+      return await ensureMode();
+    default:
+      throw new Error(`unsupported action: ${JSON.stringify(message?.action)}`);
+  }
+}
+
+async function status() {
+  const [localState, controllerState] = await Promise.all([
+    readJson(localStatePath),
+    readJson(controllerStatePath),
+  ]);
+  const mode = detectMode(localState, controllerState?.mode);
+  return {
+    ok: true,
+    mode,
+    active: mode !== "low-power" || (await browserHasSwitch("disable-webgl")),
+  };
+}
+
+async function setMode(mode) {
+  if (!GPU_MODES.includes(mode)) {
+    throw new Error(`unsupported GPU mode: ${JSON.stringify(mode)}`);
+  }
+  const scheduled = await scheduleRestart(mode);
+  return { ok: true, mode, restarting: true, scheduled };
+}
+
+async function ensureMode() {
+  const current = await status();
+  if (current.mode !== "low-power" || current.active) {
+    return { ...current, restarting: false };
+  }
+  const scheduled = await scheduleRestart(current.mode);
+  return { ...current, restarting: true, scheduled };
+}
+
+async function scheduleRestart(mode) {
+  if (!(await acquireRestartLock(restartLockPath))) {
+    return false;
+  }
+  const child = spawn(process.execPath, [applyScriptPath, mode], {
+    detached: true,
+    env: process.env,
+    stdio: "ignore",
+  });
+  child.unref();
+  return true;
+}
+
+async function browserHasSwitch(name) {
+  const commandLines = await execFileText("ps", ["-axo", "command="]);
+  const executable = join(appPath, "Contents", "MacOS", "ego lite");
+  return commandLines
+    .split(/\r?\n/)
+    .some(
+      (line) =>
+        line.trimStart().startsWith(executable) &&
+        !line.includes("--user-data-dir=") &&
+        line.includes(`--${name}`),
+    );
+}
+
+async function readJson(path) {
+  try {
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function execFileText(command, args) {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { encoding: "utf8" }, (error, stdout) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+function send(message) {
+  const payload = Buffer.from(JSON.stringify(message), "utf8");
+  const header = Buffer.alloc(4);
+  header.writeUInt32LE(payload.length);
+  process.stdout.write(Buffer.concat([header, payload]));
+}

--- a/skills/ego-browser/gpu-controller/native-host/host.mjs
+++ b/skills/ego-browser/gpu-controller/native-host/host.mjs
@@ -5,7 +5,15 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readFile } from "node:fs/promises";
-import { GPU_MODES, detectMode } from "./mode-state.mjs";
+import {
+  GPU_MODES,
+  detectMode,
+  unsupportedModesForAppVersion,
+} from "./mode-state.mjs";
+import {
+  startWatchdog,
+  watchdogIsRunning,
+} from "./low-power-watchdog.mjs";
 import { acquireRestartLock } from "./restart-lock.mjs";
 
 const MAX_NATIVE_MESSAGE_BYTES = 64 * 1024;
@@ -18,6 +26,7 @@ const localStatePath = join(userDataDirectory, "Local State");
 const controllerStatePath = join(userDataDirectory, "gpu_mode.json");
 const restartLockPath = join(userDataDirectory, "gpu_mode_restart.lock");
 const applyScriptPath = join(hostDirectory, "apply-and-restart.mjs");
+const plutilPath = process.env.EGO_LITE_PLUTIL_PATH || "/usr/bin/plutil";
 
 let input = Buffer.alloc(0);
 
@@ -70,21 +79,34 @@ async function handleMessage(message) {
 }
 
 async function status() {
-  const [localState, controllerState] = await Promise.all([
+  const [localState, controllerState, appVersion] = await Promise.all([
     readJson(localStatePath),
     readJson(controllerStatePath),
+    readAppVersion(),
   ]);
   const mode = detectMode(localState, controllerState?.mode);
+  const unsupportedModes = unsupportedModesForAppVersion(appVersion);
   return {
     ok: true,
     mode,
-    active: mode !== "low-power" || (await browserHasSwitch("disable-webgl")),
+    active:
+      !unsupportedModes.includes(mode) &&
+      (mode !== "low-power" || (await watchdogIsRunning())),
+    unsupportedModes,
   };
 }
 
 async function setMode(mode) {
   if (!GPU_MODES.includes(mode)) {
     throw new Error(`unsupported GPU mode: ${JSON.stringify(mode)}`);
+  }
+  const unsupportedModes = unsupportedModesForAppVersion(
+    await readAppVersion(),
+  );
+  if (unsupportedModes.includes(mode)) {
+    throw new Error(
+      `GPU mode ${JSON.stringify(mode)} is disabled for this ego lite version because it causes the browser to exit`,
+    );
   }
   const scheduled = await scheduleRestart(mode);
   return { ok: true, mode, restarting: true, scheduled };
@@ -94,6 +116,15 @@ async function ensureMode() {
   const current = await status();
   if (current.mode !== "low-power" || current.active) {
     return { ...current, restarting: false };
+  }
+  if (!(await browserHasSwitch("disable-webgl"))) {
+    const started = await startWatchdog();
+    return {
+      ...current,
+      active: await watchdogIsRunning(),
+      restarting: false,
+      started,
+    };
   }
   const scheduled = await scheduleRestart(current.mode);
   return { ...current, restarting: true, scheduled };
@@ -123,6 +154,24 @@ async function browserHasSwitch(name) {
         !line.includes("--user-data-dir=") &&
         line.includes(`--${name}`),
     );
+}
+
+async function readAppVersion() {
+  if (process.env.EGO_LITE_APP_VERSION) {
+    return process.env.EGO_LITE_APP_VERSION;
+  }
+  try {
+    return (
+      await execFileText(plutilPath, [
+        "-extract",
+        "CFBundleShortVersionString",
+        "raw",
+        join(appPath, "Contents", "Info.plist"),
+      ])
+    ).trim();
+  } catch {
+    return "";
+  }
 }
 
 async function readJson(path) {

--- a/skills/ego-browser/gpu-controller/native-host/low-power-watchdog.mjs
+++ b/skills/ego-browser/gpu-controller/native-host/low-power-watchdog.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+
+import { execFile, spawn } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  access,
+  open,
+  readFile,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const userDataDirectory =
+  process.env.EGO_LITE_USER_DATA_DIR ||
+  join(homedir(), "Library", "Application Support", "Citro Labs", "ego lite");
+const pidPath =
+  process.env.EGO_LITE_WATCHDOG_PID_PATH ||
+  join(userDataDirectory, "gpu_mode_low_power.pid");
+const errorPath =
+  process.env.EGO_LITE_WATCHDOG_ERROR_PATH ||
+  join(userDataDirectory, "gpu_mode_watchdog_error.log");
+const startLockPath =
+  process.env.EGO_LITE_WATCHDOG_START_LOCK_PATH ||
+  join(userDataDirectory, "gpu_mode_watchdog_start.lock");
+const restartLockPath =
+  process.env.EGO_LITE_RESTART_LOCK_PATH ||
+  join(userDataDirectory, "gpu_mode_restart.lock");
+const osascriptPath =
+  process.env.EGO_LITE_OSASCRIPT_PATH || "/usr/bin/osascript";
+const pollMilliseconds = positiveInteger(
+  process.env.EGO_LITE_WATCHDOG_POLL_MS,
+  1_000,
+);
+const unfocusedMilliseconds = positiveInteger(
+  process.env.EGO_LITE_WATCHDOG_UNFOCUSED_MS,
+  1_500,
+);
+
+export async function startWatchdog() {
+  const lock = await acquireStartLock();
+  if (lock === null) {
+    return false;
+  }
+  try {
+    if (await watchdogIsRunning()) {
+      return false;
+    }
+    await unlinkIfPresent(pidPath);
+    const child = spawn(process.execPath, [scriptPath, "run"], {
+      detached: true,
+      env: process.env,
+      stdio: "ignore",
+    });
+    try {
+      await writeFile(pidPath, `${child.pid}\n`, { mode: 0o600 });
+    } catch (error) {
+      try {
+        process.kill(child.pid, "SIGTERM");
+      } catch {}
+      throw error;
+    }
+    child.unref();
+    return true;
+  } finally {
+    await lock.close();
+    await unlinkIfPresent(startLockPath);
+  }
+}
+
+export async function stopWatchdog() {
+  const pid = await readWatchdogPid();
+  if (pid !== null && (await processIsWatchdog(pid))) {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {}
+  }
+  await unlinkIfPresent(pidPath);
+  return pid !== null;
+}
+
+export async function watchdogIsRunning() {
+  const pid = await readWatchdogPid();
+  return pid !== null && (await processIsWatchdog(pid));
+}
+
+async function runWatchdog() {
+  let stopped = false;
+  let unfocusedSince = null;
+  let errorDelayMilliseconds = pollMilliseconds;
+  const stop = () => {
+    stopped = true;
+  };
+  process.on("SIGINT", stop);
+  process.on("SIGTERM", stop);
+
+  try {
+    while (!stopped) {
+      if (await fileExists(restartLockPath)) {
+        unfocusedSince = null;
+        await delay(pollMilliseconds);
+        continue;
+      }
+      try {
+        const state = await readEgoState();
+        if (!state.running) {
+          return;
+        }
+        if (!state.visible || state.frontmost) {
+          unfocusedSince = null;
+        } else if (unfocusedSince === null) {
+          unfocusedSince = Date.now();
+        } else if (Date.now() - unfocusedSince >= unfocusedMilliseconds) {
+          await hideEgo();
+          unfocusedSince = null;
+        }
+        await unlinkIfPresent(errorPath);
+        errorDelayMilliseconds = pollMilliseconds;
+      } catch (error) {
+        await writeFile(
+          errorPath,
+          `${new Date().toISOString()} ${error.stack || error.message}\n`,
+          { mode: 0o600 },
+        );
+        await delay(errorDelayMilliseconds);
+        errorDelayMilliseconds = Math.min(
+          errorDelayMilliseconds * 2,
+          30_000,
+        );
+        continue;
+      }
+      await delay(pollMilliseconds);
+    }
+  } finally {
+    const pid = await readWatchdogPid();
+    if (pid === process.pid) {
+      await unlinkIfPresent(pidPath);
+    }
+  }
+}
+
+async function acquireStartLock() {
+  const now = Date.now();
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      return await open(startLockPath, "wx", 0o600);
+    } catch (error) {
+      if (error?.code !== "EEXIST") {
+        throw error;
+      }
+    }
+
+    try {
+      const info = await stat(startLockPath);
+      if (now - info.mtimeMs < 10_000) {
+        return null;
+      }
+      await unlink(startLockPath);
+    } catch (error) {
+      if (error?.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+  return null;
+}
+
+async function readEgoState() {
+  const output = await execFileText(osascriptPath, [
+    "-e",
+    'tell application "System Events"',
+    "-e",
+    'if not (exists process "ego lite") then return "stopped"',
+    "-e",
+    'set egoVisible to visible of process "ego lite"',
+    "-e",
+    'set egoFrontmost to frontmost of process "ego lite"',
+    "-e",
+    'return "running|" & egoVisible & "|" & egoFrontmost',
+    "-e",
+    "end tell",
+  ]);
+  const [status, visible, frontmost] = output.trim().split("|");
+  return {
+    running: status === "running",
+    visible: visible === "true",
+    frontmost: frontmost === "true",
+  };
+}
+
+async function hideEgo() {
+  await execFilePromise(osascriptPath, [
+    "-e",
+    'tell application "System Events"',
+    "-e",
+    'if exists process "ego lite" then',
+    "-e",
+    'if not frontmost of process "ego lite" then set visible of process "ego lite" to false',
+    "-e",
+    "end if",
+    "-e",
+    "end tell",
+  ]);
+}
+
+async function readWatchdogPid() {
+  try {
+    const pid = Number.parseInt((await readFile(pidPath, "utf8")).trim(), 10);
+    return Number.isSafeInteger(pid) && pid > 1 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+async function processIsWatchdog(pid) {
+  try {
+    const command = await execFileText("ps", [
+      "-p",
+      String(pid),
+      "-o",
+      "command=",
+    ]);
+    return command.includes(scriptPath) && /\brun\b/.test(command);
+  } catch {
+    return false;
+  }
+}
+
+function execFileText(command, args) {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { encoding: "utf8" }, (error, stdout) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+function execFilePromise(command, args) {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function unlinkIfPresent(path) {
+  try {
+    await unlink(path);
+  } catch {}
+}
+
+async function fileExists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value || "", 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function main() {
+  switch (process.argv[2]) {
+    case "start":
+      await startWatchdog();
+      break;
+    case "stop":
+      await stopWatchdog();
+      break;
+    case "status":
+      process.stdout.write(
+        (await watchdogIsRunning()) ? "running\n" : "stopped\n",
+      );
+      break;
+    case "run":
+      await runWatchdog();
+      break;
+    default:
+      process.stderr.write(
+        "usage: low-power-watchdog.mjs [start|stop|status|run]\n",
+      );
+      process.exitCode = 2;
+  }
+}
+
+if (process.argv[1] === scriptPath) {
+  await main();
+}

--- a/skills/ego-browser/gpu-controller/native-host/mode-state.mjs
+++ b/skills/ego-browser/gpu-controller/native-host/mode-state.mjs
@@ -1,0 +1,75 @@
+export const GPU_MODES = Object.freeze([
+  "normal",
+  "balanced",
+  "low-power",
+  "software",
+]);
+
+export const GRAPHITE_DISABLED_EXPERIMENT = "skia-graphite@5";
+
+export function assertGpuMode(mode) {
+  if (!GPU_MODES.includes(mode)) {
+    throw new Error(`unsupported GPU mode: ${JSON.stringify(mode)}`);
+  }
+  return mode;
+}
+
+export function applyModeToLocalState(value, mode) {
+  assertGpuMode(mode);
+  const state = cloneJsonObject(value);
+  const browser = isObject(state.browser) ? state.browser : {};
+  const experiments = Array.isArray(browser.enabled_labs_experiments)
+    ? browser.enabled_labs_experiments.filter(
+        (item) => typeof item === "string" && !item.startsWith("skia-graphite"),
+      )
+    : [];
+
+  if (mode === "balanced") {
+    experiments.push(GRAPHITE_DISABLED_EXPERIMENT);
+  }
+
+  const hardwareAccelerationMode = isObject(state.hardware_acceleration_mode)
+    ? state.hardware_acceleration_mode
+    : {};
+  hardwareAccelerationMode.enabled = mode !== "software";
+
+  browser.enabled_labs_experiments = experiments;
+  state.browser = browser;
+  state.hardware_acceleration_mode = hardwareAccelerationMode;
+  delete state.hardware_acceleration_mode_enabled;
+  delete state["hardware_acceleration_mode.enabled"];
+  return state;
+}
+
+export function detectMode(localState, savedMode) {
+  if (savedMode === "low-power") {
+    return savedMode;
+  }
+  if (localState?.hardware_acceleration_mode?.enabled === false) {
+    return "software";
+  }
+  if (
+    localState?.browser?.enabled_labs_experiments?.includes(
+      GRAPHITE_DISABLED_EXPERIMENT,
+    )
+  ) {
+    return "balanced";
+  }
+  return "normal";
+}
+
+export function launchArguments(mode) {
+  assertGpuMode(mode);
+  return mode === "low-power" ? ["--disable-webgl"] : [];
+}
+
+function cloneJsonObject(value) {
+  if (!isObject(value)) {
+    return {};
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/skills/ego-browser/gpu-controller/native-host/mode-state.mjs
+++ b/skills/ego-browser/gpu-controller/native-host/mode-state.mjs
@@ -6,6 +6,7 @@ export const GPU_MODES = Object.freeze([
 ]);
 
 export const GRAPHITE_DISABLED_EXPERIMENT = "skia-graphite@5";
+export const SOFTWARE_MODE_BLOCKED_VERSIONS = Object.freeze(["0.4.6.12"]);
 
 export function assertGpuMode(mode) {
   if (!GPU_MODES.includes(mode)) {
@@ -60,7 +61,11 @@ export function detectMode(localState, savedMode) {
 
 export function launchArguments(mode) {
   assertGpuMode(mode);
-  return mode === "low-power" ? ["--disable-webgl"] : [];
+  return [];
+}
+
+export function unsupportedModesForAppVersion(version) {
+  return SOFTWARE_MODE_BLOCKED_VERSIONS.includes(version) ? ["software"] : [];
 }
 
 function cloneJsonObject(value) {

--- a/skills/ego-browser/gpu-controller/native-host/restart-lock.mjs
+++ b/skills/ego-browser/gpu-controller/native-host/restart-lock.mjs
@@ -1,0 +1,31 @@
+import { stat, unlink, writeFile } from "node:fs/promises";
+
+export async function acquireRestartLock(
+  path,
+  { maxAgeMs = 20_000, now = Date.now() } = {},
+) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      await writeFile(path, String(now), { flag: "wx", mode: 0o600 });
+      return true;
+    } catch (error) {
+      if (error.code !== "EEXIST") {
+        throw error;
+      }
+    }
+
+    try {
+      const info = await stat(path);
+      if (now - info.mtimeMs < maxAgeMs) {
+        return false;
+      }
+      await unlink(path);
+    } catch (error) {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+
+  return false;
+}

--- a/skills/ego-browser/gpu-controller/uninstall.sh
+++ b/skills/ego-browser/gpu-controller/uninstall.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+set -eu
+
+HOST_NAME="com.citrolabs.ego.gpu_mode"
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+USER_DATA_DIR="${EGO_LITE_USER_DATA_DIR:-$HOME/Library/Application Support/Citro Labs/ego lite}"
+NATIVE_HOST_DIR="${EGO_LITE_NATIVE_MESSAGING_DIR:-$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts}"
+INSTALL_DIR="$USER_DATA_DIR/GpuModeController"
+MANIFEST_PATH="$NATIVE_HOST_DIR/$HOST_NAME.json"
+LOCAL_STATE_PATH="$USER_DATA_DIR/Local State"
+CONTROLLER_STATE_PATH="$USER_DATA_DIR/gpu_mode.json"
+NODE_PATH=$(command -v node || true)
+
+if [ -z "$NODE_PATH" ]; then
+	printf '%s\n' "error: Node.js 22 or newer is required" >&2
+	exit 1
+fi
+
+CURRENT_MODE=$(
+	"$NODE_PATH" --input-type=module - \
+		"$LOCAL_STATE_PATH" \
+		"$CONTROLLER_STATE_PATH" \
+		"$SCRIPT_DIR/native-host/mode-state.mjs" <<'EOF'
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const [, , localStatePath, controllerStatePath, modeStatePath] = process.argv;
+const { detectMode } = await import(pathToFileURL(modeStatePath));
+
+async function readJson(path) {
+  try {
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+const [localState, controllerState] = await Promise.all([
+  readJson(localStatePath),
+  readJson(controllerStatePath),
+]);
+process.stdout.write(detectMode(localState, controllerState.mode));
+EOF
+)
+
+if [ "$CURRENT_MODE" != "normal" ]; then
+	printf '%s\n' \
+		"error: switch ego GPU Mode to Normal and let ego lite restart before uninstalling" >&2
+	exit 1
+fi
+
+if [ -f "$MANIFEST_PATH" ]; then
+	rm "$MANIFEST_PATH"
+fi
+
+for legacy_manifest in \
+	"$USER_DATA_DIR/NativeMessagingHosts/$HOST_NAME.json" \
+	"$HOME/Library/Application Support/Citro Labs/ego/NativeMessagingHosts/$HOST_NAME.json" \
+	"$HOME/Library/Application Support/Chromium/NativeMessagingHosts/$HOST_NAME.json"; do
+	if [ "$legacy_manifest" != "$MANIFEST_PATH" ] &&
+		[ -f "$legacy_manifest" ]; then
+		rm "$legacy_manifest"
+	fi
+done
+
+if [ -d "$INSTALL_DIR" ]; then
+	find "$INSTALL_DIR" -type f -delete
+	find "$INSTALL_DIR" -depth -type d -empty -delete
+fi
+
+for state_file in \
+	"$CONTROLLER_STATE_PATH" \
+	"$USER_DATA_DIR/gpu_mode_error.log" \
+	"$USER_DATA_DIR/gpu_mode_restart.lock"; do
+	if [ -f "$state_file" ]; then
+		rm "$state_file"
+	fi
+done
+
+printf '%s\n' "Removed the ego GPU controller native host."
+printf '%s\n' "Remove the unpacked extension from ego://extensions if it is still listed."

--- a/skills/ego-browser/gpu-controller/uninstall.sh
+++ b/skills/ego-browser/gpu-controller/uninstall.sh
@@ -10,6 +10,7 @@ INSTALL_DIR="$USER_DATA_DIR/GpuModeController"
 MANIFEST_PATH="$NATIVE_HOST_DIR/$HOST_NAME.json"
 LOCAL_STATE_PATH="$USER_DATA_DIR/Local State"
 CONTROLLER_STATE_PATH="$USER_DATA_DIR/gpu_mode.json"
+WATCHDOG_PATH="$SCRIPT_DIR/native-host/low-power-watchdog.mjs"
 NODE_PATH=$(command -v node || true)
 
 if [ -z "$NODE_PATH" ]; then
@@ -50,6 +51,10 @@ if [ "$CURRENT_MODE" != "normal" ]; then
 	exit 1
 fi
 
+if [ -f "$WATCHDOG_PATH" ]; then
+	"$NODE_PATH" "$WATCHDOG_PATH" stop
+fi
+
 if [ -f "$MANIFEST_PATH" ]; then
 	rm "$MANIFEST_PATH"
 fi
@@ -72,7 +77,10 @@ fi
 for state_file in \
 	"$CONTROLLER_STATE_PATH" \
 	"$USER_DATA_DIR/gpu_mode_error.log" \
-	"$USER_DATA_DIR/gpu_mode_restart.lock"; do
+	"$USER_DATA_DIR/gpu_mode_restart.lock" \
+	"$USER_DATA_DIR/gpu_mode_low_power.pid" \
+	"$USER_DATA_DIR/gpu_mode_watchdog_error.log" \
+	"$USER_DATA_DIR/gpu_mode_watchdog_start.lock"; do
 	if [ -f "$state_file" ]; then
 		rm "$state_file"
 	fi

--- a/skills/ego-browser/references/gpu.md
+++ b/skills/ego-browser/references/gpu.md
@@ -2,7 +2,21 @@
 
 Use this guide when ego lite causes sustained GPU activity while its window is visible.
 
-This repository contains the open-source `ego-browser` automation runtime and Skill, not the browser application's Chromium host source. The launcher below is therefore an opt-in compatibility workaround while the browser-side compositor issue is fixed upstream.
+This repository contains the open-source `ego-browser` automation runtime and Skill, not the browser application's Chromium host source. The integrations below are therefore opt-in compatibility workarounds while the browser-side compositor issue is fixed upstream.
+
+## Switch modes inside ego lite
+
+The optional GPU controller adds a toolbar popup to ego lite and uses a restricted native messaging host to persist the selected mode and restart the browser.
+
+```bash
+sh skills/ego-browser/gpu-controller/install.sh
+```
+
+Complete the one-time unpacked-extension step shown by the installer, then pin **ego GPU Mode** from the extensions menu. Later mode changes happen entirely from that popup. Applying a mode restarts ego lite and ends active Agent tasks.
+
+The controller does not edit or re-sign the ego lite application. Balanced mode is persisted through Chromium's tested `skia-graphite@5` Local State experiment, which produces `--disable-features=SkiaGraphite` during a normal launch. Low-power mode is automatically reapplied because `--disable-webgl` is only accepted at browser startup.
+
+See [`gpu-controller/README.md`](../gpu-controller/README.md) for installation and security details.
 
 ## Launch a compatibility mode
 
@@ -14,14 +28,14 @@ sh skills/ego-browser/scripts/launch-gpu-mode.sh balanced
 
 Available modes:
 
-| Mode | Chromium flag | Trade-off |
-|---|---|---|
-| `normal` | none | Normal ego lite behavior |
-| `balanced` | `--disable-features=SkiaGraphite` | Keeps WebGL available but falls back from the Graphite renderer |
-| `low-power` | `--disable-webgl` | Largest measured GPU reduction; WebGL pages and ego lite visual agent overlays may be unavailable |
-| `software` | `--disable-gpu` | Troubleshooting only; shifts rendering work to the CPU and disables hardware video acceleration |
+| Mode        | Chromium flag                     | Trade-off                                                                                         |
+| ----------- | --------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `normal`    | none                              | Normal ego lite behavior                                                                          |
+| `balanced`  | `--disable-features=SkiaGraphite` | Keeps WebGL available but falls back from the Graphite renderer                                   |
+| `low-power` | `--disable-webgl`                 | Largest measured GPU reduction; WebGL pages and ego lite visual agent overlays may be unavailable |
+| `software`  | `--disable-gpu`                   | Troubleshooting only; shifts rendering work to the CPU and disables hardware video acceleration   |
 
-The script refuses to launch if ego lite is already running. It does not edit the browser profile, Chrome flags preferences, bookmarks, cookies, or extensions.
+The standalone script refuses to launch if ego lite is already running. It does not edit the browser profile, Chrome flags preferences, bookmarks, cookies, or extensions.
 
 To return to the default behavior, quit ego lite and open it normally from Finder, Spotlight, or the Dock.
 
@@ -29,12 +43,12 @@ To return to the default behavior, quit ego lite and open it normally from Finde
 
 The following 12-sample averages were recorded on ego lite `0.4.6.12`, Chromium `150.0.7871.101`, macOS `26.5.2`, and Apple M5. Each run used a new temporary profile with extensions disabled.
 
-| Mode | Average GPU utilization |
-|---|---:|
-| `normal` | `77.7%` |
-| `balanced` | `46.9%` |
-| `low-power` | `24.2%` |
-| `software` | `33.9%` |
+| Mode        | Average GPU utilization |
+| ----------- | ----------------------: |
+| `normal`    |                 `77.7%` |
+| `balanced`  |                 `46.9%` |
+| `low-power` |                 `24.2%` |
+| `software`  |                 `33.9%` |
 
 These measurements identify WebGL and Skia Graphite as major contributors on the tested configuration. They are diagnostic reference values, not performance guarantees for other hardware or releases.
 

--- a/skills/ego-browser/references/gpu.md
+++ b/skills/ego-browser/references/gpu.md
@@ -14,7 +14,7 @@ sh skills/ego-browser/gpu-controller/install.sh
 
 Complete the one-time unpacked-extension step shown by the installer, then pin **ego GPU Mode** from the extensions menu. Later mode changes happen entirely from that popup. Applying a mode restarts ego lite and ends active Agent tasks.
 
-The controller does not edit or re-sign the ego lite application. Balanced mode is persisted through Chromium's tested `skia-graphite@5` Local State experiment, which produces `--disable-features=SkiaGraphite` during a normal launch. Low-power mode is automatically reapplied because `--disable-webgl` is only accepted at browser startup.
+The controller does not edit or re-sign the ego lite application. Balanced mode is persisted through Chromium's tested `skia-graphite@5` Local State experiment, which produces `--disable-features=SkiaGraphite` during a normal launch. Low-power mode runs a small local watchdog that hides ego lite after it loses focus; clicking the Dock icon restores the browser.
 
 See [`gpu-controller/README.md`](../gpu-controller/README.md) for installation and security details.
 
@@ -28,12 +28,12 @@ sh skills/ego-browser/scripts/launch-gpu-mode.sh balanced
 
 Available modes:
 
-| Mode        | Chromium flag                     | Trade-off                                                                                         |
-| ----------- | --------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `normal`    | none                              | Normal ego lite behavior                                                                          |
-| `balanced`  | `--disable-features=SkiaGraphite` | Keeps WebGL available but falls back from the Graphite renderer                                   |
-| `low-power` | `--disable-webgl`                 | Largest measured GPU reduction; WebGL pages and ego lite visual agent overlays may be unavailable |
-| `software`  | `--disable-gpu`                   | Troubleshooting only; shifts rendering work to the CPU and disables hardware video acceleration   |
+| Mode        | Behavior                          | Trade-off                                                                                     |
+| ----------- | --------------------------------- | --------------------------------------------------------------------------------------------- |
+| `normal`    | No graphics override              | Normal ego lite behavior                                                                      |
+| `balanced`  | Disables Skia Graphite            | Keeps WebGL available but falls back from the Graphite renderer                               |
+| `low-power` | Hides ego lite after focus is lost | The browser is restored from its Dock icon; screen-based effects may pause while it is hidden |
+| `software`  | Disables GPU acceleration         | Blocked on ego lite `0.4.6.12` because that build exits during startup                        |
 
 The standalone script refuses to launch if ego lite is already running. It does not edit the browser profile, Chrome flags preferences, bookmarks, cookies, or extensions.
 
@@ -41,20 +41,23 @@ To return to the default behavior, quit ego lite and open it normally from Finde
 
 ## Reference measurements
 
-The following 12-sample averages were recorded on ego lite `0.4.6.12`, Chromium `150.0.7871.101`, macOS `26.5.2`, and Apple M5. Each run used a new temporary profile with extensions disabled.
+The following foreground-visibility comparison was recorded on August 9, 2026 with ego lite `0.4.6.12`, Chromium `150.0.7871.101`, macOS `26.5.2`, and Apple M5. It used the real browser profile and the same five-sample `powermetrics` method for each application.
 
-| Mode        | Average GPU utilization |
-| ----------- | ----------------------: |
-| `normal`    |                 `77.7%` |
-| `balanced`  |                 `46.9%` |
-| `low-power` |                 `24.2%` |
-| `software`  |                 `33.9%` |
+| Visible application | Average GPU utilization |
+| ------------------- | ----------------------: |
+| ego lite            |                 `71.73%` |
+| ChatGPT             |                 `19.90%` |
+| QuarkCloudDrive     |                 `18.88%` |
+| Google Chrome       |                  `8.55%` |
+| Clean desktop       |                  `8.54%` |
 
-These measurements identify WebGL and Skia Graphite as major contributors on the tested configuration. They are diagnostic reference values, not performance guarantees for other hardware or releases.
+A separate 12-sample run with `--disable-webgl` still averaged `76.57%`. Disabling GPU compositing and rasterization also made no material difference. Both `--disable-gpu` and Chromium's persistent hardware-acceleration-off preference caused ego lite `0.4.6.12` to exit with `SIGTRAP`.
+
+After enabling the low-power watchdog, a 12-sample hidden-window run averaged `9.72%` GPU utilization with a range of `8.14%` to `11.62%`. These results locate the sustained load in the browser-owned visible-window rendering path. Hiding ego lite is the only tested workaround that lowers the load reliably without crashing this build.
 
 ## Upstream fix
 
-The durable fix belongs in the ego lite browser host:
+The durable fix belongs in the closed-source ego lite browser host rather than this open-source automation harness:
 
 - Stop the browser-owned WebGL overlay when no agent visual effect is active.
 - Pause compositor and overlay updates while the window is hidden or occluded.

--- a/skills/ego-browser/references/gpu.md
+++ b/skills/ego-browser/references/gpu.md
@@ -1,0 +1,51 @@
+# macOS GPU compatibility modes
+
+Use this guide when ego lite causes sustained GPU activity while its window is visible.
+
+This repository contains the open-source `ego-browser` automation runtime and Skill, not the browser application's Chromium host source. The launcher below is therefore an opt-in compatibility workaround while the browser-side compositor issue is fixed upstream.
+
+## Launch a compatibility mode
+
+Quit ego lite completely before running the launcher. Closing its windows is not enough because Chromium graphics flags only apply when the browser process starts.
+
+```bash
+sh skills/ego-browser/scripts/launch-gpu-mode.sh balanced
+```
+
+Available modes:
+
+| Mode | Chromium flag | Trade-off |
+|---|---|---|
+| `normal` | none | Normal ego lite behavior |
+| `balanced` | `--disable-skia-graphite` | Keeps WebGL available but falls back from the Graphite renderer |
+| `low-power` | `--disable-webgl` | Largest measured GPU reduction; WebGL pages and ego lite visual agent overlays may be unavailable |
+| `software` | `--disable-gpu` | Troubleshooting only; shifts rendering work to the CPU and disables hardware video acceleration |
+
+The script refuses to launch if ego lite is already running. It does not edit the browser profile, Chrome flags preferences, bookmarks, cookies, or extensions.
+
+To return to the default behavior, quit ego lite and open it normally from Finder, Spotlight, or the Dock.
+
+## Reference measurements
+
+The following 12-sample averages were recorded on ego lite `0.4.6.12`, Chromium `150.0.7871.101`, macOS `26.5.2`, and Apple M5. Each run used a new temporary profile with extensions disabled.
+
+| Mode | Average GPU utilization |
+|---|---:|
+| `normal` | `77.7%` |
+| `balanced` | `52.8%` |
+| `low-power` | `24.2%` |
+| `software` | `33.9%` |
+
+These measurements identify WebGL and Skia Graphite as major contributors on the tested configuration. They are diagnostic reference values, not performance guarantees for other hardware or releases.
+
+## Upstream fix
+
+The durable fix belongs in the ego lite browser host:
+
+- Stop the browser-owned WebGL overlay when no agent visual effect is active.
+- Pause compositor and overlay updates while the window is hidden or occluded.
+- Destroy completed animation surfaces instead of leaving a full-window layer attached.
+- Clean up stale SharedImage mailboxes rather than retrying compositor submissions.
+- Fall back from Skia Graphite on affected macOS and Apple GPU combinations.
+
+Track the existing upstream report in GitHub issue `citrolabs/ego-lite#69`.

--- a/skills/ego-browser/references/gpu.md
+++ b/skills/ego-browser/references/gpu.md
@@ -17,7 +17,7 @@ Available modes:
 | Mode | Chromium flag | Trade-off |
 |---|---|---|
 | `normal` | none | Normal ego lite behavior |
-| `balanced` | `--disable-skia-graphite` | Keeps WebGL available but falls back from the Graphite renderer |
+| `balanced` | `--disable-features=SkiaGraphite` | Keeps WebGL available but falls back from the Graphite renderer |
 | `low-power` | `--disable-webgl` | Largest measured GPU reduction; WebGL pages and ego lite visual agent overlays may be unavailable |
 | `software` | `--disable-gpu` | Troubleshooting only; shifts rendering work to the CPU and disables hardware video acceleration |
 
@@ -32,7 +32,7 @@ The following 12-sample averages were recorded on ego lite `0.4.6.12`, Chromium 
 | Mode | Average GPU utilization |
 |---|---:|
 | `normal` | `77.7%` |
-| `balanced` | `52.8%` |
+| `balanced` | `46.9%` |
 | `low-power` | `24.2%` |
 | `software` | `33.9%` |
 

--- a/skills/ego-browser/references/install.md
+++ b/skills/ego-browser/references/install.md
@@ -65,4 +65,4 @@ Once the environment is ready, return to the user's original task and continue w
 - **Download failed**: the script retries 3 times automatically; if it still fails, it's usually a network issue — have the user check their network and retry.
 - **Gatekeeper still blocks it**: the script already tries to strip quarantine; if the first launch is still blocked, have the user allow ego lite manually under System Settings → Privacy & Security.
 - **Command still unavailable after onboarding**: confirm `~/.local/bin` is on the PATH (see above); or have the user reopen ego lite, finish onboarding, and retry.
-- **Sustained high GPU usage on macOS**: read [`gpu.md`](gpu.md) and use the opt-in compatibility launcher. Do not silently relaunch the browser because the low-power modes disable graphics features.
+- **Sustained high GPU usage on macOS**: read [`gpu.md`](gpu.md) and use the opt-in controller or compatibility launcher. Low-power mode hides ego lite after it loses focus, so explain that behavior before enabling it.

--- a/skills/ego-browser/references/install.md
+++ b/skills/ego-browser/references/install.md
@@ -65,3 +65,4 @@ Once the environment is ready, return to the user's original task and continue w
 - **Download failed**: the script retries 3 times automatically; if it still fails, it's usually a network issue — have the user check their network and retry.
 - **Gatekeeper still blocks it**: the script already tries to strip quarantine; if the first launch is still blocked, have the user allow ego lite manually under System Settings → Privacy & Security.
 - **Command still unavailable after onboarding**: confirm `~/.local/bin` is on the PATH (see above); or have the user reopen ego lite, finish onboarding, and retry.
+- **Sustained high GPU usage on macOS**: read [`gpu.md`](gpu.md) and use the opt-in compatibility launcher. Do not silently relaunch the browser because the low-power modes disable graphics features.

--- a/skills/ego-browser/scripts/launch-gpu-mode.sh
+++ b/skills/ego-browser/scripts/launch-gpu-mode.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+set -eu
+
+APP_NAME="ego lite"
+SYSTEM_APP_PATH="/Applications/$APP_NAME.app"
+USER_APP_PATH="$HOME/Applications/$APP_NAME.app"
+
+usage() {
+	cat <<'EOF'
+Usage:
+  launch-gpu-mode.sh [normal|balanced|low-power|software]
+
+Modes:
+  normal      Launch ego lite without graphics overrides.
+  balanced    Disable Skia Graphite while keeping WebGL available.
+  low-power   Disable WebGL for the largest GPU reduction.
+  software    Disable GPU acceleration for troubleshooting only.
+
+The mode defaults to EGO_LITE_GPU_MODE, or balanced when unset.
+Quit ego lite before running this script. Graphics flags only apply at startup.
+EOF
+}
+
+log() {
+	printf '%s\n' "$*" >&2
+}
+
+die() {
+	log "error: $*"
+	exit 1
+}
+
+find_app() {
+	if [ -n "${EGO_LITE_APP_PATH:-}" ]; then
+		[ -d "$EGO_LITE_APP_PATH" ] ||
+			die "ego lite app was not found at $EGO_LITE_APP_PATH"
+		printf '%s\n' "$EGO_LITE_APP_PATH"
+		return
+	fi
+
+	for app_path in "$SYSTEM_APP_PATH" "$USER_APP_PATH"; do
+		if [ -d "$app_path" ]; then
+			printf '%s\n' "$app_path"
+			return
+		fi
+	done
+
+	die "ego lite is not installed in /Applications or ~/Applications"
+}
+
+mode="${1:-${EGO_LITE_GPU_MODE:-balanced}}"
+
+case "$mode" in
+	-h | --help)
+		usage
+		exit 0
+		;;
+esac
+
+[ "$#" -le 1 ] || {
+	usage >&2
+	exit 2
+}
+
+[ "$(uname -s)" = "Darwin" ] ||
+	die "GPU compatibility modes currently support macOS only"
+
+app_path=$(find_app)
+
+if pgrep -x "$APP_NAME" >/dev/null 2>&1; then
+	die "ego lite is already running; quit it completely and retry"
+fi
+
+case "$mode" in
+	normal)
+		log "Launching ego lite in normal graphics mode."
+		exec open "$app_path"
+		;;
+	balanced)
+		log "Launching ego lite with Skia Graphite disabled; WebGL remains available."
+		set -- --disable-skia-graphite
+		;;
+	low-power)
+		log "Launching ego lite with WebGL disabled; WebGL pages and visual agent overlays may be unavailable."
+		set -- --disable-webgl
+		;;
+	software)
+		log "Launching ego lite with GPU acceleration disabled; use this mode for troubleshooting only."
+		set -- --disable-gpu
+		;;
+	*)
+		usage >&2
+		exit 2
+		;;
+esac
+
+exec open -n "$app_path" --args "$@"

--- a/skills/ego-browser/scripts/launch-gpu-mode.sh
+++ b/skills/ego-browser/scripts/launch-gpu-mode.sh
@@ -79,7 +79,7 @@ case "$mode" in
 		;;
 	balanced)
 		log "Launching ego lite with Skia Graphite disabled; WebGL remains available."
-		set -- --disable-skia-graphite
+		set -- --disable-features=SkiaGraphite
 		;;
 	low-power)
 		log "Launching ego lite with WebGL disabled; WebGL pages and visual agent overlays may be unavailable."

--- a/skills/ego-browser/scripts/launch-gpu-mode.sh
+++ b/skills/ego-browser/scripts/launch-gpu-mode.sh
@@ -14,7 +14,7 @@ Usage:
 Modes:
   normal      Launch ego lite without graphics overrides.
   balanced    Disable Skia Graphite while keeping WebGL available.
-  low-power   Disable WebGL for the largest GPU reduction.
+  low-power   Hide ego lite automatically after it loses focus.
   software    Disable GPU acceleration for troubleshooting only.
 
 The mode defaults to EGO_LITE_GPU_MODE, or balanced when unset.
@@ -67,9 +67,15 @@ esac
 	die "GPU compatibility modes currently support macOS only"
 
 app_path=$(find_app)
+node_path=$(command -v node || true)
+watchdog_path="${EGO_LITE_WATCHDOG_PATH:-$SCRIPT_DIR/../gpu-controller/native-host/low-power-watchdog.mjs}"
 
 if pgrep -x "$APP_NAME" >/dev/null 2>&1; then
 	die "ego lite is already running; quit it completely and retry"
+fi
+
+if [ -n "$node_path" ] && [ -f "$watchdog_path" ]; then
+	"$node_path" "$watchdog_path" stop
 fi
 
 case "$mode" in
@@ -82,10 +88,21 @@ case "$mode" in
 		set -- --disable-features=SkiaGraphite
 		;;
 	low-power)
-		log "Launching ego lite with WebGL disabled; WebGL pages and visual agent overlays may be unavailable."
-		set -- --disable-webgl
+		[ -n "$node_path" ] || die "Node.js 22 or newer is required for low-power mode"
+		[ -f "$watchdog_path" ] || die "low-power watchdog was not found at $watchdog_path"
+		log "Launching ego lite with automatic background hiding; click its Dock icon to restore it."
+		open -n "$app_path"
+		sleep 2
+		EGO_LITE_APP_PATH="$app_path" "$node_path" "$watchdog_path" start
+		exit 0
 		;;
 	software)
+		app_version=$(
+			/usr/bin/plutil -extract CFBundleShortVersionString raw \
+				"$app_path/Contents/Info.plist" 2>/dev/null || true
+		)
+		[ "$app_version" != "0.4.6.12" ] ||
+			die "software mode is disabled for ego lite 0.4.6.12 because it causes the browser to exit"
 		log "Launching ego lite with GPU acceleration disabled; use this mode for troubleshooting only."
 		set -- --disable-gpu
 		;;


### PR DESCRIPTION
## Summary

Adds an opt-in macOS GPU compatibility controller for ego lite, including a measured background low-power mode that reduces sustained GPU activity without using graphics flags that crash the current app build.

This is intentionally a compatibility layer in the open-source skill/runtime repository. It does not claim to replace the durable compositor/WebGL fix needed in the closed-source browser host.

## Related issue

Related to #69. This PR provides an immediately usable workaround and diagnostic path, but does not close the host-side GPU issue.

## Why this belongs upstream

Users have reported sustained GPU usage while ego lite is open, including when they are not actively interacting with it. Existing Chromium switches were either ineffective on the tested build or unsafe:

- `--disable-webgl`, GPU compositing, and rasterization switches produced no material reduction.
- `--disable-gpu` and the persistent hardware-acceleration-off preference caused ego lite `0.4.6.12` to exit with `SIGTRAP`.
- A background low-power mode that hides the unfocused app is the only tested workaround that returned GPU activity close to the clean-desktop baseline without crashing the browser.

The controller makes the workaround accessible inside ego lite after one-time installation, rather than requiring users to remember terminal commands.

## Changes

- Add documented `normal`, `balanced`, `low-power`, and guarded `software` modes for macOS.
- Add an optional toolbar extension and restricted native-messaging host so modes can be changed inside ego lite.
- Persist balanced mode through Chromium's Skia Graphite experiment state instead of modifying or re-signing the app bundle.
- Add a single-instance low-power watchdog that hides ego lite 1.5 seconds after focus is lost and restores normal foreground behavior when the Dock icon is clicked.
- Pause the watchdog during controlled restarts, validate PID ownership, clear stale locks, and back off on AppleScript failures.
- Block software rendering on ego lite `0.4.6.12`, where testing showed it crashes during startup.
- Add installation, rollback, security, measurement, and troubleshooting documentation.
- Add controller and launcher regression tests.

## Measured result

Measured on August 9, 2026 using ego lite `0.4.6.12`, Chromium `150.0.7871.101`, macOS `26.5.2`, and Apple M5:

| Scenario | Average GPU utilization |
| --- | ---: |
| Existing `--disable-webgl` attempt, 12 samples | `76.57%` |
| New low-power mode while hidden, 12 samples | `9.72%` |

The hidden-mode range was `8.14%–11.62%`, a reduction of `66.85` percentage points (about `87.3%`). Process CPU activity also fell from `80.74` to `7.02 ms/s` for the main process and from `88.68` to `9.92 ms/s` for the GPU helper.

This mode deliberately optimizes background use; foreground rendering behavior remains unchanged.

## Verification

Commands run from `package/ego-browser` unless noted otherwise:

```text
npm test                                      # 333/333 passing
npm run typecheck                             # passing
npm run validate:site-skills                  # passing
prettier --check                              # passing through pre-commit
npm audit --audit-level=moderate               # passing through pre-commit
EGO_BROWSER_REAL_E2E_ONLY='environment initialization,observation helpers,screencast recording' npm run e2e
                                               # 4/4 cases, 69 assertions passing
```

The low-power watchdog must be paused for screenshot/recording E2E because the feature intentionally hides an unfocused ego lite window. A full local real-browser run reached 42/45; the remaining failures were unrelated ticket-inventory and canvas-stroke interaction flakes, while all three screenshot-related cases above passed after running with the watchdog paused.

## Impact

- [ ] Public helper API or behavior
- [x] Agent skill or instructions
- [ ] Site learning
- [x] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

Compatibility and rollout notes:

- macOS only.
- Opt-in; the default browser launch remains unchanged.
- The controller does not modify the signed ego lite app bundle, cookies, bookmarks, profile data, or unrelated extensions.
- Applying a mode restarts ego lite and therefore ends active Agent tasks.
- The software mode is automatically disabled for known-crashing app versions.

## Checklist

- [x] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes.
- [x] Relevant unit tests, typecheck, validation, audit, formatting, and targeted real-browser E2E pass locally.
- [x] Agent-facing documentation is updated.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [ ] A release-note label is selected (`feat`, `fix`, `docs`, `chore`, `ci`, or `refactor`) — contributor permissions do not allow applying labels; maintainers can add the appropriate release-note label during review.
