### PR TITLE
feat(install): run on Linux, and pick the platform at install time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,5 +80,7 @@ test-e2e/
 test/
 !package/ego-browser/test/
 !package/ego-browser/test/*.test.js
+!package/ego-linux/test/
+!package/ego-linux/test/**
 # Translated skill (local only)
 skills/ego-browser/SKILL.zh.md

--- a/package/ego-linux/README.md
+++ b/package/ego-linux/README.md
@@ -1,0 +1,379 @@
+# ego-browser, Linux port
+
+The ego lite app runs on macOS only: the browser ships as a `.dmg`, and the
+`ego-browser` harness talks to it through native bindings the app injects as
+`globalThis.ego`.
+
+This package supplies that object on Linux, backed by a stock Chromium over CDP.
+**The harness itself is unmodified** — every helper, locator, driver and format
+in `package/ego-browser/` is the shared harness running as-is.
+
+## Install
+
+Requires Node >= 22 and any Chrome/Chromium/Brave/Edge build on `PATH`.
+
+```bash
+cd package/ego-browser && CI=true npm ci && npm run build   # build the shared harness
+cd ../ego-linux && npm test                                  # verify the port (headless)
+```
+
+`CI=true` is required, not cosmetic: the harness's `prepare` script runs
+`lefthook install`, which fails on any machine with a global `core.hooksPath`
+set. The script's own guard is `[ "$CI" = "true" ] && exit 0`, so this is
+upstream's intended escape hatch rather than a workaround.
+
+Put the CLI on your PATH:
+
+```bash
+ln -s "$PWD/bin/ego-browser.mjs" ~/.local/bin/ego-browser
+```
+
+## Use
+
+Identical to upstream — a heredoc of JS on stdin:
+
+```bash
+ego-browser <<'JS'
+const task = await taskSpaces.useOrCreate('research task')
+await page.goto('https://example.com')
+console.log(await page.snapshot())
+JS
+```
+
+Linux-only commands:
+
+| Command | What it does |
+|---|---|
+| `ego-browser --status` | connection state of the backing browser |
+| `ego-browser --open` | open the shared agent browser window |
+| `ego-browser --spaces` | open the Spaces overview panel |
+| `ego-browser --stop` | terminate the backing browser and clear its profile lock |
+| `ego-browser --import-chrome-profile` | copy your real Chrome profile in, so agent tasks inherit your logins |
+| `ego-browser --install-desktop-entry` | add it to your app launcher, with an icon |
+| `ego-browser --headless` | run the backing browser headless (first launch only) |
+
+### The Spaces panel
+
+`ego-browser --spaces` opens an overview of every task space: one card each, with
+a live screenshot of the space's page, its name, its owner, and its tab count.
+Clicking a card switches to that space, `×` closes it, `+` creates one.
+
+Upstream draws this inside the browser's own chrome, replacing the tab strip.
+That is not reachable from outside a Chromium fork — Chrome 137 removed the
+`--load-extension` switch, and the CDP `Extensions` domain answers
+"Method not available", so nothing can inject UI into the browser frame. (A
+Chromium-based browser that still honours `--load-extension`, such as Brave,
+*can* load one — verified on this machine — which would additionally allow
+native tab groups as space markers.)
+
+What is reachable on stock Chrome is an `--app` window: no tab strip, no
+toolbar, its own `app_id`. That is what the panel uses, so it reads as part of
+the browser rather than a web page in a tab. A small loopback HTTP server backs
+it, reading and writing the same task-space state file the CLI uses — the
+overview and the agent can never disagree about which spaces exist.
+
+### App launcher entry
+
+The macOS build installs as an app you click to open. `--install-desktop-entry`
+gives the Linux port the same affordance — an XDG desktop entry plus a scalable
+icon:
+
+```bash
+ego-browser --install-desktop-entry
+```
+
+It writes `~/.local/share/applications/ego-lite-linux.desktop` and
+`~/.local/share/icons/hicolor/scalable/apps/ego-lite-linux.svg`, then refreshes
+the desktop and icon caches. Launching it runs `--open`, which brings up the
+shared agent browser window. The icon is the ego lite mark with a badge, so a
+Linux window is never mistaken for the macOS app.
+
+The entry pins the **absolute path of the node that installed it**, rather than
+relying on a `#!/usr/bin/env node` shebang. A desktop session's PATH is not your
+shell's, so a node from nvm / fnm / asdf is invisible to it and clicking the
+icon would fail silently, with no terminal to show the error. Re-run
+`--install-desktop-entry` after switching node versions.
+
+`--open` also replaces a headless backing browser with a visible one instead of
+refusing, for the same reason: an icon has to work, not explain.
+
+The backing browser is launched once and **persists between invocations** — each
+heredoc is its own short-lived Node process, so the browser, not the process, is
+what has to survive. It uses a dedicated profile under
+`~/.local/share/ego-lite-linux/profile`, which is why `--import-chrome-profile`
+exists: it is the Linux equivalent of ego lite's "migrate your Chrome data"
+onboarding step.
+
+Environment overrides: `EGO_LINUX_CHROME` (browser binary),
+`EGO_LINUX_PROFILE` (profile dir), `EGO_LINUX_CDP_URL` (attach to an
+already-running DevTools endpoint instead of launching), `EGO_LINUX_CURSOR=0`
+(hide the agent cursor), `EGO_LINUX_CURSOR_NAME` (rename it from "Claude").
+
+### The agent's cursor
+
+Watch the agent's window and you see a cursor move, click and carry a label of
+what it is currently doing — the same "something else is driving this" signal
+the native app draws over its web view. On Linux the page is the only surface
+the shim controls, so the cursor is a DOM overlay injected into the page the
+harness is acting on (`src/cursor.mjs`), fed by the pointer coordinates the
+harness sends.
+
+It is deliberately unable to interfere with the automation it illustrates:
+
+- the host element is `pointer-events: none`, so `document.elementFromPoint`
+  never returns it. That is load-bearing, not cosmetic — the harness's wheel and
+  drag fallbacks hit-test with `elementFromPoint`, and an overlay that answered
+  those probes would swallow input meant for the page;
+- it lives in a closed shadow root, keeping it out of the agent's own snapshot
+  and out of reach of page CSS;
+- every render is fire-and-forget and swallows its errors, so a page that
+  refuses the injection or navigates mid-flight can never fail an action.
+
+It *is* drawn into screenshots, which is usually what you want and occasionally
+not: `EGO_LINUX_CURSOR=0` turns it off.
+
+### Watching it read
+
+Snapshotting is most of what an agent does, and it dispatches no input at all —
+so a window where the agent was reading showed a cursor parked in a corner under
+a badge that said "reading". True, but it never said *what*, which is the one
+thing someone watching wants to know.
+
+Every snapshot now starts a **read sweep**: the cursor walks the lines that are
+actually on screen, marking each one as it passes and naming it in the badge
+(`Claude · reading "…"`). The marks are lighter than the highlighter's and fade
+behind the cursor, because reading is constant and its marks should not pile up.
+
+The sweep runs entirely inside the page. A CDP round trip per line would cost
+more than the snapshot it illustrates, and the heredoc that triggered it has
+usually exited before the last line is drawn. It gives up after about two and a
+half seconds, and any real input — a click, a keystroke, the next read, an
+explicit `highlight()` — takes the cursor back from it immediately, mid-line.
+
+It also keeps the state the Spaces overview polls moving, so a space whose agent
+is reading no longer looks like a space whose agent walked away.
+
+### Watching it scroll
+
+The cursor is anchored to the page rather than the screen, because it marks the
+element the agent is working on and has to travel with it. The cost is that a
+long scroll carries it out of the viewport entirely, and the window went blank
+while the agent was still working.
+
+The cursor still goes; the **badge stays**, docked against the edge the cursor
+left by with an arrow pointing after it (`↑ Claude · checking the button`). It
+holds still while the page keeps moving under it, and glides back to the cursor
+when the cursor comes back into view. Scroll position is not something a CDP
+round trip announces, so this is driven by the overlay's own `scroll` listener —
+which also means it works for the `scrollIntoView` every `click()` does, not just
+for an explicit `page.wheel()`.
+
+One limit worth knowing: a docked badge is for the window, not for screenshots.
+`Page.captureScreenshot` renders the overlay in page coordinates without the
+scroll offset — a pre-existing quirk, visible on any scrolled page — so a badge
+docked at the top of a viewport scrolled far down falls outside the captured
+frame. Nothing is lost that used to be there: before, the cursor was off screen
+and the screenshot showed nothing either.
+
+Cursor movement is also timed by distance now, between a 90ms nudge and a 420ms
+glide, rather than every move taking the same 200ms whether it crossed the page
+or two fields.
+
+### The highlighter
+
+`ego` is a global inside a heredoc, so the port adds one thing the upstream API
+has no equivalent for — a marker the agent draws to show you what it is talking
+about:
+
+```js
+await ego.highlight('free shipping', { note: 'this is the bit that changed' })
+await ego.highlight('#total', { note: 'and this is the total' })
+await ego.clearHighlight()
+```
+
+A string is tried as a CSS selector first and searched for as page text if that
+finds nothing, so both forms above do the obvious thing; `{selector}` or `{text}`
+forces one. Off-screen text is scrolled into view first — a marker nobody can see
+explains nothing.
+
+It resolves to a `Range`, which is what gives **one band per line** instead of
+one box around a whole paragraph: the difference between a pen stroke and a
+coloured rectangle. Each band wipes in from its own left edge while the cursor
+travels along it, and the call resolves when the stroke finishes, so an agent can
+narrate at the speed a human reads.
+
+It never makes a real selection. Selecting text for the look of it would fight
+the agent's own work on the page.
+
+### What the launcher normalises, and why
+
+Two settings are forced on the agent profile because inheriting them silently
+breaks coordinate-based automation:
+
+- **Page zoom is reset to 100% on every launch.** `--import-chrome-profile`
+  copies real Chrome preferences, zoom included. At 150% zoom a 1280px window
+  lays out as 853 CSS px, so page content the agent expects on screen falls
+  below the fold: element coordinates hit-test to nothing, clicks land on
+  nothing, and `Input.dispatchMouseEvent` can hang outright. This was not
+  theoretical — it caused every canvas drawing case in the upstream e2e suite to
+  fail until it was fixed.
+- **The window is launched at 1280x900 with device scale factor 1**, so page
+  layout does not depend on the desktop's HiDPI setting.
+
+The launcher also clears Chrome's `SingletonLock` before starting. A browser
+killed without a clean shutdown leaves that lock, and every later launch then
+aborts with "Failed to create a ProcessSingleton". Since `launch()` only runs
+after no DevTools endpoint answered, a lock still held by a live process means
+an unreachable orphan of ours, which is terminated first.
+
+## Fidelity
+
+The harness uses 15 native methods plus 2 callbacks. All are implemented; two
+areas are degraded, and both degradations are structural rather than unfinished
+work.
+
+| Native surface | Backed by | Fidelity |
+|---|---|---|
+| `sendCDPMessage`, `onCDPMessage`, `onSendCDPMessageError` | WebSocket to Chrome's browser endpoint | **Exact.** Chrome's flat CDP wire format is byte-identical to what the harness sends and parses, so this is a passthrough, not a translation. |
+| `listTabs`, `createTab` | `Target.getTargets` / `Target.createTarget` | **Exact**, except `active`: CDP cannot report which tab is focused, so the DevTools HTTP endpoint's most-recently-used ordering stands in. It also tracks tabs the user switches to by hand. |
+| `getBrowserVersion` | `Browser.getVersion` | Exact. |
+| `upgradeBrowser` | no-op | App lifecycle; the user's own Chrome updates itself. |
+| `animationHighlightMouseToPosition`, `setAgentTaskState` | a DOM overlay injected into the page | **Equivalent, drawn elsewhere.** The native app paints the cursor over its web view; the shim has only the page, so it injects one there. See above. |
+| `snapshot` | `DOMSnapshot.captureSnapshot` + role/name computation | **Refs exact, content rebuilt.** See below. |
+| the 9 task-space methods | a seeded browser context per space | **Isolated, with inherited logins.** The seeded jar is a copy, not live shared state. See below. |
+
+Verified against upstream's own real-browser e2e suite (45 cases, ~525
+assertions), which drives this CLI exactly as it drives the macOS app.
+
+### snapshot
+
+The `refs` half is exact. `browserSnapshotRefsToRefMap()` keys the ref map by
+`String(backendNodeId)`, and CDP hands out `backendNodeId`s directly — so `@N`
+and `ref=N` resolve against genuine node identities, not a reimplementation.
+
+The `content` half is rebuilt, since the native snapshot is closed source. One
+`DOMSnapshot.captureSnapshot` call returns every document — iframes included,
+nested to any depth — with each node's `backendNodeId`, attributes and layout
+box. Hierarchy, layout-driven visibility and iframe piercing therefore come from
+the browser itself; roles, accessible names and `loc=` locators are computed
+here. Emitted `loc=` values are resolved by upstream's own `locator-query.ts`,
+so they are validated against the real resolver rather than an invented format.
+
+Not claimed: parity with the native snapshot's output. It is a different tree
+built from the same underlying facts.
+
+### Task spaces
+
+A native Space is isolated *and* inherits your login state. On stock Chromium
+those two properties look like they pull apart:
+
+- `Target.createBrowserContext` → real isolation, but an empty cookie jar
+- a separate window → your real logins, but no isolation
+
+They don't, because the empty jar can be filled. A space now owns a browser
+context that is seeded from the default jar when the space is created, so it
+gets both: cookies written in one space are invisible in every other and in the
+default jar, while the logins you already had are there from the start. Closing
+the space disposes the context, which drops that jar with it. Measurements and
+two reproducible experiments are in
+[`docs/isolation-with-inherited-logins.md`](../../docs/isolation-with-inherited-logins.md);
+seeding a real 2038-cookie profile costs ~105 ms, once per space.
+
+What this is *not* is live shared state: the seeded jar is a point-in-time copy,
+so logging into a site inside one space does not appear in the others, and
+`localStorage`, IndexedDB and service workers are not carried at all — a site
+holding its token outside cookies will still land logged out.
+
+A space also owns a tracked set of tabs plus its ownership state (`agent` /
+`agentDelegatedToUser` / `user`), with working `switch` / `claim` / `handOff` /
+`takeOver` / `complete` semantics; switching to a space puts the agent back on
+that space's page. A space that cannot get a context, and any space created
+before contexts existed, falls back to the window-only behaviour described
+below.
+
+`listTabs` is scoped to the selected space, as it is in the native app. That was
+dropped once and has been restored, because the reason it failed is gone:
+membership used to be inferred from which window a tab landed in, and
+`Target.createTarget` accepts no window id, so every heuristic tried (MRU
+ordering, "the tab the harness is attached to", "the tab we just created")
+either hid a tab the harness still held — `switchTab` then failed with "target
+not found" — or leaked one space's tabs into another's list. A context answers
+the question outright: `Target.getTargets` reports each target's
+`browserContextId`, and a tab opened for a space is created in that context.
+Spaces without one fall back to their tracked target ids.
+
+A context-backed space **does** get its own browser window, not by choice: a
+target in a non-default context cannot share a window with the default one. That
+reverses the earlier design, which deliberately used a single window because
+headless Chrome does not render tabs in background windows —
+`document.elementFromPoint` returned null there, which broke hit-testing and
+tripped the harness's input fallback (`driver/pointer.ts` `finishDragProbe`)
+into re-synthesising drags that had already landed, so the canvas cases failed
+or counted double strokes. Re-measured with contexts in place: 43/45, all three
+canvas cases passing. That flake is load-sensitive, so one clean run is evidence
+rather than proof — but contexts did not obviously bring it back.
+
+**What does not work:**
+
+- *Live shared login state.* The seeded jar is a point-in-time copy, so logging
+  into a site inside one space does not appear in the others.
+- *Storage beyond cookies.* `localStorage`, IndexedDB and service workers are
+  not seeded, so a site holding its token outside cookies lands logged out.
+
+Ownership is advisory here. The native bridge enforces the user-control boundary
+inside the app; nothing on Linux can stop an agent from driving a window the
+user has taken over, so `EGO_TASK_SPACE_USER_IN_CONTROL` is never raised.
+
+## Verification
+
+Two suites, and they must be run one at a time — both drive a browser.
+
+**`npm test` (this package)** drives the real CLI headless against a local
+fixture: navigation, snapshot content, refs resolving to coordinates,
+synthesised clicks landing on elements, locator fills, two-level iframe
+piercing, screenshots, the agent cursor, and task-space lifecycle. It also
+starts a real Spaces server and asserts its routes, its cross-origin refusal,
+and that a click by a separate agent process shows up as activity on the card.
+It uses a throwaway profile and state dir, so it never touches a browser your
+agent sessions are using.
+
+**Upstream's real-browser e2e suite** (`cd ../ego-browser && npm run e2e`, with
+`ego-browser` on PATH) is the real measure: 45 cases, ~520 assertions, driving
+this CLI exactly as it drives the macOS app.
+
+**43 of 45 cases pass** on an unloaded machine.
+
+Two failures are permanent, and neither is a port defect:
+
+| Case | Why it cannot pass |
+|---|---|
+| `macOS bare Meta input isolation` | Asserts `process.platform === "darwin"`. |
+| `regression PWB-10 permission capability` | Asserts that `Browser.grantPermissions` with `clipboardReadWrite` is *rejected* — an ego lite limitation. Stock Chromium supports it, so the port is more capable than the assertion allows. |
+
+Everything else passes: navigation, observation, task spaces, pointer input,
+keyboard, downloads, screencast, fetch, canvas drawing, the Playwright
+regression set, and the adversarial cases.
+
+### Known flake: canvas drawing under load
+
+The three canvas cases intermittently count one stroke too many
+(`expected 1, got 2`). This is a timing race in the *upstream* harness, not in
+the shim, and it is worth knowing about because it can bite any drag-heavy work:
+
+`driver/pointer.ts` `finishDragProbe` waits **50 ms** for a trusted `mouseup` on
+the drag's end element. If it has not seen one by then, it assumes the real
+input never landed and re-synthesises the entire drag in JavaScript. When the
+real events did land but arrived late, the page gets both — one trusted drag and
+one synthetic one.
+
+Anything that adds latency trips it. Running the screencast case immediately
+before the canvas cases reproduces it reliably (drag time goes from ~1.2 s to
+~4.1 s), and so does general machine load. The same code, unchanged, produced
+six clean runs in a row and later four failing ones on the same box, so the
+outcome tracks the machine rather than the port.
+
+Fixing it properly means raising that 50 ms window or making the fallback
+conditional on evidence the input actually failed — a change to
+`package/ego-browser`, which this port deliberately leaves untouched. Nothing in
+the shim layer can suppress the fallback without also removing
+`sendCDPMessage`, which everything else depends on.

--- a/package/ego-linux/README.md
+++ b/package/ego-linux/README.md
@@ -354,26 +354,21 @@ Everything else passes: navigation, observation, task spaces, pointer input,
 keyboard, downloads, screencast, fetch, canvas drawing, the Playwright
 regression set, and the adversarial cases.
 
-### Known flake: canvas drawing under load
+### Drag input under load
 
-The three canvas cases intermittently count one stroke too many
-(`expected 1, got 2`). This is a timing race in the *upstream* harness, not in
-the shim, and it is worth knowing about because it can bite any drag-heavy work:
-
-`driver/pointer.ts` `finishDragProbe` waits **50 ms** for a trusted `mouseup` on
-the drag's end element. If it has not seen one by then, it assumes the real
-input never landed and re-synthesises the entire drag in JavaScript. When the
-real events did land but arrived late, the page gets both — one trusted drag and
-one synthetic one.
+The three canvas cases intermittently counted one stroke too many
+(`expected 1, got 2`) while this port was being measured. The cause sits in the
+shared harness's input fallback rather than in the shim: `driver/pointer.ts`
+`finishDragProbe` re-synthesises a drag when it has not seen the trusted
+`mouseup` in time, so a real drag whose events arrive late is delivered twice.
 
 Anything that adds latency trips it. Running the screencast case immediately
-before the canvas cases reproduces it reliably (drag time goes from ~1.2 s to
+before the canvas cases reproduced it reliably (drag time goes from ~1.2 s to
 ~4.1 s), and so does general machine load. The same code, unchanged, produced
 six clean runs in a row and later four failing ones on the same box, so the
 outcome tracks the machine rather than the port.
 
-Fixing it properly means raising that 50 ms window or making the fallback
-conditional on evidence the input actually failed — a change to
-`package/ego-browser`, which this port deliberately leaves untouched. Nothing in
-the shim layer can suppress the fallback without also removing
-`sendCDPMessage`, which everything else depends on.
+It is recorded here because it can bite any drag-heavy work, on either
+platform. Nothing in the shim layer can suppress the fallback without also
+removing `sendCDPMessage`, which everything else depends on, so it is a
+`package/ego-browser` concern.

--- a/package/ego-linux/assets/ego-lite-linux.svg
+++ b/package/ego-linux/assets/ego-lite-linux.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <title>ego lite (Linux port)</title>
+  <rect width="512" height="512" rx="112" fill="#0B0B0C"/>
+  <!--
+    The ego mark: a disc, an overlapping lens, and a standalone ellipse.
+    evenodd makes the disc/lens overlap read as background, exactly as in
+    assets/logo.png upstream.
+  -->
+  <path fill="#FFFFFF" fill-rule="evenodd" d="
+    M 60,246 a 116,116 0 1,0 232,0 a 116,116 0 1,0 -232,0 Z
+    M 242,246 a 56,118 0 1,0 112,0 a 56,118 0 1,0 -112,0 Z
+    M 396,246 a 29,118 0 1,0 58,0 a 29,118 0 1,0 -58,0 Z
+  "/>
+  <!-- Port badge: marks this as the Linux build, not an upstream macOS one. -->
+  <circle cx="404" cy="418" r="46" fill="#0B0B0C" stroke="#FFFFFF" stroke-width="10"/>
+  <circle cx="404" cy="418" r="22" fill="#F5BD1F"/>
+</svg>

--- a/package/ego-linux/bin/ego-browser.mjs
+++ b/package/ego-linux/bin/ego-browser.mjs
@@ -1,0 +1,388 @@
+#!/usr/bin/env node
+/**
+ * ego-browser, Linux edition.
+ *
+ * Same CLI shape as the macOS app's `ego-browser`: a heredoc of JS on stdin,
+ * executed with every ego-browser helper preloaded. The difference is what backs
+ * it — `globalThis.ego` is this port's CDP shim over a stock Chromium instead of
+ * the app's native bindings. Everything above that line is the upstream harness,
+ * unmodified.
+ */
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { browserStatus, stopBrowser } from "../src/chrome.mjs";
+import { installDesktopEntry } from "../src/desktop.mjs";
+import {
+  CHROME_CONFIG_CANDIDATES,
+  PROFILE_DIR,
+  SPACES_STATE_FILE,
+  TASK_SPACE_FILE,
+  STATE_DIR,
+} from "../src/paths.mjs";
+import { createEgoShim } from "../src/shim.mjs";
+import { startSpacesServer } from "../src/spaces-server.mjs";
+
+const HARNESS = new URL("../../ego-browser/dist/out/index.js", import.meta.url);
+const SKILL_WORKSPACE = new URL("../../../skills/ego-browser", import.meta.url);
+
+const USAGE = `ego-browser (Linux port)
+
+  ego-browser <<'JS'
+  await page.goto('https://example.com')
+  console.log(await page.snapshot())
+  JS
+
+Linux-only commands:
+  --status                  show the backing browser's connection state
+  --open                    open the shared agent browser window
+  --spaces                  open the Spaces overview panel
+  --prune-spaces            close spaces that hold nothing but about:blank
+                            Spaces nobody returns to are also closed on their
+                            own after 30 minutes idle; a space stays alive as
+                            long as its session keeps using it. Set
+                            EGO_LINUX_SPACE_IDLE_MIN to change the window, or
+                            0 to sweep only by hand
+  --stop                    stop the backing browser
+  --import-chrome-profile   copy your real Chrome profile in, to inherit logins
+  --install-desktop-entry   add it to your app launcher, with an icon
+  --headless                run the backing browser headless (first launch only)
+                            EGO_LINUX_HEADLESS=1 makes that the default, so the
+                            agent window never opens over your work; --open
+                            still gives you a visible one when you want it
+`;
+
+async function importChromeProfile() {
+  const source = CHROME_CONFIG_CANDIDATES.find((candidate) =>
+    existsSync(join(candidate, "Default")),
+  );
+  if (!source) {
+    process.stderr.write("no Chrome/Chromium profile found to import\n");
+    return 1;
+  }
+  const status = await browserStatus();
+  if (status.running) {
+    process.stderr.write(
+      "the backing browser is running; run --stop and close it before importing\n",
+    );
+    return 1;
+  }
+  process.stderr.write(`importing ${join(source, "Default")} -> ${PROFILE_DIR}/Default\n`);
+  await cp(join(source, "Default"), join(PROFILE_DIR, "Default"), {
+    recursive: true,
+    force: true,
+  });
+  process.stderr.write("done — logins and cookies now carry into agent tasks\n");
+  return 0;
+}
+
+/** Is a Spaces server already listening on the recorded port? */
+async function liveSpacesServer() {
+  try {
+    const state = JSON.parse(await readFile(SPACES_STATE_FILE, "utf8"));
+    const response = await fetch(`http://127.0.0.1:${state.port}/api/health`, {
+      signal: AbortSignal.timeout(1500),
+    });
+    return response.ok ? state.port : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Open the panel as a chrome-less app window on the shared browser. */
+async function openPanelWindow(url) {
+  const status = await browserStatus();
+  spawn(status.binary || "google-chrome", [`--user-data-dir=${PROFILE_DIR}`, `--app=${url}`], {
+    detached: true,
+    stdio: "ignore",
+  }).unref();
+}
+
+/**
+ * Serve the Spaces panel until the browser goes away.
+ *
+ * Runs detached, because the panel's backend must outlive the command that
+ * opened it. Tying the server to a foreground CLI process meant that closing
+ * the terminal — or any timeout around it — left the panel showing
+ * "cannot reach the browser".
+ */
+async function runSpacesDaemon() {
+  // Spaces created from the panel are the user's, not the profile that happened
+  // to launch this daemon (see agent-identity.mjs).
+  process.env.EGO_LINUX_PANEL = "1";
+  const shim = await createEgoShim({ headless: false });
+  const spaces = await startSpacesServer(shim);
+  const url = `http://127.0.0.1:${spaces.port}/`;
+
+  await mkdir(STATE_DIR, { recursive: true });
+  await writeFile(
+    SPACES_STATE_FILE,
+    JSON.stringify({ port: spaces.port, pid: process.pid }, null, 2),
+  );
+
+  // The daemon owns the window it serves, so starting one always shows it.
+  await openPanelWindow(url);
+
+  const outcome = await new Promise((resolve) => {
+    process.on("SIGINT", () => resolve("signal"));
+    process.on("SIGTERM", () => resolve("signal"));
+
+    // Give Chrome a moment to register the window before deciding it is absent.
+    let seenPanel = false;
+    const started = Date.now();
+
+    const timer = setInterval(async () => {
+      let tabs;
+      try {
+        ({ tabs } = await shim.ego.listTabs());
+      } catch {
+        // The browser went away, taking every window — including this panel —
+        // with it. That is a restart, not a decision, so hand off to a fresh
+        // daemon that will reopen the panel against the new browser.
+        clearInterval(timer);
+        resolve("browser-gone");
+        return;
+      }
+
+      const open = tabs.some((tab) => tab.url.startsWith(url));
+      if (open) {
+        seenPanel = true;
+        return;
+      }
+      // Closing the panel while the browser keeps running is deliberate: stop
+      // serving rather than reopening a window the user just dismissed.
+      if (seenPanel || Date.now() - started > 20000) {
+        clearInterval(timer);
+        resolve("panel-closed");
+      }
+    }, 2500);
+  });
+
+  spaces.close();
+  shim.close();
+  await rm(SPACES_STATE_FILE, { force: true });
+
+  if (outcome === "browser-gone") {
+    spawn(process.execPath, [fileURLToPath(import.meta.url), "--spaces-daemon"], {
+      detached: true,
+      stdio: "ignore",
+    }).unref();
+  }
+  return 0;
+}
+
+/**
+ * Open the Spaces overview.
+ *
+ * The panel is a real Chrome app window (`--app`): no tab strip, no toolbar, its
+ * own app_id. Chrome routes the request to the already-running instance because
+ * the profile matches, so this adds a window rather than a second browser.
+ */
+async function openSpaces() {
+  const running = await liveSpacesServer();
+
+  // A running daemon already owns a window; ask it for another one. A cold start
+  // opens its own, so opening one here too would give you two.
+  if (running) {
+    await openPanelWindow(`http://127.0.0.1:${running}/`);
+    process.stderr.write(`Spaces panel: http://127.0.0.1:${running}/\n`);
+    return 0;
+  }
+
+  spawn(process.execPath, [fileURLToPath(import.meta.url), "--spaces-daemon"], {
+    detached: true,
+    stdio: "ignore",
+  }).unref();
+
+  let port = null;
+  const deadline = Date.now() + 30000;
+  while (!port && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    port = await liveSpacesServer();
+  }
+  if (!port) {
+    process.stderr.write("the Spaces server did not come up\n");
+    return 1;
+  }
+
+  process.stderr.write(`Spaces panel: http://127.0.0.1:${port}/\n`);
+  return 0;
+}
+
+/**
+ * Sweep spaces that hold nothing but about:blank.
+ *
+ * The automatic sweep in reconcile only touches spaces stamped with a creation
+ * time, so it cannot reach the drift left behind before that existed — and a
+ * user staring at twenty empty windows wants them gone now, not in two minutes.
+ * Explicitly invoked, so it ignores age and asks no questions.
+ */
+async function pruneSpaces() {
+  // Maintenance must never be the thing that opens a browser. Forcing a headed
+  // launch here meant running the sweep on a quiet machine started a visible
+  // window — producing exactly the empty windows it exists to clear.
+  const status = await browserStatus();
+  if (!status.running) {
+    process.stdout.write("no backing browser is running; nothing to prune\n");
+    return 0;
+  }
+  const shim = await createEgoShim({ headless: status.headless === true });
+  try {
+    const { taskSpaces = [] } = await shim.ego.listTaskSpaces();
+    // The selected space is the one an agent is working in right now, and its
+    // tab is about:blank for a moment on every navigation. Closing it would
+    // take the agent's context out from under it mid-task.
+    let selectedId = null;
+    try {
+      ({ selectedId = null } = JSON.parse(await readFile(TASK_SPACE_FILE, "utf8")));
+    } catch {
+      // No state file means no selection to protect.
+    }
+    const { targetInfos = [] } = await shim.cdp.call("Target.getTargets");
+    const byTarget = new Map(targetInfos.map((target) => [target.targetId, target]));
+
+    let closed = 0;
+    for (const space of taskSpaces) {
+      const tabs = (space.targetIds || []).map((id) => byTarget.get(id)).filter(Boolean);
+      if (tabs.length === 0) continue;
+      if (space.id === selectedId) continue;
+      if (space.lastContentAt) continue;
+      if (!tabs.every((target) => target.url === "about:blank")) continue;
+      await shim.ego.closeTaskSpace(space.id).then(
+        () => {
+          closed += 1;
+        },
+        () => {},
+      );
+    }
+    process.stdout.write(
+      closed === 0
+        ? "no empty spaces to close\n"
+        : `closed ${closed} empty ${closed === 1 ? "space" : "spaces"}\n`,
+    );
+  } finally {
+    shim.close();
+  }
+  return 0;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+
+  // The skill documents `ego-browser nodejs <<'EOF'`; accept it as a no-op prefix.
+  if (argv[0] === "nodejs") argv.shift();
+
+  if (argv[0] === "--help" || argv[0] === "-h") {
+    process.stdout.write(USAGE);
+    return 0;
+  }
+  if (argv[0] === "--status") {
+    process.stdout.write(`${JSON.stringify(await browserStatus(), null, 2)}\n`);
+    return 0;
+  }
+  if (argv[0] === "--stop") {
+    const stopped = await stopBrowser();
+    process.stdout.write(
+      stopped
+        ? "backing browser stopped; the next run launches a fresh one\n"
+        : "no backing browser was running; profile lock cleared\n",
+    );
+    return 0;
+  }
+  if (argv[0] === "--import-chrome-profile") {
+    return importChromeProfile();
+  }
+  if (argv[0] === "--prune-spaces") {
+    return pruneSpaces();
+  }
+  if (argv[0] === "--spaces") {
+    return openSpaces();
+  }
+  if (argv[0] === "--spaces-daemon") {
+    return runSpacesDaemon();
+  }
+  if (argv[0] === "--install-desktop-entry") {
+    const { entryPath, iconPath } = await installDesktopEntry();
+    process.stdout.write(`installed ${entryPath}\n         ${iconPath}\n`);
+    return 0;
+  }
+  if (argv[0] === "--open") {
+    // Launched from a desktop icon there is no terminal to read an error in, so
+    // this has to succeed rather than explain. A headless browser has no window
+    // to show, so trade it for a visible one.
+    const status = await browserStatus();
+    if (status.running && status.headless) {
+      process.stderr.write("replacing the headless browser with a visible one\n");
+      await stopBrowser();
+    }
+    const shim = await createEgoShim({ headless: false });
+    try {
+      const { tabs } = await shim.ego.listTabs();
+      // A browser with no page target shows no window; give it one.
+      let targetId = tabs.find((tab) => tab.active)?.targetId ?? tabs[0]?.targetId;
+      if (!targetId) ({ targetId } = await shim.ego.createTab("about:blank"));
+
+      // The window usually already exists — it is just behind everything else.
+      // Clicking a launcher icon has to raise it, not quietly confirm it is
+      // running, which looks identical to nothing happening.
+      await shim.cdp.call("Target.activateTarget", { targetId }).catch(() => {});
+      const { sessionId } = await shim.cdp.call("Target.attachToTarget", {
+        targetId,
+        flatten: true,
+      });
+      await shim.cdp.call("Page.bringToFront", {}, sessionId).catch(() => {});
+    } finally {
+      shim.close();
+    }
+    return 0;
+  }
+
+  // EGO_LINUX_HEADLESS is for a machine whose owner does not want the agent
+  // window in front of their work. The harness needs a page target to attach to,
+  // so a visible browser always shows a window — headless is the only way to be
+  // driven without one. --headless still works per run, and --open still trades
+  // a headless browser for a visible one on demand.
+  const envHeadless = !["", "0", "false", "no"].includes(
+    (process.env.EGO_LINUX_HEADLESS ?? "").toLowerCase(),
+  );
+  const headless = argv.includes("--headless") || envHeadless;
+  const rest = argv.filter((arg) => arg !== "--headless");
+
+  // `--sdk-path <file>` selects which harness bundle to run. Upstream's real
+  // browser e2e runner passes it to test a local build; here the local build is
+  // the only harness there is, so honour the path it names.
+  let harness = HARNESS.href;
+  const sdkFlag = rest.indexOf("--sdk-path");
+  if (sdkFlag !== -1) {
+    const path = rest[sdkFlag + 1];
+    if (!path) {
+      process.stderr.write("--sdk-path requires a path\n");
+      return 2;
+    }
+    harness = pathToFileURL(path).href;
+    rest.splice(sdkFlag, 2);
+  }
+
+  // Site skills and learnings live in the repo's skill directory.
+  process.env.EGO_BROWSER_AGENT_WORKSPACE ||= SKILL_WORKSPACE.pathname;
+
+  const shim = await createEgoShim({ headless });
+  globalThis.ego = shim.ego;
+
+  const { runMain } = await import(harness);
+  try {
+    return await runMain({ argv: rest });
+  } finally {
+    shim.close();
+  }
+}
+
+main()
+  .then((code) => process.exit(code ?? 0))
+  .catch((error) => {
+    process.stderr.write(`${error?.stack || error}\n`);
+    process.exit(1);
+  });

--- a/package/ego-linux/bin/ego-browser.mjs
+++ b/package/ego-linux/bin/ego-browser.mjs
@@ -92,13 +92,24 @@ async function liveSpacesServer() {
   }
 }
 
+/** Spawn a detached, unref'd process without letting its errors kill us. */
+function spawnDetached(command, args) {
+  const child = spawn(command, args, { detached: true, stdio: "ignore" });
+  // Detached + unref'd, so the parent cannot react through the child's exit.
+  // An unhandled 'error' on a child process kills Node, which is exactly what
+  // --spaces and --spaces-daemon are trying to avoid — swallow it instead.
+  child.on("error", () => {});
+  child.unref();
+  return child;
+}
+
 /** Open the panel as a chrome-less app window on the shared browser. */
 async function openPanelWindow(url) {
   const status = await browserStatus();
-  spawn(status.binary || "google-chrome", [`--user-data-dir=${PROFILE_DIR}`, `--app=${url}`], {
-    detached: true,
-    stdio: "ignore",
-  }).unref();
+  spawnDetached(status.binary || "google-chrome", [
+    `--user-data-dir=${PROFILE_DIR}`,
+    `--app=${url}`,
+  ]);
 }
 
 /**
@@ -161,15 +172,12 @@ async function runSpacesDaemon() {
     }, 2500);
   });
 
-  spaces.close();
+  await spaces.close();
   shim.close();
   await rm(SPACES_STATE_FILE, { force: true });
 
   if (outcome === "browser-gone") {
-    spawn(process.execPath, [fileURLToPath(import.meta.url), "--spaces-daemon"], {
-      detached: true,
-      stdio: "ignore",
-    }).unref();
+    spawnDetached(process.execPath, [fileURLToPath(import.meta.url), "--spaces-daemon"]);
   }
   return 0;
 }
@@ -192,10 +200,7 @@ async function openSpaces() {
     return 0;
   }
 
-  spawn(process.execPath, [fileURLToPath(import.meta.url), "--spaces-daemon"], {
-    detached: true,
-    stdio: "ignore",
-  }).unref();
+  spawnDetached(process.execPath, [fileURLToPath(import.meta.url), "--spaces-daemon"]);
 
   let port = null;
   const deadline = Date.now() + 30000;

--- a/package/ego-linux/package.json
+++ b/package/ego-linux/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ego-browser-linux",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Linux backing layer for the ego-browser harness: backs globalThis.ego with a plain Chromium over CDP.",
+  "type": "module",
+  "bin": {
+    "ego-browser-linux": "./bin/ego-browser.mjs"
+  },
+  "scripts": {
+    "test": "node --test \"test/*.test.mjs\""
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT"
+}

--- a/package/ego-linux/package.json
+++ b/package/ego-linux/package.json
@@ -4,9 +4,6 @@
   "private": true,
   "description": "Linux backing layer for the ego-browser harness: backs globalThis.ego with a plain Chromium over CDP.",
   "type": "module",
-  "bin": {
-    "ego-browser-linux": "./bin/ego-browser.mjs"
-  },
   "scripts": {
     "test": "node --test \"test/*.test.mjs\""
   },

--- a/package/ego-linux/src/agent-identity.mjs
+++ b/package/ego-linux/src/agent-identity.mjs
@@ -1,0 +1,65 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * Who is opening this space.
+ *
+ * The panel's right-hand label mirrors the native Space category ("Personal",
+ * "Work"). On a cue-managed machine the useful equivalent is the agent profile
+ * that opened the space, so a glance at the overview answers "which of my agents
+ * is doing this" rather than just "an agent is".
+ *
+ * Read at creation time, from the environment of the process that ran the
+ * heredoc — the browser itself has no idea who is driving it.
+ */
+
+const RUNTIME_MARKER = "/.config/cue/runtime/";
+
+/** cue launches its sessions against a per-profile runtime directory. */
+function profileFromEnvironment() {
+  for (const value of Object.values(process.env)) {
+    if (typeof value !== "string") continue;
+    const at = value.indexOf(RUNTIME_MARKER);
+    if (at === -1) continue;
+    const rest = value.slice(at + RUNTIME_MARKER.length);
+    const name = rest.split("/")[0];
+    if (name) return name;
+  }
+  return null;
+}
+
+/** Directories can pin a profile; walk up like cue itself does. */
+function profileFromPinFile(startDir) {
+  let dir = startDir;
+  for (let depth = 0; depth < 12; depth += 1) {
+    const pin = join(dir, ".cue.profile");
+    if (existsSync(pin)) {
+      try {
+        const name = readFileSync(pin, "utf8").trim();
+        if (name) return name;
+      } catch {
+        // unreadable pin is the same as no pin
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+export function agentIdentity(cwd = process.cwd()) {
+  // The Spaces panel's own daemon inherits the environment of whichever session
+  // happened to start it. A space you create by hand from the panel is yours,
+  // not that profile's, so the daemon opts out of attribution entirely.
+  if (process.env.EGO_LINUX_PANEL === "1") {
+    return { profile: null, session: null };
+  }
+  const profile = profileFromEnvironment() || profileFromPinFile(cwd) || null;
+  const session = process.env.CLAUDE_CODE_SESSION_ID || null;
+  return {
+    profile,
+    // Enough to tell two concurrent sessions apart without being a wall of hex.
+    session: session ? session.slice(0, 8) : null,
+  };
+}

--- a/package/ego-linux/src/chrome.mjs
+++ b/package/ego-linux/src/chrome.mjs
@@ -1,0 +1,511 @@
+import { spawn } from "node:child_process";
+import { access, mkdir, readdir, readFile, readlink, writeFile, rm } from "node:fs/promises";
+import { constants } from "node:fs";
+import { join } from "node:path";
+
+import { BROWSER_STATE_FILE, PROFILE_DIR, STATE_DIR } from "./paths.mjs";
+
+const BINARY_CANDIDATES = [
+  process.env.EGO_LINUX_CHROME,
+  "google-chrome",
+  "google-chrome-stable",
+  "chromium",
+  "chromium-browser",
+  "brave-browser",
+  "microsoft-edge",
+].filter(Boolean);
+
+// Chrome writes the negotiated port here once the DevTools endpoint is live.
+const PORT_FILE = "DevToolsActivePort";
+
+// Shared by the launch args and the orphan reaper that reads them back out of
+// /proc — if the two spellings drifted, the reaper would match nothing.
+const PROFILE_FLAG = "--user-data-dir=";
+
+/** Window class shared with the desktop entry's StartupWMClass. */
+export const WM_CLASS = "ego-lite-linux";
+
+/** Shown in Chrome's profile chip so the agent window is identifiable. */
+const PROFILE_LABEL = "ego lite — agent";
+
+const LAUNCH_FLAGS = [
+  "--no-first-run",
+  "--no-default-browser-check",
+  "--disable-background-timer-throttling",
+  "--disable-backgrounding-occluded-windows",
+  "--disable-renderer-backgrounding",
+  // Node's WebSocket sends no Origin; without this Chrome rejects the upgrade.
+  "--remote-allow-origins=*",
+  // Big enough that a page laid out for a desktop viewport fits. The default
+  // headless window is ~800x600, which pushes lower page content out of view;
+  // input dispatched at those coordinates hit-tests to nothing and
+  // Input.dispatchMouseEvent can hang waiting for a frame that never comes.
+  "--window-size=1280,900",
+  // Without this the desktop's HiDPI scaling (1.5x here) shrinks the CSS
+  // viewport — a 1280px window lays out as 853px — so page content the agent
+  // expects on screen falls below the fold.
+  "--force-device-scale-factor=1",
+  // "Chrome didn't shut down correctly — Restore pages?". Two things keep it
+  // away, covering different halves: the graceful Browser.close in stopBrowser()
+  // stops the profile *earning* the mark, and clearStaleCrashMark() clears a
+  // mark it already carries, which a clean exit alone never does. This flag is
+  // the backstop for what neither covers — a browser killed by something outside
+  // this launcher, between one launch's clear and the next.
+  "--hide-crash-restore-bubble",
+  // Give the agent browser its own window class. Without it the window carries
+  // Chrome's, so the desktop groups it under the ordinary Chrome icon: it never
+  // appears as its own running app and the launcher icon cannot raise it.
+  // Paired with StartupWMClass in the desktop entry.
+  `--class=${WM_CLASS}`,
+];
+
+/**
+ * Is this directory *provably* absent?
+ *
+ * exists() answers "could I stat it", collapsing every failure into false —
+ * fine for picking a browser binary, dangerous for deciding whether to kill a
+ * process. A transient ESTALE on NFS, an EIO, or a FUSE timeout would read as
+ * "profile deleted" and take a live browser down with it. Only ENOENT is
+ * evidence of absence; every other error means "assume it is there".
+ */
+async function definitelyGone(path) {
+  try {
+    await access(path, constants.F_OK);
+    return false;
+  } catch (error) {
+    return error?.code === "ENOENT";
+  }
+}
+
+async function exists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveBinary() {
+  for (const candidate of BINARY_CANDIDATES) {
+    if (candidate.includes("/")) {
+      if (await exists(candidate)) return candidate;
+      continue;
+    }
+    const found = await which(candidate);
+    if (found) return found;
+  }
+  throw new Error(
+    `no Chrome/Chromium binary found (tried: ${BINARY_CANDIDATES.join(", ")}). ` +
+      `Set EGO_LINUX_CHROME to an absolute path.`,
+  );
+}
+
+function which(name) {
+  return new Promise((resolve) => {
+    const child = spawn("which", [name], { stdio: ["ignore", "pipe", "ignore"] });
+    let out = "";
+    child.stdout.on("data", (chunk) => {
+      out += chunk;
+    });
+    child.on("error", () => resolve(null));
+    child.on("close", (code) => resolve(code === 0 ? out.trim() : null));
+  });
+}
+
+/** Ask a running DevTools endpoint for its browser-level WebSocket URL. */
+async function probe(port) {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/json/version`, {
+      signal: AbortSignal.timeout(1500),
+    });
+    if (!response.ok) return null;
+    const info = await response.json();
+    return info.webSocketDebuggerUrl || null;
+  } catch {
+    return null;
+  }
+}
+
+async function readBrowserState() {
+  try {
+    return JSON.parse(await readFile(BROWSER_STATE_FILE, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function writeBrowserState(state) {
+  await mkdir(STATE_DIR, { recursive: true });
+  await writeFile(BROWSER_STATE_FILE, JSON.stringify(state, null, 2));
+}
+
+/**
+ * Poll for a DevTools endpoint that answers.
+ *
+ * The port file appears a beat after the process starts, and Chrome does not
+ * necessarily write it once: a launch that loses the ProcessSingleton race is
+ * restarted internally, and the process that survives publishes a different
+ * port. Probing whatever the file said first therefore names a port that never
+ * listens — so re-read it on every attempt and keep probing until one answers.
+ */
+export async function waitForEndpoint(profileDir, { timeoutMs = 20000 } = {}) {
+  const path = join(profileDir, PORT_FILE);
+  const deadline = Date.now() + timeoutMs;
+  let lastPort = null;
+  while (Date.now() < deadline) {
+    let port = null;
+    try {
+      const [line] = (await readFile(path, "utf8")).split("\n");
+      port = Number(line.trim()) || null;
+    } catch {
+      // not written yet
+    }
+    if (port) {
+      lastPort = port;
+      const wsUrl = await probe(port);
+      if (wsUrl) return { port, wsUrl };
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(
+    lastPort
+      ? `Chrome came up on port ${lastPort} but exposed no WebSocket URL within ${timeoutMs}ms`
+      : `Chrome did not expose a DevTools port within ${timeoutMs}ms`,
+  );
+}
+
+/**
+ * Reset page zoom in the agent profile.
+ *
+ * --import-chrome-profile copies real Chrome preferences, which include the
+ * user's zoom level. A 150% zoom lays a 1280px window out as 853 CSS px, so
+ * content the page expects on screen falls below the fold — element coordinates
+ * then hit-test to nothing and pointer input silently does nothing. This profile
+ * exists only to drive agents, so zoom is pinned to 100%.
+ */
+async function neutralizeZoom(profileDir) {
+  const path = join(profileDir, "Default", "Preferences");
+  try {
+    const prefs = JSON.parse(await readFile(path, "utf8"));
+    let changed = false;
+    for (const scope of ["partition", "profile"]) {
+      for (const key of ["default_zoom_level", "per_host_zoom_levels"]) {
+        if (prefs[scope]?.[key] && Object.keys(prefs[scope][key]).length > 0) {
+          prefs[scope][key] = {};
+          changed = true;
+        }
+      }
+    }
+    // --import-chrome-profile clones the user's real profile, so the agent
+    // browser ends up looking exactly like their everyday Chrome — same
+    // bookmarks, same theme, no way to tell which window an agent is driving.
+    // Naming the profile puts a label in Chrome's own toolbar chip.
+    if (prefs.profile?.name !== PROFILE_LABEL) {
+      prefs.profile = { ...prefs.profile, name: PROFILE_LABEL };
+      changed = true;
+    }
+    if (changed) await writeFile(path, JSON.stringify(prefs));
+    return changed;
+  } catch {
+    // A fresh profile has no Preferences file yet; nothing to reset.
+    return false;
+  }
+}
+
+/**
+ * Clear a stale crash mark before launching.
+ *
+ * Chrome stamps `profile.exit_type` "Crashed" while it runs and rewrites it to
+ * "Normal" on a graceful exit — but only if it did not *start* out marked. Once
+ * a profile carries the mark, Chrome keeps it until someone answers the
+ * "Restore pages?" prompt, and in an agent browser nobody ever does. So a single
+ * ungraceful kill marks a profile permanently: every later launch opens with the
+ * prompt, and even a clean Browser.close leaves the mark exactly where it was.
+ *
+ * Established by bisecting a marked profile's Preferences against a fresh one,
+ * top-level keys first and then within `profile`, down to this single key: seed
+ * "Crashed" and the next clean stop still reads "Crashed"; seed anything else
+ * and it reads "Normal".
+ *
+ * The mark exists to protect a human's tabs. This profile has none worth
+ * restoring — the agent opens what it needs — so clearing it costs nothing.
+ */
+export async function clearStaleCrashMark(profileDir) {
+  const path = join(profileDir, "Default", "Preferences");
+  try {
+    const prefs = JSON.parse(await readFile(path, "utf8"));
+    if (!prefs.profile || prefs.profile.exit_type === "Normal") return false;
+    prefs.profile = { ...prefs.profile, exit_type: "Normal" };
+    await writeFile(path, JSON.stringify(prefs));
+    return true;
+  } catch {
+    // A fresh profile has no Preferences file yet; nothing to clear.
+    return false;
+  }
+}
+
+/** Whether a pid is a browser running against our own profile directory. */
+async function ownsOurProfile(pid, profileDir) {
+  try {
+    const cmdline = await readFile(`/proc/${pid}/cmdline`, "utf8");
+    return cmdline.includes(profileDir);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Terminate ego browsers whose profile directory no longer exists.
+ *
+ * A harness that points EGO_LINUX_PROFILE (or XDG_DATA_HOME) at a scratch tree
+ * gets a browser of its own, and browsers are spawned detached so they outlive
+ * whatever started them. A harness that deletes its scratch tree without
+ * stopping its browser first leaves that browser running against a profile
+ * nobody can reach: ensureBrowser() tracks one browser per state file, so the
+ * orphan is invisible to it and simply accumulates — hundreds of MB per stale
+ * run, for as long as the machine stays up.
+ *
+ * A missing profile directory is the unambiguous signal. Chrome cannot function
+ * without it, so such a browser is already dead weight rather than someone's
+ * live session. Our own profile is created before this runs, which keeps the
+ * browser we are about to launch — and any other live one — out of scope.
+ *
+ * @returns {Promise<number>} How many orphans were signalled.
+ */
+export async function reapOrphanedBrowsers() {
+  let entries;
+  try {
+    entries = await readdir("/proc");
+  } catch {
+    return 0; // no procfs to walk; nothing to reap
+  }
+
+  let reaped = 0;
+  await Promise.all(
+    entries
+      .filter((entry) => /^\d+$/.test(entry))
+      .map(async (pid) => {
+        let argv;
+        try {
+          argv = (await readFile(`/proc/${pid}/cmdline`, "utf8")).split("\0");
+        } catch {
+          return; // exited under us, or another user's process
+        }
+        // Renderers and helpers inherit --user-data-dir but carry --type=;
+        // signalling the browser process takes its children with it anyway.
+        if (!argv.includes(`--class=${WM_CLASS}`)) return;
+        if (argv.some((arg) => arg.startsWith("--type="))) return;
+
+        const flag = argv.find((arg) => arg.startsWith(PROFILE_FLAG));
+        if (!flag) return;
+        const profileDir = flag.slice(PROFILE_FLAG.length);
+        if (profileDir === PROFILE_DIR) return;
+        if (!(await definitelyGone(profileDir))) return;
+
+        try {
+          process.kill(Number(pid), "SIGTERM");
+          reaped += 1;
+        } catch {
+          // already gone, or not ours to signal
+        }
+      }),
+  );
+  return reaped;
+}
+
+/**
+ * Clear the profile lock before launching.
+ *
+ * Chrome's SingletonLock is a symlink named `<host>-<pid>`; a browser that dies
+ * without a clean shutdown leaves it behind, and the next launch refuses to
+ * start ("Failed to create a ProcessSingleton ... Aborting now").
+ *
+ * launch() only runs after ensureBrowser() has confirmed no DevTools endpoint
+ * answers, so a lock owner that is still alive is an unreachable orphan of ours
+ * — a browser we can no longer drive. Since this profile is single-purpose,
+ * that orphan is terminated rather than left to block every future run.
+ */
+async function clearProfileLock(profileDir) {
+  const lock = join(profileDir, "SingletonLock");
+  let target;
+  try {
+    target = await readlink(lock);
+  } catch {
+    return false; // no lock at all
+  }
+
+  const pid = Number(target.slice(target.lastIndexOf("-") + 1));
+  if (Number.isFinite(pid) && pid > 0 && (await ownsOurProfile(pid, profileDir))) {
+    try {
+      process.kill(pid, "SIGTERM");
+      // Give it a moment to release the lock on its own.
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    } catch {
+      // already gone
+    }
+  }
+
+  await Promise.all(
+    ["SingletonLock", "SingletonSocket", "SingletonCookie"].map((name) =>
+      rm(join(profileDir, name), { force: true }),
+    ),
+  );
+  return true;
+}
+
+async function launch({ headless }) {
+  const binary = await resolveBinary();
+  await mkdir(PROFILE_DIR, { recursive: true });
+  // Ours now exists, so it cannot be mistaken for an orphan below.
+  await reapOrphanedBrowsers();
+  await neutralizeZoom(PROFILE_DIR);
+  await clearStaleCrashMark(PROFILE_DIR);
+  await clearProfileLock(PROFILE_DIR);
+  // A stale port file would be read as this launch's port.
+  await rm(join(PROFILE_DIR, PORT_FILE), { force: true });
+
+  const args = [
+    ...LAUNCH_FLAGS,
+    `${PROFILE_FLAG}${PROFILE_DIR}`,
+    "--remote-debugging-port=0",
+    ...(headless ? ["--headless=new"] : []),
+    // The harness attaches its CDP session to the active tab and fails with
+    // "no active tab to attach session" when there is none, so the browser has
+    // to come up holding one. --no-startup-window was tried here and breaks
+    // every page operation for that reason.
+    "about:blank",
+  ];
+  const child = spawn(binary, args, {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+
+  const { port, wsUrl } = await waitForEndpoint(PROFILE_DIR);
+  await writeBrowserState({
+    port,
+    wsUrl,
+    pid: child.pid,
+    binary,
+    headless,
+    profileDir: PROFILE_DIR,
+  });
+  return { port, wsUrl, launched: true };
+}
+
+/**
+ * Return a live browser-level CDP endpoint, reusing the browser this machine
+ * already has open when possible. Each heredoc runs in its own short-lived Node
+ * process, so the browser — not this process — is what has to persist.
+ */
+export async function ensureBrowser({ headless = false } = {}) {
+  if (process.env.EGO_LINUX_CDP_URL) {
+    return { wsUrl: process.env.EGO_LINUX_CDP_URL, launched: false };
+  }
+
+  const state = await readBrowserState();
+  if (state?.port) {
+    const wsUrl = await probe(state.port);
+    if (wsUrl) return { port: state.port, wsUrl, launched: false };
+  }
+  return launch({ headless });
+}
+
+/**
+ * Ask the browser to close itself, over CDP.
+ *
+ * SIGTERM is recorded by Chrome as a crash: the profile keeps `exit_type:
+ * "Crashed"`, and every later launch greets the user with "Chrome didn't shut
+ * down correctly — Restore pages?". Browser.close is the graceful path, so the
+ * profile records a clean exit and there is nothing left to restore.
+ */
+async function closeBrowserGracefully(port, timeoutMs = 5000) {
+  const wsUrl = await probe(port);
+  if (!wsUrl) return false;
+
+  return new Promise((resolve) => {
+    let socket = null;
+    let sent = false;
+    let settled = false;
+    const finish = (ok) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        socket?.close();
+      } catch {
+        // already closing
+      }
+      resolve(ok);
+    };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+
+    try {
+      socket = new WebSocket(wsUrl);
+    } catch {
+      finish(false);
+      return;
+    }
+    socket.onopen = () => {
+      sent = true;
+      socket.send(JSON.stringify({ id: 1, method: "Browser.close" }));
+    };
+    // Chrome answers and then drops the socket as it goes away; whichever lands
+    // first means the request was taken. A close *before* the request went out
+    // is a failed connection, not a shutdown.
+    socket.onmessage = () => finish(true);
+    socket.onclose = () => finish(sent);
+    socket.onerror = () => finish(false);
+  });
+}
+
+/** Wait for a pid to disappear — a browser still exiting still holds the profile lock. */
+async function waitForProcessExit(pid, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return false;
+}
+
+/** Terminate the backing browser and forget it. */
+export async function stopBrowser() {
+  const state = await readBrowserState();
+  let stopped = false;
+
+  if (state?.port) stopped = await closeBrowserGracefully(state.port);
+  // Answering the request is not the same as acting on it. A browser that
+  // stayed up has to be signalled anyway — otherwise --stop removes the state
+  // file that is the only handle on it and leaves it running, unreachable.
+  if (stopped && state?.pid && !(await waitForProcessExit(state.pid))) stopped = false;
+
+  // The blunt instrument, only when the browser did not take the polite request.
+  if (!stopped && state?.pid) {
+    try {
+      process.kill(state.pid, "SIGTERM");
+      stopped = true;
+    } catch {
+      // already gone
+    }
+  }
+
+  await rm(BROWSER_STATE_FILE, { force: true });
+  // A SIGTERMed Chrome does not always release its profile lock, which would
+  // block the next launch. After a graceful close there is nothing left to
+  // clear, and this is a no-op.
+  await clearProfileLock(PROFILE_DIR);
+  return stopped;
+}
+
+export async function browserStatus() {
+  const state = await readBrowserState();
+  if (!state?.port) return { running: false };
+  const wsUrl = await probe(state.port);
+  return wsUrl ? { running: true, ...state, wsUrl } : { running: false, ...state };
+}

--- a/package/ego-linux/src/chrome.mjs
+++ b/package/ego-linux/src/chrome.mjs
@@ -401,7 +401,26 @@ async function launch({ headless }) {
  */
 export async function ensureBrowser({ headless = false } = {}) {
   if (process.env.EGO_LINUX_CDP_URL) {
-    return { wsUrl: process.env.EGO_LINUX_CDP_URL, launched: false };
+    const wsUrl = process.env.EGO_LINUX_CDP_URL;
+    // The DevTools HTTP endpoint lives at the same host:port as the websocket,
+    // and tabs.list's MRU ordering (the closest thing to a "which tab is
+    // focused" answer) is what we get from there. The URL tells us the port;
+    // a best-effort probe is enough to surface a dead endpoint instead of
+    // handing the caller one whose every call will hang.
+    let port = null;
+    try {
+      const url = new URL(wsUrl);
+      if (url.protocol === "ws:" || url.protocol === "wss:") {
+        port = Number(url.port) || (url.protocol === "wss:" ? 443 : 80);
+      }
+    } catch {
+      // not a URL we can parse — leave port null and let the caller fall back
+    }
+    if (port) {
+      const probed = await probe(port);
+      if (!probed) throw new Error(`EGO_LINUX_CDP_URL set but port ${port} does not answer`);
+    }
+    return { wsUrl, port, launched: false };
   }
 
   const state = await readBrowserState();

--- a/package/ego-linux/src/cursor.mjs
+++ b/package/ego-linux/src/cursor.mjs
@@ -1,0 +1,1292 @@
+import { createSessionResolver } from "./session.mjs";
+
+/**
+ * The agent's cursor — the visible "something else is driving this page" mark.
+ *
+ * The native macOS app draws this itself, over the web view; on Linux the page
+ * is the only surface the shim controls, so the cursor is a DOM overlay
+ * injected into whichever page the harness is currently acting on. It follows
+ * every pointer position the harness sends, presses and springs back when a
+ * button goes down and up, ripples where it clicks, sweeps the lines it reads,
+ * and carries the agent's current task state as a label.
+ *
+ * Two properties keep it from interfering with the automation it illustrates:
+ *
+ *   - the host element is `pointer-events: none`, so `document.elementFromPoint`
+ *     never returns it. That matters beyond cosmetics: the harness's wheel and
+ *     drag fallbacks hit-test with elementFromPoint, and an overlay that
+ *     answered those probes would swallow input meant for the page.
+ *   - every render is fire-and-forget and swallows its own errors, so a page
+ *     that refuses the injection, or navigates mid-flight, can never fail an
+ *     action. The cursor is allowed to be missing; it is not allowed to break
+ *     anything.
+ *
+ * The overlay is a Runtime.evaluate injection rather than a content script, so
+ * it works on pages with a strict CSP and needs no extension.
+ *
+ * Env: EGO_LINUX_CURSOR=0 turns it off (it is drawn into screenshots, which is
+ * usually wanted and occasionally not); EGO_LINUX_CURSOR_NAME renames it from
+ * the default "Claude".
+ */
+
+const HOST_ID = "ego-agent-cursor-overlay";
+const ACCENT = "#d97757";
+// Reading is where an agent spends most of its time, and the state a watcher is
+// likeliest to mistake for an idle window. Giving it its own colour means one
+// glance separates looking at the page from changing it — terracotta acts, blue
+// observes. Every mark the overlay draws while reading switches to this, and
+// switches back the moment real input lands.
+const READ_ACCENT = "#4a9eff";
+
+/** How long the pressed look is held, however briefly the button was down. */
+const MIN_PRESS_MS = 130;
+
+/** Keystrokes stop arriving well before the agent is done thinking; hold on. */
+const TYPING_IDLE_MS = 700;
+
+export function createCursorApi(cdp, { listTabs }) {
+  const enabled = process.env.EGO_LINUX_CURSOR !== "0";
+  const name = process.env.EGO_LINUX_CURSOR_NAME || "Claude";
+  const sessionForActiveTab = createSessionResolver(cdp, {
+    listTabs,
+    op: "cursor",
+  });
+
+  const state = {
+    x: 0,
+    y: 0,
+    label: "",
+    visible: true,
+    placed: false,
+    pressed: false,
+    typing: false,
+    note: "",
+    highlight: null,
+    read: null,
+  };
+  // Where the cursor rests on a page it has only read, never touched.
+  const RESTING_X = 28;
+  const RESTING_Y = 28;
+  let previousLabel = "";
+  let dirty = false;
+  let pendingPulse = false;
+  let inFlight = false;
+  let pressedAt = 0;
+  let releaseTimer = null;
+  let typingTimer = null;
+  let labelX = null;
+  let labelY = null;
+  let highlightId = 0;
+  let readId = 0;
+
+  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  /**
+   * Put the overlay back after the page it lived in was replaced.
+   *
+   * The cursor is a DOM node injected into the current document, so a
+   * navigation destroys it — and nothing re-injects. Only a render does that,
+   * and renders are driven by snapshots, pointer events and keystrokes, none of
+   * which a goto() performs. So an agent that navigated and then worked through
+   * page.evaluate or a site tool — neither of which snapshots — drove the page
+   * with no cursor on screen at all, which reads as an idle window.
+   *
+   * The old coordinates described elements in a document that no longer exists,
+   * so re-drawing at them would point confidently at nothing. The cursor goes
+   * back to its resting corner instead and lets the badge carry what the agent
+   * is doing; the label is already marked stale by the move, so it presents
+   * itself as history rather than as the current action.
+   */
+  function pageReplaced() {
+    if (!enabled) return;
+    endRead();
+    state.x = RESTING_X;
+    state.y = RESTING_Y;
+    state.placed = true;
+    schedule();
+  }
+
+  // Events only reach the shim for sessions it has claimed, and only for domains
+  // enabled on them — see claimSession/onShimEvent in transport.mjs. Registered
+  // once here; flush() does the per-session claim as targets come and go.
+  cdp.onShimEvent?.("Page.loadEventFired", () => pageReplaced());
+
+  /** Sessions already claimed and told to report loads. */
+  const watchedSessions = new Set();
+
+  async function watchLoads(sessionId) {
+    if (!sessionId || watchedSessions.has(sessionId)) return;
+    watchedSessions.add(sessionId);
+    cdp.claimSession?.(sessionId);
+    // Without Page.enable the load event never fires on this session. Failure is
+    // cosmetic, exactly like every other render step here.
+    await cdp.call("Page.enable", {}, sessionId).catch(() => {});
+  }
+
+  /**
+   * A read sweep narrates the snapshot that started it, so any real input makes
+   * it stale. Dropping the read from the payload is how the page is told to stop
+   * — the sweep owns the cursor only while the id it began with keeps arriving.
+   */
+  function endRead() {
+    state.read = null;
+  }
+
+  function placeAt(x, y) {
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+    state.x = x;
+    state.y = y;
+    state.placed = true;
+  }
+
+  /**
+   * Coalesce renders: a drag dispatches mouse moves far faster than a CDP round
+   * trip completes, so only the latest position is ever sent, and a pulse that
+   * lands mid-flight is carried over to the next render rather than dropped.
+   */
+  function schedule() {
+    dirty = true;
+    if (inFlight) return;
+    void flush();
+  }
+
+  async function flush() {
+    if (!dirty || inFlight) return;
+    inFlight = true;
+    try {
+      while (dirty) {
+        dirty = false;
+        const payload = {
+          x: state.x,
+          y: state.y,
+          // The label always goes out, so the badge never empties mid-session —
+          // a blank badge tells a watcher less than a slightly old one. Whether
+          // it still describes where the cursor now is travels alongside it, and
+          // the overlay dims a stale label rather than passing it off as current.
+          label: state.label,
+          labelStale: !(state.x === labelX && state.y === labelY),
+          name,
+          accent: ACCENT,
+          readAccent: READ_ACCENT,
+          hostId: HOST_ID,
+          // Typing counts as something to show even before the cursor has been
+          // placed, because fill() never places it.
+          visible: state.visible && (state.placed || state.typing),
+          placed: state.placed,
+          pressed: state.pressed,
+          typing: state.typing,
+          note: state.note,
+          highlight: state.highlight,
+          read: state.read,
+          pulse: pendingPulse,
+        };
+        pendingPulse = false;
+        const sessionId = await sessionForActiveTab();
+        await watchLoads(sessionId);
+        await cdp.call(
+          "Runtime.evaluate",
+          {
+            expression: `(${renderOverlay.toString()})(${JSON.stringify(payload)})`,
+            returnByValue: false,
+            awaitPromise: false,
+            userGesture: false,
+          },
+          sessionId,
+        );
+      }
+    } catch {
+      // Cosmetic only: a closed tab, a page mid-navigation or a target that
+      // rejected the evaluate must never surface as an automation failure.
+    } finally {
+      inFlight = false;
+      if (dirty) void flush();
+    }
+  }
+
+  return {
+    /**
+     * Arm the load watcher ahead of a navigation the overlay has to survive.
+     *
+     * flush() claims the session as a side effect of rendering, so a process
+     * whose very first act is a goto has claimed nothing yet and misses its own
+     * first load — leaving the window blank for exactly the shape of task that
+     * navigates and then works through page.evaluate or a site tool. Called on
+     * Page.navigate, which the harness sends before the document is replaced.
+     */
+    async watchPage() {
+      if (!enabled) return { done: false, reason: "cursor disabled" };
+      try {
+        await watchLoads(await sessionForActiveTab());
+      } catch {
+        // No tab yet, or a target that refused the attach: cosmetic, like every
+        // other step here.
+      }
+      return { done: true };
+    },
+
+    /** Back ego.animationHighlightMouseToPosition(x, y). */
+    moveTo(x, y) {
+      if (!enabled) return { done: false, reason: "cursor disabled" };
+      if (!Number.isFinite(x) || !Number.isFinite(y)) return { done: false };
+      // A redundant move is normally worth nothing, but a read sweep has walked
+      // the cursor away from where the harness last put it — so moving back to
+      // that same point is a real move, and the one that ends the sweep.
+      if (state.placed && state.x === x && state.y === y && !state.read) {
+        return { done: true };
+      }
+      endRead();
+      state.x = x;
+      state.y = y;
+      state.placed = true;
+      // The label is no longer blanked here: it stays up, marked stale, until a
+      // real action replaces it. Emptying it on every move is what made the
+      // badge flicker on a page the agent was only walking across.
+      schedule();
+      return { done: true };
+    },
+
+    /**
+     * The agent is reading the page rather than touching it.
+     *
+     * Reading is most of what an agent does — open a page, snapshot it, decide —
+     * and none of it dispatches a pointer event, so until now the overlay simply
+     * never appeared: watching a session work looked like nothing was happening.
+     * Placing the cursor on the first read gives the badge (which already
+     * breathes) something to attach to, so reading reads as activity.
+     *
+     * The resting spot is only used when no click has placed the cursor yet; a
+     * cursor that has been somewhere stays there, because jumping it to a corner
+     * on every snapshot would lose where the agent actually was.
+     *
+     * The badge alone said the agent was reading but never *what*, which is the
+     * one thing a person watching wants to know — so each read also carries an
+     * id, and the page runs a sweep for it: the cursor travels the lines that
+     * are actually on screen, marking each as it passes. The sweep is driven
+     * from inside the page, because a round trip per line would cost more than
+     * the snapshot it illustrates.
+     */
+    reading(label = "reading") {
+      if (!enabled) return { done: false, reason: "cursor disabled" };
+      if (!state.placed) {
+        state.x = RESTING_X;
+        state.y = RESTING_Y;
+        state.placed = true;
+      }
+      previousLabel = state.label;
+      if (state.label !== label) state.label = label;
+      readId += 1;
+      state.read = { id: readId };
+      schedule();
+      return { done: true };
+    },
+
+    /**
+     * The label persists until a different activity replaces it.
+     *
+     * A snapshot completes in milliseconds, so clearing the label when the read
+     * returned made "reading" flash for less than a frame — the badge just read
+     * "Claude". Leaving it up means the window always says what the agent last
+     * did, which is what makes an idle-looking window legible. moveTo and
+     * pulseAt take it down again when real input arrives.
+     */
+    clearReadingLabel() {
+      if (state.label !== "reading") return;
+      state.label = previousLabel === "reading" ? "" : previousLabel || "";
+      schedule();
+    },
+
+    /** Back ego.setAgentTaskState(label) — the text shown next to the cursor. */
+
+    /**
+     * Back ego.setAgentTaskState(label).
+     *
+     * The harness sets this from an action's own `label` option, immediately
+     * after moving the cursor there — so it describes *that* action, at *that*
+     * point. It is therefore remembered against the point it was set for, and
+     * stops applying once the cursor moves on. Without that it would be set
+     * once and then narrate every later action wrongly, forever.
+     */
+    setTaskState(taskState) {
+      if (!enabled) return { done: false, reason: "cursor disabled" };
+      const label = labelOf(taskState);
+      if (label === state.label && labelX === state.x && labelY === state.y) {
+        return { done: true };
+      }
+      state.label = label;
+      labelX = state.x;
+      labelY = state.y;
+      schedule();
+      return { done: true };
+    },
+
+    /** A button went down here: hold the cursor pressed, and ripple. */
+    press(x, y) {
+      if (!enabled) return;
+      endRead();
+      placeAt(x, y);
+      clearTimeout(releaseTimer);
+      state.pressed = true;
+      pressedAt = Date.now();
+      pendingPulse = true;
+      schedule();
+    },
+
+    /**
+     * The button came back up. A click's press and release are 25ms apart, which
+     * is too short to read as anything, so the pressed look is held for a floor
+     * of MIN_PRESS_MS. A drag releases long after that floor and springs back at
+     * once.
+     */
+    release(x, y) {
+      if (!enabled) return;
+      endRead();
+      placeAt(x, y);
+      if (!state.pressed) {
+        schedule();
+        return;
+      }
+      const remaining = MIN_PRESS_MS - (Date.now() - pressedAt);
+      if (remaining <= 0) {
+        state.pressed = false;
+        schedule();
+        return;
+      }
+      schedule(); // the new position now; the spring back on its own schedule
+      clearTimeout(releaseTimer);
+      releaseTimer = setTimeout(() => {
+        state.pressed = false;
+        schedule();
+      }, remaining);
+      // A heredoc is a short-lived process; never hold it open for a flourish.
+      releaseTimer.unref?.();
+    },
+
+    /**
+     * A key went to the page. Typing has no coordinates, so this is a state
+     * with a tail rather than an event: it stays on until the keystrokes stop.
+     * Called per key event, but the render coalescer collapses a burst into a
+     * couple of draws, and re-drawing is what lets the ring follow focus from
+     * one field to the next.
+     */
+    typed() {
+      if (!enabled) return;
+      endRead();
+      clearTimeout(typingTimer);
+      typingTimer = setTimeout(() => {
+        state.typing = false;
+        schedule();
+      }, TYPING_IDLE_MS);
+      typingTimer.unref?.();
+      state.typing = true;
+      schedule();
+    },
+
+    /**
+     * Draw a marker over some text, the way you would to explain it.
+     *
+     * `target` is a CSS selector, or the text itself — a string is tried as a
+     * selector first and searched for as text if that finds nothing, so both
+     * `highlight("#total")` and `highlight("free shipping")` do the obvious
+     * thing. `{selector}` or `{text}` forces one.
+     *
+     * The bands are an overlay, never a real selection: selecting text for the
+     * look of it would fight the agent's own work on the page.
+     *
+     * @param {string|{selector?: string, text?: string}} target
+     * @param {{note?: string}} [options] Text to show next to the cursor while drawing.
+     * @returns {Promise<{done: boolean, lines: number}>}
+     */
+    async highlight(target, options = {}) {
+      if (!enabled) return { done: false, lines: 0, reason: "cursor disabled" };
+      const request =
+        typeof target === "string"
+          ? { selector: target, text: target }
+          : { selector: target?.selector || "", text: target?.text || "" };
+
+      let found;
+      try {
+        const sessionId = await sessionForActiveTab();
+        const { result } = await cdp.call(
+          "Runtime.evaluate",
+          {
+            expression: `(${resolveHighlight.toString()})(${JSON.stringify(request)})`,
+            returnByValue: true,
+            awaitPromise: false,
+          },
+          sessionId,
+        );
+        found = result?.value;
+      } catch {
+        return { done: false, lines: 0 };
+      }
+      if (!found || !found.rects?.length) return { done: false, lines: 0 };
+
+      // An explicit marker replaces the automatic sweep: both drive the cursor,
+      // and the agent's own explanation is the one worth watching.
+      endRead();
+      state.note = String(options.note ?? "").slice(0, 120);
+      highlightId += 1;
+      state.highlight = { id: highlightId, rects: found.rects, upTo: -1 };
+
+      // Walk the cursor along each line as its band draws, so the marker looks
+      // drawn rather than pasted. The caller awaits this: it is an explanation,
+      // and an explanation you cannot see happen is just a screenshot.
+      for (let index = 0; index < found.rects.length; index += 1) {
+        const rect = found.rects[index];
+        const baseline = rect.y + rect.height - found.scrollY;
+        state.x = rect.x - found.scrollX;
+        state.y = baseline;
+        state.placed = true;
+        state.highlight.upTo = index;
+        schedule();
+        await wait(Math.round(rect.ms * 0.2));
+        state.x = rect.x + rect.width - found.scrollX;
+        state.y = baseline;
+        schedule();
+        await wait(rect.ms);
+      }
+      return { done: true, lines: found.rects.length };
+    },
+
+    /** Wipe the marker off again. */
+    clearHighlight() {
+      if (!enabled) return { done: false, reason: "cursor disabled" };
+      state.highlight = null;
+      state.note = "";
+      schedule();
+      return { done: true };
+    },
+
+    /** Hidden while the space belongs to the user (handOffTaskSpace). */
+    hide() {
+      if (!enabled) return;
+      if (!state.visible) return;
+      state.visible = false;
+      schedule();
+    },
+
+    /** Shown again when the agent resumes (takeOverTaskSpace). */
+    show() {
+      if (!enabled) return;
+      if (state.visible) return;
+      state.visible = true;
+      schedule();
+    },
+  };
+}
+
+/**
+ * Find what to draw the marker over, and measure it line by line.
+ *
+ * Serialized into the page like the renderer. A Range is what gives one box per
+ * *line* rather than one for the whole paragraph — which is the difference
+ * between a pen stroke and a coloured rectangle.
+ */
+function resolveHighlight(request) {
+  let range = null;
+
+  if (request.selector) {
+    let element = null;
+    try {
+      element = document.querySelector(request.selector);
+    } catch {
+      element = null; // a text query is rarely also valid CSS
+    }
+    if (element) {
+      range = document.createRange();
+      range.selectNodeContents(element);
+    }
+  }
+
+  if (!range && request.text) {
+    const needle = request.text.trim().toLowerCase();
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    while (walker.nextNode()) {
+      const node = walker.currentNode;
+      const parent = node.parentElement;
+      if (!parent || !parent.getClientRects().length) continue;
+      const at = (node.nodeValue || "").toLowerCase().indexOf(needle);
+      if (at === -1) continue;
+      range = document.createRange();
+      range.setStart(node, at);
+      range.setEnd(node, at + needle.length);
+      break;
+    }
+  }
+
+  if (!range) return { rects: [], scrollX: window.scrollX, scrollY: window.scrollY };
+
+  // A marker nobody can see explains nothing, so bring it on screen first.
+  const first = range.getBoundingClientRect();
+  if (first.bottom < 0 || first.top > window.innerHeight) {
+    const anchor = range.startContainer.parentElement;
+    anchor?.scrollIntoView({ block: "center" });
+  }
+
+  const rects = [];
+  for (const rect of range.getClientRects()) {
+    if (rect.width < 2 || rect.height < 2) continue;
+    rects.push({
+      x: rect.left + window.scrollX,
+      y: rect.top + window.scrollY,
+      width: rect.width,
+      height: rect.height,
+      // Long lines take longer to draw, the way a real stroke would.
+      ms: Math.min(700, Math.max(160, Math.round(rect.width * 1.7))),
+    });
+  }
+  return { rects, scrollX: window.scrollX, scrollY: window.scrollY };
+}
+
+/**
+ * Read the overlay back out of a page: where the cursor is, what it is doing,
+ * and how long ago it last moved. The Spaces overview runs this in its own
+ * process — the page is the only state the two share, since each heredoc is a
+ * separate Node process with its own CDP connection.
+ *
+ * Returns null when no agent has acted in that page.
+ */
+export const CURSOR_PROBE_EXPRESSION = `(${probeOverlay.toString()})(${JSON.stringify(HOST_ID)})`;
+
+function probeOverlay(hostId) {
+  const host = document.getElementById(hostId);
+  const state = host && host.__egoState;
+  if (!state) return null;
+  return {
+    // Where the cursor is *now*: it is anchored to the page, so a scroll since
+    // the last action has moved it on screen. Reporting the stale viewport
+    // position would crop an active card to the wrong place.
+    x: state.pageX - window.scrollX,
+    y: state.pageY - window.scrollY,
+    label: state.label || "",
+    name: state.name || "",
+    ageMs: Date.now() - state.at,
+    // Newest last, ages rather than timestamps: the reader is in another
+    // process and has no business trusting this page's clock.
+    trail: (host.__egoLog || []).map((entry) => ({
+      text: entry.text,
+      ageMs: Date.now() - entry.at,
+    })),
+    // A screenshot clip is in page coordinates; hand back what converts it.
+    scrollX: window.scrollX,
+    scrollY: window.scrollY,
+    viewportWidth: window.innerWidth,
+    viewportHeight: window.innerHeight,
+  };
+}
+
+/**
+ * The harness passes a label string, but the native surface is documented only
+ * as "task state" — accept the object form rather than printing [object Object].
+ */
+function labelOf(taskState) {
+  if (taskState === null || taskState === undefined) return "";
+  if (typeof taskState === "string") return taskState.slice(0, 120);
+  if (typeof taskState === "object") {
+    const text = taskState.label ?? taskState.state ?? taskState.text;
+    return typeof text === "string" ? text.slice(0, 120) : "";
+  }
+  return String(taskState).slice(0, 120);
+}
+
+/**
+ * The overlay itself, serialized with Function.prototype.toString() and run
+ * inside the page on every update. It must stay self-contained: no imports, no
+ * closure over anything in this module, and idempotent — it is re-entered for
+ * every move, and re-creates itself after a navigation blew the old one away.
+ */
+function renderOverlay(payload) {
+  const parent = document.body || document.documentElement;
+  if (!parent) return;
+
+  let host = document.getElementById(payload.hostId);
+  if (!payload.visible) {
+    // Handing the space back is a departure, not a disappearance, so the cursor
+    // fades instead of blinking out. The state the Spaces overview polls goes
+    // immediately though: the agent has let go, whatever the pixels still say.
+    if (host && !host.__egoLeaving) {
+      host.__egoLeaving = true;
+      host.__egoState = null;
+      if (host.__egoSweep) host.__egoSweep.done = true;
+      host.style.opacity = "0";
+      setTimeout(() => host.remove(), 220);
+    }
+    return;
+  }
+
+  // A host on its way out is not one to reuse: its opacity is already bound for
+  // zero, and a taken-over space would inherit the fade meant for the handoff.
+  if (host && host.__egoLeaving) {
+    host.remove();
+    host = null;
+  }
+
+  if (!host) {
+    host = document.createElement("div");
+    host.id = payload.hostId;
+    host.setAttribute("aria-hidden", "true");
+    // Inline, so page rules cannot win against it, and `pointer-events: none`
+    // last so `all: initial` cannot reset it back to auto. Every child inherits
+    // that, which is what keeps elementFromPoint blind to the overlay.
+    host.style.cssText =
+      "all:initial;position:fixed;left:0;top:0;width:0;height:0;" +
+      "z-index:2147483647;pointer-events:none;" +
+      // Arrives and leaves under its own power. The agent taking a page over is
+      // an event worth seeing, and a cursor that pops into existence reads as a
+      // rendering glitch rather than as something showing up.
+      "opacity:0;transition:opacity 200ms ease;";
+    const shadow = host.attachShadow({ mode: "closed" });
+    shadow.innerHTML =
+      "<style>" +
+      // The cursor is anchored to the page, not the screen: it marks the thing
+      // the agent is working on, so it has to travel with that thing when the
+      // page scrolls. #layer carries the scroll offset with no transition of
+      // its own, leaving #pointer's transition free to animate agent movement —
+      // one element carrying both would make scrolling look rubbery.
+      "#layer{position:absolute;left:0;top:0}" +
+      // Marker bands, one per line of text, drawn in page coordinates so they
+      // stay on their words when the page scrolls. Each wipes in from its own
+      // left edge — a pen stroke, not a rectangle appearing.
+      "#bands{position:absolute;left:0;top:0}" +
+      ".band{position:absolute;left:0;top:0;width:0;border-radius:3px;" +
+      "background:linear-gradient(180deg,rgba(217,119,87,.34),rgba(217,119,87,.22));" +
+      "box-shadow:0 0 0 1px rgba(217,119,87,.22);" +
+      "transition:width 260ms cubic-bezier(.33,.9,.5,1)}" +
+      // A read band is the same stroke, lighter and temporary: reading is
+      // constant, so its marks fade behind the cursor instead of piling up the
+      // way a deliberate highlight does.
+      ".band.read{background:linear-gradient(180deg,rgba(74,158,255,.32),rgba(74,158,255,.16));" +
+      "box-shadow:none;transition-property:width,opacity;transition-timing-function:linear}" +
+      // While reading, every mark the overlay owns turns blue: the arrow, the
+      // ring, the badge's dot. The rules are scoped to #layer.reading so the
+      // whole scheme reverts in one class toggle when input arrives.
+      "#layer.reading #arrow path,#layer.reading #hand path{fill:" +
+      payload.readAccent +
+      "}" +
+      "#layer.reading #ring{border-color:" +
+      payload.readAccent +
+      ";box-shadow:0 0 0 4px rgba(74,158,255,.18)}" +
+      "#layer.reading #dot{background:" +
+      payload.readAccent +
+      "}" +
+      // A label that no longer describes where the cursor is stays legible but
+      // stops competing with one that does — and its dot stops breathing,
+      // because breathing is what marks the badge as live.
+      "#badge.stale{opacity:.5}" +
+      "#badge.stale #dot{animation:none;opacity:.35}" +
+      "#pointer{position:absolute;left:0;top:0;" +
+      "transition:transform 200ms cubic-bezier(.22,.61,.36,1);will-change:transform}" +
+      "#ring{position:absolute;left:0;top:0;border:2px solid " +
+      payload.accent +
+      ";border-radius:7px;box-shadow:0 0 0 4px rgba(217,119,87,.18);opacity:0;" +
+      "transition:opacity 160ms ease,transform 200ms cubic-bezier(.22,.61,.36,1)," +
+      "width 200ms ease,height 200ms ease}" +
+      "#ring.on{opacity:1}" +
+      "#arrow{position:absolute;left:-1px;top:-1px;display:block;" +
+      // Scaled about its own tip, so pressing squashes the arrow without
+      // moving the point it is aiming at. Down is fast and flat; the spring
+      // back overshoots, which is what makes it read as a button release.
+      "transform-origin:2px 2px;" +
+      "transition:transform 190ms cubic-bezier(.34,1.56,.64,1);" +
+      "filter:drop-shadow(0 2px 5px rgba(0,0,0,.35))}" +
+      "#pointer.press #arrow{transform:scale(.76);" +
+      "transition:transform 70ms cubic-bezier(.4,0,1,1)}" +
+      "#pulse{position:absolute;left:-19px;top:-19px;width:38px;height:38px;" +
+      "border-radius:50%;border:2px solid " +
+      payload.accent +
+      ";opacity:0}" +
+      "#pulse.on{animation:ego-pulse 500ms ease-out}" +
+      "@keyframes ego-pulse{from{transform:scale(.2);opacity:.9}" +
+      "to{transform:scale(1);opacity:0}}" +
+      // Positioned by transform alone, in the page coordinates #layer works in.
+      "#badge{position:absolute;left:0;top:0;display:flex;align-items:center;" +
+      "gap:7px;max-width:300px;padding:5px 11px 5px 9px;border-radius:999px;" +
+      "background:rgba(24,24,27,.72);color:#fff;box-sizing:border-box;" +
+      // Frosted rather than flat: the badge sits over arbitrary pages, and one
+      // that lets its background through belongs to the page it is labelling
+      // instead of hovering over it as a second opaque card.
+      "-webkit-backdrop-filter:blur(14px) saturate(1.5);" +
+      "backdrop-filter:blur(14px) saturate(1.5);" +
+      "border:1px solid rgba(255,255,255,.09);letter-spacing:.01em;" +
+      "font:500 12px/1.35 ui-sans-serif,system-ui,-apple-system,'Segoe UI',sans-serif;" +
+      "box-shadow:0 8px 24px rgba(0,0,0,.28),0 1px 2px rgba(0,0,0,.2);" +
+      "transition:transform 200ms ease}" +
+      // Docked, the badge is holding still against a moving page: every scroll
+      // event rewrites its offset, and a transition would chase each one.
+      "#badge.docked{transition:none}" +
+      // Which way the cursor went, when it is no longer on screen to point at.
+      "#hint{flex:none;opacity:.7;font-size:11px}" +
+      "#hint:empty{display:none}" +
+      "#text{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" +
+      "animation:ego-fade 220ms ease}" +
+      "@keyframes ego-fade{from{opacity:.3}to{opacity:1}}" +
+      "#dot{flex:none;width:7px;height:7px;border-radius:50%;background:" +
+      payload.accent +
+      ";animation:ego-breathe 1.7s ease-in-out infinite}" +
+      "@keyframes ego-breathe{0%,100%{opacity:1}50%{opacity:.35}}" +
+      // The reading glow. A sibling of #layer, not a child: #layer carries the
+      // scroll offset as a transform, and a transformed ancestor would make
+      // position:fixed resolve against it instead of the viewport — the glow
+      // would then scroll away from the edges it is meant to trace.
+      "#glow{position:fixed;left:0;top:0;right:0;bottom:0;opacity:0;" +
+      "transition:opacity 260ms ease;" +
+      "box-shadow:inset 0 0 0 2px rgba(74,158,255,.22)," +
+      "inset 0 0 52px rgba(74,158,255,.13)}" +
+      // Breathing at a slower beat than the badge dot, so the two read as one
+      // system rather than as two things blinking out of step.
+      "#glow.on{opacity:1;animation:ego-read-glow 2.4s ease-in-out infinite}" +
+      "@keyframes ego-read-glow{0%,100%{opacity:1}50%{opacity:.5}}" +
+      // The shape says what the cursor is over, the way a real one does: an
+      // arrow on the page, a hand on anything clickable, a beam over text.
+      "svg.shape{position:absolute;left:-1px;top:-1px;display:none}" +
+      "svg.shape.on{display:block}" +
+      "</style>" +
+      '<div id="layer">' +
+      '<div id="bands"></div>' +
+      '<div id="ring"></div>' +
+      '<div id="pointer">' +
+      '<div id="pulse"></div>' +
+      '<svg id="arrow" class="shape on" width="20" height="26" viewBox="-1.4 -1.4 17 24">' +
+      '<path d="M0 0 L0 18.6 L4.6 14.3 L7.7 21.1 L11.1 19.5 L8 12.9 L13.9 12.5 Z" ' +
+      'fill="' +
+      payload.accent +
+      '" stroke="#fff" stroke-width="1.5" stroke-linejoin="round"/></svg>' +
+      '<svg id="hand" class="shape" width="23" height="26" viewBox="-1.4 -1.4 20 24">' +
+      '<path d="M4.6 11.4 L4.6 2.4 A1.8 1.8 0 0 1 8.2 2.4 L8.2 9.4 L8.2 6.6 ' +
+      "A1.7 1.7 0 0 1 11.6 6.6 L11.6 9.4 L11.6 7.6 A1.7 1.7 0 0 1 15 7.6 L15 9.6 " +
+      "A1.7 1.7 0 0 1 18.4 9.9 L18.4 15.4 A5.6 5.6 0 0 1 12.8 21 L10.4 21 " +
+      'A5.4 5.4 0 0 1 5.6 18.1 L2.2 13.4 A1.7 1.7 0 0 1 4.6 11.4 Z" ' +
+      'fill="' +
+      payload.accent +
+      '" stroke="#fff" stroke-width="1.5" stroke-linejoin="round"/></svg>' +
+      '<svg id="beam" class="shape" width="14" height="26" viewBox="-1.4 -1.4 12 24">' +
+      '<path d="M1.6 1 H7.4 M4.5 1 V19.4 M1.6 19.4 H7.4" ' +
+      'stroke="#fff" stroke-width="4.4" stroke-linecap="round" fill="none"/>' +
+      '<path d="M1.6 1 H7.4 M4.5 1 V19.4 M1.6 19.4 H7.4" stroke="' +
+      payload.accent +
+      '" stroke-width="2" stroke-linecap="round" fill="none"/></svg>' +
+      "</div>" +
+      // A sibling of #pointer rather than a child of it. The badge has to stay
+      // readable exactly when the cursor has scrolled out of view, and a child
+      // of something parked far off screen is at the mercy of whether that
+      // layer gets drawn at all. Still inside #layer, though: everything the
+      // overlay draws shares one coordinate space, and a screenshot treats the
+      // whole subtree alike only while that stays true.
+      '<div id="badge"><span id="dot"></span><span id="hint"></span>' +
+      '<span id="text"></span></div>' +
+      "</div>" +
+      '<div id="glow"></div>';
+    host.__egoShadow = shadow;
+
+    // The page scrolls under the cursor between actions, and no CDP round trip
+    // announces that. Compensating in the page keeps it glued to its element.
+    const sync = () => {
+      const layer = shadow.getElementById("layer");
+      if (layer) {
+        layer.style.transform =
+          "translate3d(" + -window.scrollX + "px," + -window.scrollY + "px,0)";
+      }
+      // Staying glued to its element means riding that element off the screen,
+      // and a long scroll leaves the window showing nothing at all. The cursor
+      // keeps its place; the badge is what has to remain readable.
+      const at = host.__egoState;
+      if (at) placeBadge(at.pageX - window.scrollX, at.pageY - window.scrollY);
+    };
+    // hide() removes the host but leaves the realm standing, so a hide/show
+    // cycle would stack a listener per show, each closing over a dead root.
+    if (window.__egoCursorSync) {
+      window.removeEventListener("scroll", window.__egoCursorSync);
+      window.removeEventListener("resize", window.__egoCursorSync);
+    }
+    window.addEventListener("scroll", sync, { passive: true });
+    // A resize reflows the page under an overlay whose marks are held in page
+    // coordinates, and re-docks nothing on its own: the badge keeps measuring
+    // itself against the viewport it was placed in, so the whole overlay reads
+    // as slid away from what it points at. Retiling the window — switching to a
+    // dynamic or split layout — is the everyday way to hit it, and scrolling was
+    // the only event that used to put it right again.
+    window.addEventListener("resize", sync, { passive: true });
+    window.__egoCursorSync = sync;
+    host.__egoSync = sync;
+    parent.appendChild(host);
+    void host.offsetWidth; // let opacity:0 land, or there is nothing to fade from
+    host.style.opacity = "1";
+  }
+
+  const shadow = host.__egoShadow;
+  if (!shadow) return;
+
+  // Looked up before the first sync rather than where they are first drawn:
+  // sync() places the badge too, and it runs on the line below.
+  const badge = shadow.getElementById("badge");
+  const hint = shadow.getElementById("hint");
+
+  host.__egoSync?.();
+
+  // The harness speaks in viewport coordinates, but the cursor lives in page
+  // ones. Convert only when the viewport point actually changed: re-deriving it
+  // on a label-only render would walk the cursor across the page on every
+  // scroll, since the same viewport point is a different page point by then.
+  const previous = host.__egoState;
+  const moved = !previous || previous.x !== payload.x || previous.y !== payload.y;
+  let pageX = moved ? payload.x + window.scrollX : previous.pageX;
+  let pageY = moved ? payload.y + window.scrollY : previous.pageY;
+
+  // fill() focuses its target and inserts text without dispatching a single
+  // pointer event, so an agent can fill a whole form having never placed the
+  // cursor. Park it on the field it is typing into rather than at the origin.
+  if (!payload.placed) {
+    const target = focusedRect();
+    if (!target) return;
+    pageX = target.right + window.scrollX - 8;
+    pageY = target.bottom + window.scrollY - 6;
+  }
+
+  // Where it sits on screen right now, which is not payload.x/y once the page
+  // has scrolled under it.
+  const viewX = pageX - window.scrollX;
+  const viewY = pageY - window.scrollY;
+
+  // A read sweep drives the cursor from inside the page, line by line, so a
+  // render belonging to the same read must not drag it back to where the sweep
+  // began. Anything else — a click, a keystroke, the next read — ends it.
+  const pointer = shadow.getElementById("pointer");
+  const running = host.__egoSweep;
+  const readId = payload.read ? payload.read.id : 0;
+  const sweeping = Boolean(running) && running.id === readId && !running.done;
+  if (running && !running.done && !sweeping) {
+    // Cut off mid-line. Hand the pointer back with the timing it had before the
+    // sweep borrowed it, or the next real move animates like a read.
+    running.done = true;
+    pointer.style.transitionDuration = "";
+    pointer.style.transitionTimingFunction = "";
+  }
+  if (!sweeping) {
+    // One fixed duration for every move made a nudge between two fields crawl
+    // and a jump across the page look like a teleport. Scaling it to the
+    // distance is what a hand on a mouse does: near is quick, far takes a beat.
+    const far = previous ? Math.hypot(pageX - previous.pageX, pageY - previous.pageY) : 0;
+    pointer.style.transitionDuration =
+      Math.round(Math.min(420, Math.max(90, far * 0.45))) + "ms";
+    pointer.style.transform = "translate3d(" + pageX + "px," + pageY + "px,0)";
+  }
+  pointer.classList.toggle("press", Boolean(payload.pressed));
+
+  // What the cursor is over decides both its shape and, when the agent has not
+  // said what it is doing, what the badge reads. elementFromPoint is safe to
+  // ask here precisely because the overlay is pointer-events:none.
+  const under = document.elementFromPoint(viewX, viewY);
+  const subject = under
+    ? under.closest("a,button,input,select,textarea,label,summary,[role]") ||
+      // Falling back to whatever is under the cursor is useful for a paragraph
+      // or an image. It is not for <html> or <body>: their textContent is the
+      // entire document, stylesheet text and all, so the badge would read
+      // "Claude · Example Domainbody{background:#…". Resting the cursor in a
+      // corner after a navigation lands on exactly those, so describing them
+      // has to mean describing nothing — the stale label is the better answer.
+      (under.tagName === "HTML" || under.tagName === "BODY" ? null : under)
+    : null;
+  showShape(shadow, payload.typing ? "beam" : shapeFor(under));
+
+  // A label that still matches where the cursor is outranks everything. Once it
+  // goes stale it yields to a fresh description of what is actually under the
+  // cursor, and only comes back when there is nothing else to say — dimmed, to
+  // admit it is history. That ordering is what keeps the badge both permanent
+  // and honest: it never empties, and it never narrates the wrong thing.
+  const current = payload.note || (payload.labelStale ? "" : payload.label);
+  const nearby = describe(subject);
+  const showingStale =
+    !payload.typing && !current && !nearby && Boolean(payload.label);
+  const detail = payload.typing ? "typing…" : current || nearby || payload.label;
+  setBadgeText(detail ? payload.name + " · " + detail : payload.name);
+
+  // Reading owns the blue scheme; anything else hands it straight back. The
+  // read is what the harness cleared on the last real input, so this follows
+  // the same signal the sweep does rather than tracking a second one.
+  const readingNow = Boolean(payload.read) && !payload.typing;
+  shadow.getElementById("layer").classList.toggle("reading", readingNow);
+  // A host injected by an older build has no #glow, and the shim reuses whatever
+  // host it finds rather than rebuilding it. Reaching straight through would
+  // throw a TypeError that flush() silently swallows, leaving the cursor frozen
+  // on every page that was already open when the update landed. Missing glow
+  // just means no glow until that page next navigates.
+  const glow = shadow.getElementById("glow");
+  if (glow) glow.classList.toggle("on", readingNow);
+  // A reading label is always current — the sweep rewrites it per line — so the
+  // stale dimming only applies when the badge actually fell back to old text.
+  shadow
+    .getElementById("badge")
+    .classList.toggle("stale", showingStale && !readingNow);
+
+  placeBadge(viewX, viewY);
+
+  // A short trail of what happened, kept in the page for the same reason the
+  // cursor's position is: the Spaces panel runs in another process and this is
+  // the only state the two share. Recorded on transitions, so a burst of
+  // keystrokes is one entry rather than sixty.
+  const log = host.__egoLog || (host.__egoLog = []);
+  const remember = (text) => {
+    if (!text) return;
+    if (log.length && log[log.length - 1].text === text) return;
+    log.push({ text, at: Date.now() });
+    if (log.length > 6) log.shift();
+  };
+  if (payload.pulse) remember("clicked " + (describe(subject) || "the page"));
+  if (payload.typing && !previous?.typing) {
+    remember("typed into " + (describe(document.activeElement) || "a field"));
+  }
+  if (payload.highlight && payload.highlight.id !== previous?.highlightId) {
+    remember("highlighted " + (payload.note || "a passage"));
+  }
+
+  // Typing has no pointer to follow, so the field being typed into is what the
+  // overlay marks instead — otherwise text simply appears with nothing to say
+  // where it came from.
+  const ring = shadow.getElementById("ring");
+  const focused = payload.typing ? focusedRect() : null;
+  ring.classList.toggle("on", Boolean(focused));
+  if (focused) {
+    ring.style.width = focused.width + "px";
+    ring.style.height = focused.height + "px";
+    ring.style.transform =
+      "translate3d(" +
+      (focused.left + window.scrollX) +
+      "px," +
+      (focused.top + window.scrollY) +
+      "px,0)";
+  }
+
+  // Marker bands. Each is created at zero width and given its real width on the
+  // same frame, so the CSS transition draws it on rather than snapping it in.
+  // They are created only as the sweep reaches them, which is what makes the
+  // cursor look like it is doing the drawing.
+  const bands = shadow.getElementById("bands");
+  const marks = payload.highlight ? payload.highlight.rects : [];
+  if (!marks.length) {
+    // A sweep in flight puts its own bands in here; only a render that ended it
+    // is entitled to wipe them.
+    if (!sweeping) {
+      bands.replaceChildren();
+      bands.__egoId = 0;
+    }
+  } else {
+    // A new highlight replaces the old one. Without the generation check the
+    // previous stroke's bands would be reused for it, and the second highlight
+    // of a session would silently draw nothing.
+    if (bands.__egoId !== payload.highlight.id) {
+      bands.replaceChildren();
+      bands.__egoId = payload.highlight.id;
+    }
+    for (let index = 0; index < marks.length; index += 1) {
+      if (index > payload.highlight.upTo || bands.children[index]) continue;
+      const rect = marks[index];
+      const band = document.createElement("div");
+      band.className = "band";
+      band.style.height = rect.height + "px";
+      band.style.transform =
+        "translate3d(" + rect.x + "px," + rect.y + "px,0)";
+      band.style.transitionDuration = rect.ms + "ms";
+      bands.appendChild(band);
+      void band.offsetWidth; // let the zero width land before the real one
+      band.style.width = rect.width + "px";
+    }
+  }
+
+  if (payload.pulse) {
+    const pulse = shadow.getElementById("pulse");
+    pulse.classList.remove("on");
+    void pulse.offsetWidth; // restart the animation rather than ignore a re-click
+    pulse.classList.add("on");
+  }
+
+  // Left for anything reading the page from outside — the Spaces overview uses
+  // it to tell a space being worked in from one sitting idle.
+  host.__egoState = {
+    x: payload.x,
+    y: payload.y,
+    pageX,
+    pageY,
+    label: detail,
+    name: payload.name,
+    typing: Boolean(payload.typing),
+    highlightId: payload.highlight ? payload.highlight.id : 0,
+    at: Date.now(),
+  };
+
+  // Last, so everything the sweep reaches for — the log, the badge, the state
+  // it keeps fresh — already exists by the time it runs.
+  if (readId && (!running || running.id !== readId)) startReadSweep(readId);
+
+  /**
+   * Reading, made watchable.
+   *
+   * Snapshotting is most of what an agent does and it dispatches no input at
+   * all, so a window where the agent was reading showed a cursor parked in a
+   * corner under a badge that said "reading" — true, but never *what*. The
+   * sweep walks the cursor along the lines that are actually on screen, marking
+   * each as it passes and naming it in the badge, so someone watching can
+   * follow what the agent took in.
+   *
+   * It runs entirely inside the page: a round trip per line would cost more
+   * than the snapshot it illustrates, and the heredoc that triggered it has
+   * usually exited before the last line is drawn. That also means it must give
+   * up on its own — the sweep object is the only handle anything has on it.
+   */
+  function startReadSweep(id) {
+    const sweep = { id, done: false };
+    host.__egoSweep = sweep;
+    const lines = readableLines();
+    if (!lines.length) {
+      sweep.done = true;
+      return;
+    }
+    remember("read " + snip(lines[0].text));
+
+    let index = 0;
+    let spent = 0;
+
+    const step = () => {
+      if (sweep.done) return;
+      // A budget rather than a line count: reading is constant, and a sweep
+      // still going when the agent acts again would only ever be interrupted.
+      if (index >= lines.length || spent > 2400) {
+        sweep.done = true;
+        pointer.style.transitionDuration = "";
+        pointer.style.transitionTimingFunction = "";
+        return;
+      }
+      const line = lines[index];
+      index += 1;
+      const scanMs = Math.min(360, Math.max(130, Math.round(line.width * 0.8)));
+      spent += scanMs + 110;
+      const baseline = line.y + line.height - 2;
+
+      // Onto the start of the line first, then along it: the two legs are what
+      // make it read as following the words rather than sliding to a spot.
+      pointer.style.transitionTimingFunction = "ease-out";
+      pointer.style.transitionDuration = "100ms";
+      pointer.style.transform =
+        "translate3d(" + line.x + "px," + baseline + "px,0)";
+      setBadgeText(payload.name + " · reading “" + snip(line.text) + "”");
+      placeBadge(line.x - window.scrollX, baseline - window.scrollY);
+
+      setTimeout(() => {
+        if (sweep.done) return;
+        pointer.style.transitionTimingFunction = "linear";
+        pointer.style.transitionDuration = scanMs + "ms";
+        pointer.style.transform =
+          "translate3d(" + (line.x + line.width) + "px," + baseline + "px,0)";
+
+        const band = document.createElement("div");
+        band.className = "band read";
+        band.style.height = line.height + "px";
+        band.style.transform = "translate3d(" + line.x + "px," + line.y + "px,0)";
+        band.style.transitionDuration = scanMs + "ms";
+        bands.appendChild(band);
+        void band.offsetWidth; // let the zero width land before the real one
+        band.style.width = line.width + "px";
+        setTimeout(() => {
+          band.style.opacity = "0";
+          setTimeout(() => band.remove(), scanMs + 60);
+        }, scanMs + 320);
+
+        // Keep the state the Spaces overview polls moving: a card whose agent is
+        // reading should not look like a card whose agent walked away.
+        host.__egoState.pageX = line.x + line.width;
+        host.__egoState.pageY = baseline;
+        host.__egoState.label = "reading " + snip(line.text);
+        host.__egoState.at = Date.now();
+
+        setTimeout(step, scanMs + 10);
+      }, 110);
+    };
+
+    step();
+  }
+
+  /**
+   * The lines of text actually on screen, in reading order.
+   *
+   * Line boxes rather than elements: a Range hands back one rect per line, which
+   * is what lets the cursor travel a paragraph the way a reader does. Only the
+   * first few rects of any one node, so a long paragraph cannot spend the whole
+   * sweep while the rest of the page goes unread.
+   */
+  function readableLines() {
+    const root = document.body;
+    if (!root) return [];
+    const found = [];
+    // Measuring is what costs, and an agent scrolled halfway down a long page
+    // has thousands of text nodes above it that can never be swept. Dropping a
+    // container that is entirely off screen drops everything inside it in one
+    // test — but only when it has a box of its own to judge by, since an empty
+    // rect (display:contents, a zero-height wrapper) says nothing about the
+    // children. The count is the backstop for what pruning cannot reach.
+    let measured = 0;
+    const walker = document.createTreeWalker(
+      root,
+      NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
+      {
+        acceptNode(node) {
+          if (node.nodeType === 3) return NodeFilter.FILTER_ACCEPT;
+          const box = node.getBoundingClientRect();
+          const offScreen = box.bottom < 4 || box.top > window.innerHeight - 4;
+          if (box.width > 0 && box.height > 0 && offScreen) {
+            return NodeFilter.FILTER_REJECT;
+          }
+          return NodeFilter.FILTER_SKIP; // an element is not a line; its text is
+        },
+      },
+    );
+    while (found.length < 12 && measured < 400 && walker.nextNode()) {
+      const node = walker.currentNode;
+      const text = (node.nodeValue || "").replace(/\s+/g, " ").trim();
+      if (text.length < 12) continue;
+      const parent = node.parentElement;
+      if (!parent || parent.closest("script,style,noscript,svg")) continue;
+      measured += 1;
+      const range = document.createRange();
+      range.selectNodeContents(node);
+      let taken = 0;
+      for (const rect of range.getClientRects()) {
+        if (taken >= 3 || found.length >= 12) break;
+        if (rect.width < 80 || rect.height < 9 || rect.height > 96) continue;
+        if (rect.bottom < 4 || rect.top > window.innerHeight - 4) continue;
+        taken += 1;
+        found.push({
+          x: rect.left + window.scrollX,
+          y: rect.top + window.scrollY,
+          width: rect.width,
+          height: rect.height,
+          text,
+        });
+      }
+    }
+    // Document order is close to reading order but not the same thing under
+    // absolute positioning, and a cursor that jumps back up the page reads as a
+    // glitch rather than as reading.
+    return found.sort((a, b) => a.y - b.y || a.x - b.x);
+  }
+
+  /** Short enough for a badge that is drawn into every screenshot. */
+  function snip(text) {
+    const value = String(text || "").replace(/\s+/g, " ").trim();
+    return value.length > 44 ? value.slice(0, 43) + "…" : value;
+  }
+
+  /**
+   * The label, swapped without a jump cut.
+   *
+   * Written synchronously — anything reading the badge sees the new text on the
+   * next tick, and only the fade is deferred. The animation is restarted by hand
+   * because a swap arriving mid-fade would otherwise inherit whatever opacity
+   * the last one had reached and never brighten.
+   */
+  function setBadgeText(next) {
+    const text = shadow.getElementById("text");
+    if (text.textContent === next) return;
+    text.textContent = next;
+    text.style.animation = "none";
+    void text.offsetWidth;
+    text.style.animation = "";
+  }
+
+  /**
+   * Where the label goes, in viewport coordinates: what matters is where the
+   * cursor currently sits on screen, not where on the page it is marking.
+   *
+   * Near an edge the badge flips back over the cursor, so the label is never the
+   * thing that gets clipped. Past the edge — the cursor scrolled out of view
+   * entirely — it stops following and docks, because a label that leaves with
+   * the cursor tells a watcher nothing about what is still happening.
+   */
+  function placeBadge(atX, atY) {
+    const outY = atY < 4 ? "↑" : atY > window.innerHeight - 4 ? "↓" : "";
+    const outX = atX < 4 ? "←" : atX > window.innerWidth - 4 ? "→" : "";
+    // Vertical first: pages scroll that way, so it is the direction that
+    // actually carries the cursor off screen.
+    const away = outY || outX;
+    hint.textContent = away;
+
+    // #layer already carries -scroll, so a viewport target has to be written
+    // back into page coordinates to survive it.
+    const toPage = (x, y) =>
+      "translate(" +
+      Math.round(x + window.scrollX) +
+      "px," +
+      Math.round(y + window.scrollY) +
+      "px)";
+
+    if (!away) {
+      // Trailing the cursor at the offset it used to sit at as a child of it,
+      // then flipped back over it near an edge so the label is never the thing
+      // that gets clipped.
+      badge.classList.remove("docked");
+      badge.style.transform =
+        toPage(atX + 20, atY + 22) +
+        (atX + 340 > window.innerWidth ? " translateX(calc(-100% - 40px))" : "") +
+        (atY + 70 > window.innerHeight ? " translateY(-60px)" : "");
+      return;
+    }
+
+    // Parked against the edge the cursor left by, and held there while the page
+    // keeps moving under it.
+    const width = badge.offsetWidth || 240;
+    const dockX = Math.min(Math.max(atX, 12), Math.max(12, window.innerWidth - width - 12));
+    const dockY = Math.min(Math.max(atY, 12), Math.max(12, window.innerHeight - 40));
+    badge.classList.add("docked");
+    badge.style.transform = toPage(dockX, dockY);
+  }
+
+  /** The page's own cursor for this element is the honest source of shape. */
+  function shapeFor(element) {
+    if (!element) return "arrow";
+    const style = getComputedStyle(element).cursor;
+    if (style === "pointer") return "hand";
+    if (style === "text" || style === "vertical-text") return "beam";
+    return "arrow";
+  }
+
+  function showShape(root, id) {
+    for (const shape of root.querySelectorAll("svg.shape")) {
+      shape.classList.toggle("on", shape.id === id);
+    }
+  }
+
+  /**
+   * A short name for the thing under the cursor. Deliberately never reads an
+   * input's value: the agent types passwords into these, and the badge is drawn
+   * into every screenshot.
+   */
+  function describe(element) {
+    if (!element) return "";
+    const candidates = [
+      element.getAttribute("aria-label"),
+      // A form control's own <label> beats its placeholder: "typed into Your
+      // name" reads like a sentence, "typed into type a name" does not.
+      element.labels?.[0]?.textContent,
+      element.getAttribute("alt"),
+      element.getAttribute("placeholder"),
+      element.getAttribute("title"),
+      element.tagName === "INPUT" || element.tagName === "TEXTAREA"
+        ? ""
+        : element.textContent,
+    ];
+    for (const candidate of candidates) {
+      const text = String(candidate || "")
+        .replace(/\s+/g, " ")
+        .trim();
+      if (text) return text.length > 40 ? text.slice(0, 39) + "…" : text;
+    }
+    return "";
+  }
+
+  function focusedRect() {
+    const active = document.activeElement;
+    if (!active || active === document.body || active === document.documentElement) {
+      return null;
+    }
+    const rect = active.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0 ? rect : null;
+  }
+}

--- a/package/ego-linux/src/desktop.mjs
+++ b/package/ego-linux/src/desktop.mjs
@@ -1,0 +1,73 @@
+import { spawn } from "node:child_process";
+import { copyFile, mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { WM_CLASS } from "./chrome.mjs";
+
+/**
+ * Desktop integration.
+ *
+ * The macOS build installs as an app: an icon in the launcher you click to open
+ * the browser your agents share. There is no Linux app to install, but the same
+ * affordance is just an XDG desktop entry plus an icon, so this provides one.
+ */
+
+const DATA_HOME = process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+const APP_ID = "ego-lite-linux";
+const ICON_SOURCE = new URL("../assets/ego-lite-linux.svg", import.meta.url);
+const LAUNCHER = new URL("../bin/ego-browser.mjs", import.meta.url);
+
+/**
+ * The desktop session's PATH is not your shell's. A node installed by nvm, fnm
+ * or asdf lives outside it, so a `#!/usr/bin/env node` shebang resolves to
+ * nothing and clicking the icon fails silently. Pin the interpreter that is
+ * running this installer — re-run --install-desktop-entry after switching node
+ * versions.
+ */
+function desktopEntry(execPath) {
+  return `[Desktop Entry]
+Type=Application
+Name=ego lite (Linux port)
+GenericName=Agent Browser
+Comment=The browser you and your AI agents share
+Exec=${process.execPath} ${execPath} --open
+Icon=${APP_ID}
+Terminal=false
+# Ties the browser window (launched with --class=ego-lite-linux) to this entry,
+# so the desktop shows it as its own running app under this icon instead of
+# folding it into the ordinary Chrome window group.
+StartupWMClass=${WM_CLASS}
+Categories=Network;WebBrowser;
+Keywords=agent;automation;browser;ego;
+StartupNotify=true
+`;
+}
+
+/** Best-effort cache refresh; the entry works without it on most desktops. */
+function refresh(command, args) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { stdio: "ignore" });
+    child.on("error", () => resolve(false));
+    child.on("close", (code) => resolve(code === 0));
+  });
+}
+
+export async function installDesktopEntry() {
+  const applications = join(DATA_HOME, "applications");
+  const icons = join(DATA_HOME, "icons", "hicolor", "scalable", "apps");
+  await mkdir(applications, { recursive: true });
+  await mkdir(icons, { recursive: true });
+
+  const iconPath = join(icons, `${APP_ID}.svg`);
+  await copyFile(fileURLToPath(ICON_SOURCE), iconPath);
+
+  const entryPath = join(applications, `${APP_ID}.desktop`);
+  await writeFile(entryPath, desktopEntry(fileURLToPath(LAUNCHER)), { mode: 0o755 });
+
+  await refresh("update-desktop-database", [applications]);
+  await refresh("gtk-update-icon-cache", ["-f", "-t", join(DATA_HOME, "icons", "hicolor")]);
+
+  return { entryPath, iconPath };
+}

--- a/package/ego-linux/src/paths.mjs
+++ b/package/ego-linux/src/paths.mjs
@@ -1,0 +1,29 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const HOME = homedir();
+
+/** Persistent browser profile — the Linux stand-in for the ego lite app's profile. */
+export const DATA_DIR = join(
+  process.env.XDG_DATA_HOME || join(HOME, ".local", "share"),
+  "ego-lite-linux",
+);
+
+/** Runtime state shared across heredoc invocations (each run is its own process). */
+export const STATE_DIR = join(
+  process.env.XDG_STATE_HOME || join(HOME, ".local", "state"),
+  "ego-lite-linux",
+);
+
+export const PROFILE_DIR = process.env.EGO_LINUX_PROFILE || join(DATA_DIR, "profile");
+export const BROWSER_STATE_FILE = join(STATE_DIR, "browser.json");
+export const SPACES_STATE_FILE = join(STATE_DIR, "spaces-server.json");
+export const TASK_SPACE_FILE = join(STATE_DIR, "task-spaces.json");
+
+/** Where a stock Chrome keeps the profile we can import logins from. */
+export const CHROME_CONFIG_CANDIDATES = [
+  join(HOME, ".config", "google-chrome"),
+  join(HOME, ".config", "chromium"),
+  join(HOME, ".config", "microsoft-edge"),
+  join(HOME, ".config", "BraveSoftware", "Brave-Browser"),
+];

--- a/package/ego-linux/src/session.mjs
+++ b/package/ego-linux/src/session.mjs
@@ -1,0 +1,37 @@
+/**
+ * Which page the shim's own CDP calls should act on.
+ *
+ * The harness picks its own target (state.preferredTargetId, then the active
+ * tab) and attaches a session to it. That choice is invisible from here, so the
+ * transport records the target of the harness's Target.attachToTarget calls.
+ * Using it keeps every shim-side read and overlay on the page the harness is
+ * driving — computing "the active tab" independently lets the two drift, which
+ * reads as an empty snapshot, or as a cursor drawn on the wrong tab.
+ *
+ * The resolver caches its session per target, so a run of calls on one page
+ * costs a single attach.
+ */
+export function createSessionResolver(cdp, { listTabs, op }) {
+  let session = { targetId: null, sessionId: null };
+
+  return async function sessionForActiveTab() {
+    let targetId = cdp.attachedHint?.();
+
+    if (!targetId) {
+      const { tabs } = await listTabs();
+      const active = tabs.find((tab) => tab.active) || tabs[tabs.length - 1];
+      if (!active) throw new Error(`${op}: no page tab to attach to`);
+      targetId = active.targetId;
+    }
+
+    if (session.targetId === targetId && session.sessionId) {
+      return session.sessionId;
+    }
+    const { sessionId } = await cdp.call("Target.attachToTarget", {
+      targetId,
+      flatten: true,
+    });
+    session = { targetId, sessionId };
+    return sessionId;
+  };
+}

--- a/package/ego-linux/src/shim.mjs
+++ b/package/ego-linux/src/shim.mjs
@@ -1,0 +1,145 @@
+import { ensureBrowser } from "./chrome.mjs";
+import { connectCdp } from "./transport.mjs";
+import { createTabsApi } from "./tabs.mjs";
+import { createSnapshotApi } from "./snapshot.mjs";
+import { createTaskSpacesApi } from "./task-spaces.mjs";
+import { createCursorApi } from "./cursor.mjs";
+import { createWindowFit } from "./window-fit.mjs";
+
+/**
+ * Build the `globalThis.ego` object the ego-browser harness expects, backed by a
+ * plain Chromium over CDP instead of the macOS-only ego lite app.
+ *
+ * The full native surface the harness uses is 15 methods plus 2 callbacks; every
+ * one of them is implemented or explicitly degraded here. See README.md for the
+ * per-method fidelity table.
+ */
+export async function createEgoShim({ headless = false } = {}) {
+  const { wsUrl, port } = await ensureBrowser({ headless });
+  const cdp = await connectCdp(wsUrl);
+
+  const taskSpaces = createTaskSpacesApi(cdp);
+  // Downloads are armed per browser context, and a space owns one — so the
+  // harness's context-less setDownloadBehavior has to be aimed at the space the
+  // agent is actually in. See aimDownloadsAtCurrentSpace in transport.mjs.
+  cdp.setDownloadContext(() => taskSpaces.selectedContextId());
+  const tabs = createTabsApi(cdp, {
+    port,
+    getScope: () => taskSpaces.selectedScope(),
+  });
+  const snapshot = createSnapshotApi(cdp, { listTabs: tabs.listTabs });
+  const cursor = createCursorApi(cdp, { listTabs: tabs.listTabs });
+
+  // Every pointer event the harness sends moves the overlay, and a press ripples
+  // where it landed — so a user watching the window sees the agent work.
+  cdp.watchMouse((params) => {
+    // A wheel does not move the pointer, and page.wheel() defaults its
+    // coordinates to (0, 0) — following those would snap the cursor into the
+    // corner on every scroll.
+    if (params.type === "mouseWheel") return;
+    if (params.type === "mousePressed") cursor.press(params.x, params.y);
+    else if (params.type === "mouseReleased") cursor.release(params.x, params.y);
+    else cursor.moveTo(params.x, params.y);
+  });
+
+  // Typing is the one action with nothing to watch: fill() dispatches no pointer
+  // event at all, so without this a whole form fills itself with no explanation.
+  cdp.watchKeys(() => cursor.typed());
+
+  // A space that has ever loaded a real page is never "opened and never used",
+  // however blank its tab looks between navigations.
+  // A phone-width emulation in a desktop-width window shows a strip of site
+  // beside a band of empty chrome; the window follows the viewport instead.
+  const windowFit = createWindowFit(cdp);
+  cdp.watchViewport((metrics) => {
+    void windowFit.follow(metrics, cdp.attachedHint()).catch(() => {});
+  });
+
+  cdp.watchNavigation(() => {
+    void taskSpaces.noteContent().catch(() => {});
+    // A navigation destroys the overlay with the document it lives in. This is
+    // the earliest point the shim hears about one, and arming here is what lets
+    // the cursor come back on the load that follows.
+    void cursor.watchPage().catch(() => {});
+  });
+
+  const ego = {
+    // --- CDP transport: exact passthrough -----------------------------------
+    sendCDPMessage: (payload) => cdp.sendRaw(payload),
+    onCDPMessage: null,
+    onSendCDPMessageError: null,
+
+    // --- Tabs ---------------------------------------------------------------
+    listTabs: tabs.listTabs,
+    createTab: (url) => taskSpaces.createTabInSelectedSpace(tabs, url),
+
+    // --- Observation --------------------------------------------------------
+    // Reading is most of what an agent does, and none of it dispatches pointer
+    // events — so a session that only opened pages and snapshotted them drew no
+    // cursor at all, and looked idle. Showing the read is what makes the window
+    // legible while the agent is thinking rather than clicking.
+    // The label is deliberately left up afterwards: a snapshot returns in
+    // milliseconds, so clearing it on completion made "reading" flash for less
+    // than a frame. moveTo and pulseAt take it down when real input arrives.
+    async snapshot(options) {
+      cursor.reading();
+      return snapshot.snapshot(options);
+    },
+
+    // --- Task spaces --------------------------------------------------------
+    listTaskSpaces: taskSpaces.listTaskSpaces,
+    // Arming on Page.navigate is too late for that same navigation — the claim
+    // and Page.enable race the load and usually lose. Selecting a space is the
+    // first moment a tab is guaranteed to exist, and it always precedes the
+    // goto, so this is where a process's very first load gets covered.
+    async createTaskSpace(name) {
+      const result = await taskSpaces.createTaskSpace(name);
+      void cursor.watchPage().catch(() => {});
+      return result;
+    },
+    async useTaskSpace(id) {
+      const result = await taskSpaces.useTaskSpace(id);
+      void cursor.watchPage().catch(() => {});
+      return result;
+    },
+    claimTaskSpace: taskSpaces.claimTaskSpace,
+    // Handing a space back to the user drops the agent overlay, and taking it
+    // over brings it back — the same signal the native app's Space overlay gives.
+    async handOffTaskSpace(id) {
+      const result = await taskSpaces.handOffTaskSpace(id);
+      cursor.hide();
+      return result;
+    },
+    async takeOverTaskSpace(id) {
+      const result = await taskSpaces.takeOverTaskSpace(id);
+      cursor.show();
+      return result;
+    },
+    completeTaskSpace: taskSpaces.completeTaskSpace,
+    closeTaskSpace: taskSpaces.closeTaskSpace,
+
+    // --- The agent's cursor -------------------------------------------------
+    animationHighlightMouseToPosition: (x, y) => cursor.moveTo(x, y),
+    setAgentTaskState: (taskState) => cursor.setTaskState(taskState),
+
+    // Not upstream surface: a Linux-port extension an agent calls directly to
+    // show a human what it is talking about. `ego` is a global in the heredoc,
+    // so this reads as `await ego.highlight("free shipping")`.
+    highlight: (target, options) => cursor.highlight(target, options),
+    clearHighlight: () => cursor.clearHighlight(),
+
+    // --- App-lifecycle: no-ops on Linux -------------------------------------
+    async getBrowserVersion() {
+      const version = await cdp.call("Browser.getVersion");
+      return { version: version.product, revision: version.revision, linuxPort: true };
+    },
+    async upgradeBrowser() {
+      // The Linux port has no bundled app to upgrade; the user's Chrome updates
+      // itself. Reporting "done" keeps the harness's upgrade path a no-op.
+      return { done: false, reason: "not applicable on the Linux port" };
+    },
+  };
+
+  cdp.bind(ego);
+  return { ego, cdp, close: () => cdp.close(), port, wsUrl };
+}

--- a/package/ego-linux/src/snapshot.mjs
+++ b/package/ego-linux/src/snapshot.mjs
@@ -1,0 +1,424 @@
+import { createSessionResolver } from "./session.mjs";
+
+/**
+ * snapshot() — the semantic page view the agent reads.
+ *
+ * Contract (package/ego-browser/src/driver/observe.ts + browser-runtime.ts:309):
+ *   snapshot(options) -> { content: string, refs: [{ backendNodeId, role, name }] }
+ *
+ * `refs` is the load-bearing half: browserSnapshotRefsToRefMap() keys the ref map
+ * by String(backendNodeId), which is exactly what `@N` / `ref=N` resolve against.
+ * CDP hands out backendNodeIds directly, so refs are reproduced faithfully.
+ *
+ * `content` is rebuilt rather than reproduced — the native snapshot is closed
+ * source. One DOMSnapshot.captureSnapshot call returns every document (iframes
+ * included, nested to any depth), each node's backendNodeId and attributes, and
+ * the layout tree. That covers hierarchy, visibility and iframe piercing in a
+ * single round trip; roles and accessible names are computed here.
+ */
+
+const SKIP_TAGS = new Set([
+  "script", "style", "noscript", "head", "meta", "link", "title", "template", "br",
+]);
+
+const ROLE_BY_TAG = new Map(Object.entries({
+  a: "link", button: "button", select: "combobox", textarea: "textbox",
+  h1: "heading", h2: "heading", h3: "heading", h4: "heading", h5: "heading", h6: "heading",
+  img: "img", nav: "navigation", main: "main", header: "banner", footer: "contentinfo",
+  form: "form", ul: "list", ol: "list", li: "listitem", table: "table", tr: "row",
+  td: "cell", th: "columnheader", dialog: "dialog", option: "option", summary: "button",
+  details: "group", label: "label", fieldset: "group", legend: "legend", article: "article",
+  section: "region", aside: "complementary", iframe: "iframe", video: "video", audio: "audio",
+}));
+
+const INPUT_TYPE_ROLE = new Map(Object.entries({
+  button: "button", submit: "button", reset: "button", image: "button",
+  checkbox: "checkbox", radio: "radio", range: "slider", file: "file-input",
+  hidden: "hidden",
+}));
+
+/** Roles worth handing the agent a ref for. */
+const INTERACTIVE_ROLES = new Set([
+  "link", "button", "textbox", "checkbox", "radio", "combobox", "option", "slider",
+  "tab", "menuitem", "menuitemcheckbox", "menuitemradio", "switch", "searchbox",
+  "file-input", "spinbutton",
+]);
+
+/**
+ * Roles whose accessible name comes from their own text content (ARIA's
+ * "name from content"). Everything else — main, nav, form, region, list — is a
+ * container: naming it would swallow the whole page into one string, and taking
+ * that name as final would stop the walk before any child ever gets a ref.
+ */
+const NAME_FROM_CONTENT = new Set([
+  "button", "link", "heading", "option", "tab", "menuitem", "menuitemcheckbox",
+  "menuitemradio", "label", "legend", "switch",
+]);
+
+/** Roles that carry structure worth printing even without a ref. */
+const STRUCTURAL_ROLES = new Set([
+  "heading", "list", "listitem", "table", "row", "cell", "columnheader", "navigation",
+  "main", "banner", "contentinfo", "form", "dialog", "article", "region", "complementary",
+  "img", "label", "legend", "group", "iframe", "video", "audio",
+]);
+
+const MAX_NAME = 120;
+const MAX_TEXT = 200;
+
+function squash(value, limit = MAX_TEXT) {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > limit ? `${text.slice(0, limit - 1)}…` : text;
+}
+
+/** RareBooleanData -> Set of node indices that are true. */
+function rareBooleanSet(rare) {
+  return new Set(rare?.index || []);
+}
+
+/** RareIntegerData / RareStringData -> Map of node index -> value. */
+function rareMap(rare) {
+  const map = new Map();
+  const index = rare?.index || [];
+  const value = rare?.value || [];
+  for (let i = 0; i < index.length; i += 1) map.set(index[i], value[i]);
+  return map;
+}
+
+function cssEscapeIdent(value) {
+  return String(value).replace(/([^\w-])/g, "\\$1");
+}
+
+/** A document's nodes, decoded from the string table into a usable shape. */
+function decodeDocument(document, strings) {
+  const nodes = document.nodes;
+  const count = nodes.nodeName?.length || 0;
+  const str = (index) => (index === undefined || index < 0 ? "" : strings[index] || "");
+
+  const contentDocumentIndex = rareMap(nodes.contentDocumentIndex);
+  const clickable = rareBooleanSet(nodes.isClickable);
+  const inputValue = rareMap(nodes.inputValue);
+  const inputChecked = rareBooleanSet(nodes.inputChecked);
+
+  const layoutBounds = new Map();
+  const layoutText = new Map();
+  const layout = document.layout || {};
+  for (let i = 0; i < (layout.nodeIndex || []).length; i += 1) {
+    const nodeIndex = layout.nodeIndex[i];
+    layoutBounds.set(nodeIndex, layout.bounds?.[i]);
+    const text = str(layout.text?.[i]);
+    if (text) layoutText.set(nodeIndex, text);
+  }
+
+  const decoded = [];
+  const children = new Map();
+  const byId = new Map();
+
+  for (let i = 0; i < count; i += 1) {
+    const attributes = {};
+    const flat = nodes.attributes?.[i] || [];
+    for (let a = 0; a + 1 < flat.length; a += 2) {
+      attributes[str(flat[a]).toLowerCase()] = str(flat[a + 1]);
+    }
+    const node = {
+      index: i,
+      parent: nodes.parentIndex?.[i] ?? -1,
+      nodeType: nodes.nodeType?.[i],
+      tag: str(nodes.nodeName?.[i]).toLowerCase(),
+      value: str(nodes.nodeValue?.[i]),
+      backendNodeId: nodes.backendNodeId?.[i],
+      attributes,
+      bounds: layoutBounds.get(i),
+      text: layoutText.get(i),
+      clickable: clickable.has(i),
+      inputValue: inputValue.has(i) ? str(inputValue.get(i)) : undefined,
+      inputChecked: inputChecked.has(i),
+      contentDocumentIndex: contentDocumentIndex.get(i),
+    };
+    decoded.push(node);
+    if (node.parent >= 0) {
+      if (!children.has(node.parent)) children.set(node.parent, []);
+      children.get(node.parent).push(i);
+    }
+    if (node.attributes.id) byId.set(node.attributes.id, node);
+  }
+
+  return {
+    nodes: decoded,
+    children,
+    byId,
+    scrollX: document.scrollOffsetX || 0,
+    scrollY: document.scrollOffsetY || 0,
+    url: str(document.documentURL),
+  };
+}
+
+function roleOf(node) {
+  const explicit = node.attributes.role;
+  if (explicit) return explicit.trim().split(/\s+/)[0];
+  if (node.tag === "input") {
+    const type = (node.attributes.type || "text").toLowerCase();
+    if (INPUT_TYPE_ROLE.has(type)) return INPUT_TYPE_ROLE.get(type);
+    if (type === "search") return "searchbox";
+    if (type === "number") return "spinbutton";
+    return "textbox";
+  }
+  if (node.tag === "a") return node.attributes.href !== undefined ? "link" : "generic";
+  if (node.attributes.contenteditable === "" || node.attributes.contenteditable === "true") {
+    return "textbox";
+  }
+  return ROLE_BY_TAG.get(node.tag) || "generic";
+}
+
+/** Visible text of a subtree, used as the fallback accessible name. */
+function subtreeText(doc, index, budget = MAX_NAME) {
+  const parts = [];
+  const walk = (current) => {
+    if (parts.join(" ").length > budget) return;
+    const node = doc.nodes[current];
+    if (!node) return;
+    if (node.nodeType === 3) {
+      const text = node.text || node.value;
+      if (text && text.trim()) parts.push(text.trim());
+      return;
+    }
+    if (SKIP_TAGS.has(node.tag)) return;
+    for (const child of doc.children.get(current) || []) walk(child);
+  };
+  walk(index);
+  return squash(parts.join(" "), budget);
+}
+
+function accessibleName(doc, node, role) {
+  const attrs = node.attributes;
+  if (attrs["aria-label"]) return squash(attrs["aria-label"], MAX_NAME);
+  if (attrs["aria-labelledby"]) {
+    const labels = attrs["aria-labelledby"]
+      .split(/\s+/)
+      .map((id) => doc.byId.get(id))
+      .filter(Boolean)
+      .map((target) => subtreeText(doc, target.index));
+    if (labels.length) return squash(labels.join(" "), MAX_NAME);
+  }
+  if (node.tag === "img") return squash(attrs.alt || "", MAX_NAME);
+  if (node.tag === "input" || node.tag === "textarea" || node.tag === "select") {
+    if (attrs.id) {
+      for (const candidate of doc.nodes) {
+        if (candidate.tag === "label" && candidate.attributes.for === attrs.id) {
+          return subtreeText(doc, candidate.index);
+        }
+      }
+    }
+    // A wrapping <label> is the other half of the native label association.
+    let parent = node.parent;
+    while (parent >= 0) {
+      const ancestor = doc.nodes[parent];
+      if (!ancestor) break;
+      if (ancestor.tag === "label") return subtreeText(doc, ancestor.index);
+      parent = ancestor.parent;
+    }
+    return squash(attrs.placeholder || attrs.title || attrs.name || "", MAX_NAME);
+  }
+  if (role === "iframe") return squash(attrs.title || attrs.name || "", MAX_NAME);
+  if (NAME_FROM_CONTENT.has(role)) return subtreeText(doc, node.index);
+  // Containers are named only by an explicit label, never by their contents.
+  return squash(attrs.title || "", MAX_NAME);
+}
+
+/** Most stable `loc=` the resolver (locator-query.ts) can re-find this node by. */
+function stableLocator(node, role, name) {
+  const attrs = node.attributes;
+  if (attrs["data-testid"]) return `testid:${attrs["data-testid"]}`;
+  if (attrs.id && /^[A-Za-z][\w-]*$/.test(attrs.id)) return `css:#${cssEscapeIdent(attrs.id)}`;
+  if (role === "link" && attrs.href) return `href:${attrs.href}`;
+  if (attrs.placeholder) return `placeholder:${attrs.placeholder}`;
+  if (attrs["data-test"]) return `css:[data-test="${attrs["data-test"]}"]`;
+  if (name && INTERACTIVE_ROLES.has(role)) return `role:${role}[name='${name.replace(/'/g, "\\'")}']`;
+  if (attrs.name) return `css:${node.tag}[name="${attrs.name}"]`;
+  return null;
+}
+
+function intersectsViewport(bounds, viewport) {
+  if (!bounds || !viewport) return true;
+  const [x, y, width, height] = bounds;
+  return (
+    x + width >= viewport.x &&
+    y + height >= viewport.y &&
+    x <= viewport.x + viewport.width &&
+    y <= viewport.y + viewport.height
+  );
+}
+
+function renderDocument(doc, documents, options, out, refs, depth, seenDocs) {
+  const { viewport, includeActionMarks, includeStableLocator } = options;
+
+  const emit = (indent, line) => out.push(`${"  ".repeat(indent)}${line}`);
+
+  const walk = (index, indent) => {
+    const node = doc.nodes[index];
+    if (!node) return;
+
+    if (node.nodeType === 3) {
+      const text = squash(node.text || node.value);
+      // Text only counts as rendered when it made it into the layout tree, and
+      // it answers to the same viewport scope as an element does. Skipping this
+      // check meant `only_within_viewport` still emitted every paragraph below
+      // the fold — on a text-heavy page that is most of the content, which is
+      // why scoping the view saved so much less than it looked like it should.
+      if (
+        text &&
+        node.text !== undefined &&
+        intersectsViewport(node.bounds, viewport)
+      ) {
+        emit(indent, `text: ${text}`);
+      }
+      return;
+    }
+    if (node.nodeType !== 1) {
+      for (const child of doc.children.get(index) || []) walk(child, indent);
+      return;
+    }
+    if (SKIP_TAGS.has(node.tag)) return;
+    if (node.attributes["aria-hidden"] === "true") return;
+
+    const role = roleOf(node);
+    if (role === "hidden") return;
+
+    const rendered = node.bounds && node.bounds[2] > 0 && node.bounds[3] > 0;
+    const inScope = rendered && intersectsViewport(node.bounds, viewport);
+
+    // An iframe is a document boundary: recurse into its content document so
+    // nested frames appear inline in one tree.
+    if (node.contentDocumentIndex !== undefined) {
+      const childDoc = documents[node.contentDocumentIndex];
+      if (childDoc && !seenDocs.has(node.contentDocumentIndex)) {
+        seenDocs.add(node.contentDocumentIndex);
+        const name = accessibleName(doc, node, role);
+        emit(indent, `iframe${name ? ` "${name}"` : ""} [url=${childDoc.url}]`);
+        renderDocument(childDoc, documents, options, out, refs, indent + 1, seenDocs);
+        return;
+      }
+    }
+
+    const interactive =
+      INTERACTIVE_ROLES.has(role) ||
+      node.clickable ||
+      node.attributes.onclick !== undefined ||
+      node.attributes.tabindex !== undefined;
+
+    const shouldEmit =
+      inScope && (interactive || STRUCTURAL_ROLES.has(role));
+    const addressable = interactive && node.backendNodeId !== undefined;
+
+    // Being addressable is a different question from being on screen. An
+    // interactive node joins the refMap wherever it sits, so `@N` still
+    // resolves for something below the fold; only the rendered line stays
+    // viewport-scoped. Tying the two together is what made
+    // `scope: only_within_viewport` hand back "Unknown ref" for everything it
+    // had scrolled past, forcing a choice between a cheap snapshot and usable
+    // refs. The extra work is one bounded accessible-name walk per off-screen
+    // interactive node, over a document that is already decoded in memory —
+    // no additional CDP round trip, and full_page is unaffected because every
+    // node is in scope there anyway.
+    const name =
+      shouldEmit || addressable ? accessibleName(doc, node, role) : "";
+    if (addressable) {
+      refs.push({ backendNodeId: node.backendNodeId, role, name });
+    }
+
+    if (shouldEmit) {
+      const marks = [];
+
+      if (addressable) {
+        marks.push(`ref=${node.backendNodeId}`);
+      }
+      if (includeStableLocator) {
+        const locator = stableLocator(node, role, name);
+        if (locator) marks.push(`loc=${locator}`);
+      }
+      if (role === "link" && node.attributes.href) marks.push(`url=${node.attributes.href}`);
+      if (includeActionMarks && interactive) {
+        marks.push(role === "textbox" || role === "searchbox" ? "action=type" : "action=click");
+      }
+      if (node.inputValue) marks.push(`value=${squash(node.inputValue, 40)}`);
+      if (node.inputChecked) marks.push("checked");
+      if (node.attributes.disabled !== undefined) marks.push("disabled");
+
+      const heading = node.tag.match(/^h([1-6])$/);
+      const label = heading ? `heading${heading[1]}` : role;
+      const suffix = marks.length ? ` [${marks.join(", ")}]` : "";
+      emit(indent, `${label}${name ? ` "${name}"` : ""}${suffix}`);
+
+      // A name-from-content node has already printed its whole subtree as its
+      // name; recursing would repeat it. Containers must never take this path —
+      // their children are where the refs live.
+      if (name && NAME_FROM_CONTENT.has(role) && subtreeText(doc, index) === name) {
+        return;
+      }
+    }
+
+    const nextIndent = shouldEmit ? indent + 1 : indent;
+    for (const child of doc.children.get(index) || []) walk(child, nextIndent);
+  };
+
+  walk(0, depth);
+}
+
+export function createSnapshotApi(cdp, { listTabs }) {
+  // Snapshot whatever page the harness is actually driving: observation and
+  // action drifting apart reads as an empty snapshot. See session.mjs.
+  const sessionForActiveTab = createSessionResolver(cdp, {
+    listTabs,
+    op: "snapshot",
+  });
+
+  return {
+    async snapshot(options = {}) {
+      const sessionId = await sessionForActiveTab();
+      const scope = options.scope ?? "full_page";
+
+      let viewport = null;
+      if (scope === "only_within_viewport") {
+        const metrics = await cdp.call("Page.getLayoutMetrics", {}, sessionId);
+        const visual = metrics.cssVisualViewport || metrics.visualViewport;
+        if (visual) {
+          viewport = {
+            x: visual.pageX ?? 0,
+            y: visual.pageY ?? 0,
+            width: visual.clientWidth ?? 0,
+            height: visual.clientHeight ?? 0,
+          };
+        }
+      }
+
+      const captured = await cdp.call(
+        "DOMSnapshot.captureSnapshot",
+        { computedStyles: [], includeDOMRects: false, includePaintOrder: false },
+        sessionId,
+      );
+
+      const strings = captured.strings || [];
+      const documents = (captured.documents || []).map((document) =>
+        decodeDocument(document, strings),
+      );
+      if (!documents.length) return { content: "", refs: [] };
+
+      const out = [];
+      const refs = [];
+      renderDocument(
+        documents[0],
+        documents,
+        {
+          viewport,
+          includeActionMarks: options.includeActionMarks ?? true,
+          includeStableLocator: options.includeStableLocator ?? true,
+        },
+        out,
+        refs,
+        0,
+        new Set([0]),
+      );
+
+      return { content: out.join("\n"), refs };
+    },
+  };
+}

--- a/package/ego-linux/src/spaces-server.mjs
+++ b/package/ego-linux/src/spaces-server.mjs
@@ -1,0 +1,355 @@
+import { createServer } from "node:http";
+
+import { CURSOR_PROBE_EXPRESSION } from "./cursor.mjs";
+import { SPACES_HTML } from "./spaces-ui.mjs";
+
+/**
+ * The Spaces overview.
+ *
+ * Upstream draws this inside the browser's own chrome, which a Chromium fork can
+ * do and a stock Chromium cannot: Chrome 137 removed --load-extension, and the
+ * CDP Extensions domain reports "Method not available", so nothing can inject UI
+ * into the tab strip from outside. What is reachable is an --app window: no tab
+ * strip, no toolbar, its own app_id — a standalone panel that behaves like part
+ * of the browser.
+ *
+ * The server is the only source of truth's front door: it reads and writes the
+ * same task-space state file the CLI uses, so the overview and the agent never
+ * disagree about which spaces exist.
+ */
+
+const THUMBNAIL = {
+  format: "jpeg",
+  quality: 60,
+};
+
+/** How long after its last pointer event a space still counts as being worked in. */
+const ACTIVE_WINDOW_MS = 30_000;
+
+/** The crop used while an agent is active. Matches the card's 16/10 frame. */
+const FOLLOW = { width: 760, aspect: 16 / 10 };
+
+function clamp(value, low, high) {
+  return Math.max(low, Math.min(high, value));
+}
+
+/** Where the agent's cursor is in this page, or null if none has acted here. */
+async function readCursor(cdp, sessionId) {
+  try {
+    const { result } = await cdp.call(
+      "Runtime.evaluate",
+      { expression: CURSOR_PROBE_EXPRESSION, returnByValue: true },
+      sessionId,
+    );
+    return result?.value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A crop centred on the cursor, clamped to the visible viewport.
+ *
+ * A full-page thumbnail scaled into a ~294px card renders the cursor about five
+ * pixels wide, which reads as "nothing is happening" even while the agent is
+ * clicking. Cropping to where it is working makes the activity legible; the
+ * clamp keeps the rect inside what captureBeyondViewport:false actually paints.
+ */
+function followClip(cursor) {
+  const width = Math.min(FOLLOW.width, cursor.viewportWidth);
+  const height = Math.min(width / FOLLOW.aspect, cursor.viewportHeight);
+  const left = clamp(cursor.x - width / 2, 0, cursor.viewportWidth - width);
+  const top = clamp(cursor.y - height / 2, 0, cursor.viewportHeight - height);
+  // The overlay is viewport-fixed; the clip is in page coordinates.
+  return {
+    x: left + cursor.scrollX,
+    y: top + cursor.scrollY,
+    width,
+    height,
+    scale: 1,
+  };
+}
+
+/**
+ * Live frames, pushed rather than polled.
+ *
+ * captureScreenshot per poll cost four CDP round trips per space (attach, read
+ * cursor, capture, detach) and could never show more than one frame per poll —
+ * an agent's cursor jumped between stills instead of moving. Page.startScreencast
+ * inverts it: Chrome sends a frame whenever the page changes, into a cache the
+ * request path just reads.
+ *
+ * The cost is the crop. A screencast frame is the whole viewport, so the
+ * cursor-following zoom moves to the client, which has the cursor position
+ * anyway — see the transform in spaces-ui.mjs.
+ */
+const CAST = { format: "jpeg", quality: 55, maxWidth: 960, maxHeight: 600 };
+
+function createCastPool(cdp) {
+  const casts = new Map();
+  // Opening is async, so two concurrent polls for the same tab would each find
+  // no cast and each attach — the loser's session then leaks, attached and
+  // acking frames nobody reads.
+  const opening = new Map();
+  let closed = false;
+
+  cdp.onShimEvent("Page.screencastFrame", (params, sessionId) => {
+    for (const cast of casts.values()) {
+      if (cast.sessionId !== sessionId) continue;
+      cast.frame = params.data || null;
+      cast.seq += 1;
+      break;
+    }
+    // Chrome stops sending frames until each one is acknowledged.
+    cdp
+      .call("Page.screencastFrameAck", { sessionId: params.sessionId }, sessionId)
+      .catch(() => {});
+  });
+
+  async function open(targetId) {
+    const { sessionId } = await cdp.call("Target.attachToTarget", {
+      targetId,
+      flatten: true,
+    });
+    cdp.claimSession(sessionId);
+    if (closed) {
+      // The pool was torn down while this attach was in flight. Registering it
+      // now would leave a claimed session that nothing will ever detach.
+      cdp.releaseSession(sessionId);
+      cdp.call("Target.detachFromTarget", { sessionId }).catch(() => {});
+      throw new Error("cast pool is closed");
+    }
+    const cast = { sessionId, frame: null, seq: 0 };
+    casts.set(targetId, cast);
+    try {
+      await cdp.call("Page.startScreencast", { ...CAST, everyNthFrame: 1 }, sessionId);
+    } catch (error) {
+      // Leaving the entry behind would serve a blank card for as long as the tab
+      // lives: every later poll finds it, skips open(), and reads a stream that
+      // is not running.
+      casts.delete(targetId);
+      cdp.releaseSession(sessionId);
+      cdp.call("Target.detachFromTarget", { sessionId }).catch(() => {});
+      throw error;
+    }
+    // The first frame only arrives once the page next paints, which on a static
+    // page can be never — so prime the cache with one shot rather than show an
+    // empty card until something happens to move.
+    try {
+      const shot = await cdp.call(
+        "Page.captureScreenshot",
+        { format: CAST.format, quality: CAST.quality, captureBeyondViewport: false },
+        sessionId,
+      );
+      if (shot.data && !cast.frame) cast.frame = shot.data;
+    } catch {
+      // The stream will fill it in as soon as the page paints.
+    }
+    return cast;
+  }
+
+  return {
+    /** The newest frame for this tab, opening a stream for it on first ask. */
+    async frameFor(targetId) {
+      const existing = casts.get(targetId);
+      if (existing) return existing;
+      // Same contract for every caller: a broken stream yields null, never a
+      // rejection a caller has to remember to catch.
+      const inFlight = opening.get(targetId);
+      if (inFlight) return inFlight.catch(() => null);
+
+      const attempt = open(targetId).finally(() => opening.delete(targetId));
+      opening.set(targetId, attempt);
+      return attempt.catch(() => null);
+    },
+
+    sessionFor(targetId) {
+      return casts.get(targetId)?.sessionId ?? null;
+    },
+
+    /** Tabs that went away take their stream with them. */
+    async retain(liveTargetIds) {
+      for (const [targetId, cast] of [...casts.entries()]) {
+        if (liveTargetIds.has(targetId)) continue;
+        casts.delete(targetId);
+        cdp.releaseSession(cast.sessionId);
+        await cdp.call("Target.detachFromTarget", { sessionId: cast.sessionId }).catch(() => {});
+      }
+    },
+
+    closeAll() {
+      closed = true;
+      // Detach first. Releasing alone stops the shim claiming the session while
+      // Chrome is still streaming to it, so every frame in flight is forwarded
+      // to the harness — into the buffer drainEvents() hands to agents, which is
+      // the exact leak the claim exists to prevent.
+      for (const cast of casts.values()) {
+        cdp.call("Target.detachFromTarget", { sessionId: cast.sessionId }).catch(() => {});
+        cdp.releaseSession(cast.sessionId);
+      }
+      casts.clear();
+    },
+  };
+}
+
+async function captureCard(cdp, targetId, pool) {
+  try {
+    const cast = await pool.frameFor(targetId);
+    if (!cast) return { thumbnail: null, activity: null, trail: [] };
+
+    const cursor = await readCursor(cdp, cast.sessionId);
+    const active = Boolean(cursor) && cursor.ageMs < ACTIVE_WINDOW_MS;
+    return {
+      thumbnail: cast.frame ? `data:image/jpeg;base64,${cast.frame}` : null,
+      activity: active
+        ? {
+            name: cursor.name,
+            label: cursor.label,
+            ageMs: Math.round(cursor.ageMs),
+            // Fractions of the viewport, so the card can zoom to the cursor
+            // without the server cropping the frame.
+            fx: cursor.viewportWidth ? cursor.x / cursor.viewportWidth : null,
+            fy: cursor.viewportHeight ? cursor.y / cursor.viewportHeight : null,
+          }
+        : null,
+      trail: cursor?.trail?.slice(-3).reverse() ?? [],
+    };
+  } catch {
+    return { thumbnail: null, activity: null, trail: [] };
+  }
+}
+
+function json(response, status, body) {
+  const payload = JSON.stringify(body);
+  response.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(payload),
+    "cache-control": "no-store",
+  });
+  response.end(payload);
+}
+
+async function readBody(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  if (chunks.length === 0) return {};
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Start the overview server.
+ * @param {object} shim The live ego shim (ego + cdp).
+ * @returns {Promise<{port:number, close:() => void}>}
+ */
+export async function startSpacesServer(shim) {
+  const { ego, cdp } = shim;
+  const pool = createCastPool(cdp);
+
+  const server = createServer(async (request, response) => {
+    // Bound to loopback, but a page in the agent's own browser can still reach
+    // it, so only same-origin callers get to act.
+    const origin = request.headers.origin;
+    if (origin && !origin.startsWith("http://127.0.0.1:")) {
+      json(response, 403, { error: "cross-origin request refused" });
+      return;
+    }
+
+    const url = new URL(request.url, "http://127.0.0.1");
+
+    if (request.method === "GET" && url.pathname === "/") {
+      const html = SPACES_HTML;
+      response.writeHead(200, {
+        "content-type": "text/html; charset=utf-8",
+        "content-length": Buffer.byteLength(html),
+      });
+      response.end(html);
+      return;
+    }
+
+    if (request.method === "GET" && url.pathname === "/api/health") {
+      json(response, 200, { ok: true });
+      return;
+    }
+
+    if (request.method === "GET" && url.pathname === "/api/spaces") {
+      const { taskSpaces = [] } = await ego.listTaskSpaces();
+      // Deliberately NOT ego.listTabs(): that is scoped to the selected space,
+      // which is right for an agent (it should only see its own tabs) and wrong
+      // for an overview of every space — every non-selected card would report
+      // zero tabs, no title and no thumbnail. The panel needs the whole browser.
+      const { targetInfos = [] } = await cdp.call("Target.getTargets");
+      const byTarget = new Map(
+        targetInfos
+          .filter((target) => target.type === "page")
+          .map((target) => [target.targetId, target]),
+      );
+
+      await pool.retain(new Set(byTarget.keys()));
+      const spaces = await Promise.all(
+        taskSpaces.map(async (space) => {
+          const live = (space.targetIds || []).filter((id) => byTarget.has(id));
+          const lead = live[0];
+          const card = lead
+            ? await captureCard(cdp, lead, pool)
+            : { thumbnail: null, activity: null, trail: [] };
+          return {
+            id: space.id,
+            name: space.name,
+            ownership: space.ownership,
+            profile: space.profile || null,
+            session: space.session || null,
+            tabCount: live.length,
+            title: lead ? byTarget.get(lead).title : "",
+            url: lead ? byTarget.get(lead).url : "",
+            thumbnail: card.thumbnail,
+            activity: card.activity,
+            trail: card.trail,
+          };
+        }),
+      );
+      json(response, 200, { spaces });
+      return;
+    }
+
+    if (request.method === "POST" && url.pathname === "/api/spaces") {
+      const { name } = await readBody(request);
+      const space = await ego.createTaskSpace(name || "new space");
+      json(response, 200, { space });
+      return;
+    }
+
+    // takeover / stop are the panel's half of the ownership handshake the
+    // native app puts on its Space overlay: stop hands the space back to you
+    // (the agent's cursor goes away), takeover claims it for the agent again.
+    const match = /^\/api\/spaces\/(\d+)\/(use|close|stop|takeover)$/.exec(url.pathname);
+    if (request.method === "POST" && match) {
+      const id = Number(match[1]);
+      if (match[2] === "use") {
+        await ego.useTaskSpace(id);
+      } else if (match[2] === "stop") {
+        await ego.handOffTaskSpace(id);
+      } else if (match[2] === "takeover") {
+        await ego.takeOverTaskSpace(id);
+      } else {
+        await ego.closeTaskSpace(id);
+      }
+      json(response, 200, { done: true });
+      return;
+    }
+
+    json(response, 404, { error: "not found" });
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return {
+    port: server.address().port,
+    close: () => {
+      pool.closeAll();
+      server.close();
+    },
+  };
+}

--- a/package/ego-linux/src/spaces-server.mjs
+++ b/package/ego-linux/src/spaces-server.mjs
@@ -85,6 +85,10 @@ function followClip(cursor) {
  */
 const CAST = { format: "jpeg", quality: 55, maxWidth: 960, maxHeight: 600 };
 
+// Exported under a test-only name so the close/open race has a unit test that
+// does not need a real browser. Renaming this is a breaking change for the
+// internal probe, not for any caller of startSpacesServer.
+export const __createCastPoolForTest = createCastPool;
 function createCastPool(cdp) {
   const casts = new Map();
   // Opening is async, so two concurrent polls for the same tab would each find
@@ -116,7 +120,11 @@ function createCastPool(cdp) {
       // The pool was torn down while this attach was in flight. Registering it
       // now would leave a claimed session that nothing will ever detach.
       cdp.releaseSession(sessionId);
-      cdp.call("Target.detachFromTarget", { sessionId }).catch(() => {});
+      try {
+        await cdp.call("Target.detachFromTarget", { sessionId });
+      } catch {
+        // already detached
+      }
       throw new Error("cast pool is closed");
     }
     const cast = { sessionId, frame: null, seq: 0 };
@@ -129,7 +137,11 @@ function createCastPool(cdp) {
       // is not running.
       casts.delete(targetId);
       cdp.releaseSession(sessionId);
-      cdp.call("Target.detachFromTarget", { sessionId }).catch(() => {});
+      try {
+        await cdp.call("Target.detachFromTarget", { sessionId });
+      } catch {
+        // already detached
+      }
       throw error;
     }
     // The first frame only arrives once the page next paints, which on a static
@@ -169,24 +181,36 @@ function createCastPool(cdp) {
 
     /** Tabs that went away take their stream with them. */
     async retain(liveTargetIds) {
-      for (const [targetId, cast] of [...casts.entries()]) {
-        if (liveTargetIds.has(targetId)) continue;
-        casts.delete(targetId);
-        cdp.releaseSession(cast.sessionId);
-        await cdp.call("Target.detachFromTarget", { sessionId: cast.sessionId }).catch(() => {});
-      }
+      const stale = [...casts.entries()].filter(([targetId]) => !liveTargetIds.has(targetId));
+      for (const [targetId] of stale) casts.delete(targetId);
+      await Promise.all(
+        stale.map(async ([, cast]) => {
+          try {
+            await cdp.call("Target.detachFromTarget", { sessionId: cast.sessionId });
+          } catch {
+            // the browser is already gone, or the session was never attached
+          }
+          cdp.releaseSession(cast.sessionId);
+        }),
+      );
     },
 
-    closeAll() {
+    async closeAll() {
       closed = true;
-      // Detach first. Releasing alone stops the shim claiming the session while
-      // Chrome is still streaming to it, so every frame in flight is forwarded
-      // to the harness — into the buffer drainEvents() hands to agents, which is
-      // the exact leak the claim exists to prevent.
-      for (const cast of casts.values()) {
-        cdp.call("Target.detachFromTarget", { sessionId: cast.sessionId }).catch(() => {});
-        cdp.releaseSession(cast.sessionId);
-      }
+      // Detach first, then release. Releasing alone stops the shim claiming the
+      // session while Chrome is still streaming to it, so every frame in flight
+      // is forwarded to the harness — into the buffer drainEvents() hands to
+      // agents, which is the exact leak the claim exists to prevent.
+      await Promise.all(
+        [...casts.values()].map(async (cast) => {
+          try {
+            await cdp.call("Target.detachFromTarget", { sessionId: cast.sessionId });
+          } catch {
+            // the browser is already gone, or the session was never attached
+          }
+          cdp.releaseSession(cast.sessionId);
+        }),
+      );
       casts.clear();
     },
   };
@@ -219,24 +243,49 @@ async function captureCard(cdp, targetId, pool) {
   }
 }
 
-function json(response, status, body) {
+function json(response, status, body, { close = false } = {}) {
   const payload = JSON.stringify(body);
   response.writeHead(status, {
     "content-type": "application/json",
     "content-length": Buffer.byteLength(payload),
     "cache-control": "no-store",
+    ...(close ? { connection: "close" } : {}),
   });
   response.end(payload);
 }
 
+// The server is loopback, but a page in the agent's own browser can reach it,
+// so any caller can stream as much as it likes unless we bound it. 1 MiB is
+// enough for a generous space name; anything bigger is a misuse.
+const MAX_BODY_BYTES = 1 * 1024 * 1024;
+
 async function readBody(request) {
   const chunks = [];
-  for await (const chunk of request) chunks.push(chunk);
+  let total = 0;
+  for await (const chunk of request) {
+    total += chunk.length;
+    if (total > MAX_BODY_BYTES) {
+      // Stop consuming the rest. The connection stays open until the client
+      // finishes sending — once the response is written and the client has
+      // nothing more to say, server.close() can finish. Do NOT destroy()
+      // here: that resets the TCP connection before the 413 has been
+      // delivered, and undici reads it as a transport error.
+      throw new ResponseError(413, "request body too large");
+    }
+    chunks.push(chunk);
+  }
   if (chunks.length === 0) return {};
   try {
     return JSON.parse(Buffer.concat(chunks).toString("utf8"));
   } catch {
     return {};
+  }
+}
+
+class ResponseError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.status = status;
   }
 }
 
@@ -250,6 +299,21 @@ export async function startSpacesServer(shim) {
   const pool = createCastPool(cdp);
 
   const server = createServer(async (request, response) => {
+    try {
+      await route(request, response);
+    } catch (error) {
+      if (error instanceof ResponseError) {
+        // 413 leaves a request body the client may still be sending. Telling
+        // the client to close keeps server.close() from waiting on a half-open
+        // socket until the client's keep-alive timeout fires.
+        json(response, error.status, { error: error.message }, { close: error.status === 413 });
+        return;
+      }
+      json(response, 500, { error: "internal error" });
+    }
+  });
+
+  async function route(request, response) {
     // Bound to loopback, but a page in the agent's own browser can still reach
     // it, so only same-origin callers get to act.
     const origin = request.headers.origin;
@@ -342,14 +406,14 @@ export async function startSpacesServer(shim) {
     }
 
     json(response, 404, { error: "not found" });
-  });
+  }
 
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
   return {
     port: server.address().port,
-    close: () => {
-      pool.closeAll();
-      server.close();
+    close: async () => {
+      await pool.closeAll();
+      await new Promise((resolve) => server.close(resolve));
     },
   };
 }

--- a/package/ego-linux/src/spaces-ui.mjs
+++ b/package/ego-linux/src/spaces-ui.mjs
@@ -1,0 +1,456 @@
+/**
+ * The Spaces overview page, served by spaces-server.mjs.
+ *
+ * Kept as a single self-contained string: the page is loaded in an --app window
+ * with no toolbar, so there is no navigation to a second file, and inlining
+ * avoids a static-file route that would widen the server's surface.
+ */
+export const SPACES_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Spaces</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #eef1f7;
+    --card: #ffffff;
+    --line: rgba(15, 18, 25, 0.10);
+    --text: #12151c;
+    --muted: #6b7280;
+    --accent: #2f6df6;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #14161b;
+      --card: #1c1f26;
+      --line: rgba(255, 255, 255, 0.10);
+      --text: #eef0f4;
+      --muted: #9aa1ad;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    padding: 34px 40px 48px;
+    background:
+      radial-gradient(1200px 460px at 12% -8%, rgba(47, 109, 246, .10), transparent 60%),
+      radial-gradient(900px 420px at 92% 4%, rgba(120, 90, 220, .09), transparent 62%),
+      var(--bg);
+    color: var(--text);
+    font: 14px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  header { display: flex; align-items: baseline; gap: 12px; margin-bottom: 26px; }
+  h1 { font-size: 19px; font-weight: 650; margin: 0; letter-spacing: -0.01em; }
+  .sub { color: var(--muted); font-size: 13px; }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: 30px 26px;
+  }
+  /* The outer container stacks sections; only each section's body is a grid. */
+  .sections { display: block; }
+  .section + .section { margin-top: 38px; }
+  .section-head {
+    display: flex; align-items: baseline; gap: 10px;
+    margin-bottom: 14px; padding-bottom: 9px;
+    border-bottom: 1px solid var(--line);
+  }
+  .section-title { font-weight: 620; letter-spacing: -0.005em; }
+  .section-count { color: var(--muted); font-size: 12px; }
+  .card { display: flex; flex-direction: column; gap: 11px; }
+  .frame {
+    position: relative;
+    aspect-ratio: 16 / 10;
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    overflow: hidden;
+    cursor: pointer;
+    box-shadow: 0 1px 2px rgba(10, 14, 25, .05);
+    transition: box-shadow .18s ease, transform .18s ease, border-color .18s ease;
+  }
+  .frame:hover {
+    box-shadow: 0 14px 34px rgba(10, 14, 25, .16);
+    transform: translateY(-3px);
+    border-color: rgba(47, 109, 246, .35);
+  }
+  .dot {
+    display: inline-block; width: 7px; height: 7px; border-radius: 50%;
+    margin-right: 8px; vertical-align: middle;
+    background: var(--accent);
+  }
+  .dot.user { background: var(--muted); }
+  .dot.agentDelegatedToUser { background: #e0a02a; }
+  .frame img {
+    width: 100%; height: 100%; object-fit: cover; object-position: top center;
+    display: block;
+    transition: transform .28s ease-out, transform-origin .28s ease-out;
+  }
+  /* A working space is cropped to where its agent is, so the frame shows the
+     action rather than the whole page — say so, or the zoom looks like a bug. */
+  .frame.live { border-color: rgba(217, 119, 87, .55); }
+  .frame.live img { object-position: center; }
+  .live-chip {
+    position: absolute; left: 9px; bottom: 9px; right: 9px;
+    display: flex; align-items: center; gap: 7px;
+    padding: 5px 11px 5px 9px; border-radius: 999px;
+    background: rgba(24, 24, 27, .92); color: #fff;
+    font-size: 11.5px; font-weight: 500; line-height: 1.35;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, .28);
+    pointer-events: none;
+  }
+  .live-chip span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .live-chip i {
+    flex: none; width: 7px; height: 7px; border-radius: 50%;
+    background: #d97757; animation: breathe 1.7s ease-in-out infinite;
+  }
+  @keyframes breathe { 0%, 100% { opacity: 1; } 50% { opacity: .35; } }
+  .frame.empty { display: grid; place-items: center; color: var(--muted); font-size: 13px; }
+  .meta { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; padding: 0 3px; }
+  .name { font-weight: 550; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .tag { color: var(--muted); font-size: 12px; white-space: nowrap; }
+  .close {
+    position: absolute; top: 9px; right: 9px;
+    width: 25px; height: 25px; border-radius: 50%;
+    border: 1px solid var(--line); background: var(--card); color: var(--muted);
+    font-size: 15px; line-height: 1; cursor: pointer;
+    opacity: 0; transition: opacity .14s ease;
+  }
+  .frame:hover .close { opacity: 1; }
+  .close:hover { color: #d3453c; }
+  .add {
+    aspect-ratio: 16 / 10;
+    border: 1px dashed var(--line);
+    border-radius: 13px;
+    background: transparent;
+    color: var(--muted);
+    font-size: 30px; font-weight: 300;
+    cursor: pointer;
+    transition: border-color .16s ease, color .16s ease, background .16s ease;
+  }
+  .add:hover { border-color: var(--accent); color: var(--accent); background: var(--card); }
+  /* Ownership controls: quiet until the card is hovered, so a grid of spaces
+     stays calm rather than reading as a wall of buttons. */
+  .controls { display: flex; gap: 8px; padding: 0 3px; min-height: 26px; }
+  .ctl {
+    font: inherit; font-size: 12px; line-height: 1;
+    padding: 6px 12px; border-radius: 999px;
+    border: 1px solid var(--line); background: var(--card); color: var(--muted);
+    cursor: pointer; opacity: 0;
+    transition: opacity .14s ease, color .14s ease, border-color .14s ease;
+  }
+  .card:hover .ctl, .ctl:focus-visible { opacity: 1; }
+  .ctl:hover { color: var(--text); border-color: var(--accent); }
+  .ctl.primary { color: var(--accent); border-color: rgba(47, 109, 246, .45); }
+  .note {
+    margin-top: 34px; padding-top: 16px; border-top: 1px solid var(--line);
+    color: var(--muted); font-size: 12px; max-width: 62ch;
+  }
+  /* What the space actually did, so a card that has gone quiet still says
+     something. Reads newest first, like a log. */
+  .trail { display: flex; flex-direction: column; gap: 2px; padding: 2px 3px 0; }
+  .trail div {
+    display: flex; gap: 7px; color: var(--muted); font-size: 11.5px;
+    overflow: hidden; white-space: nowrap;
+  }
+  .trail div span:first-child { overflow: hidden; text-overflow: ellipsis; }
+  .trail div span:last-child { flex: none; opacity: .72; }
+  .trail div:first-child { color: var(--text); opacity: .82; }
+  .empty-state { color: var(--muted); padding: 40px 0; }
+</style>
+</head>
+<body>
+  <header>
+    <h1>Spaces</h1>
+    <span class="sub">workspaces you and your agents share</span>
+  </header>
+  <div class="sections" id="grid"></div>
+  <p class="note" id="note"></p>
+
+<script>
+const grid = document.getElementById("grid");
+const note = document.getElementById("note");
+let busy = false;
+let anyLive = false;
+
+async function api(path, options) {
+  const response = await fetch(path, {
+    ...options,
+    headers: { "content-type": "application/json" },
+  });
+  if (!response.ok) throw new Error(await response.text());
+  return response.json();
+}
+
+/**
+ * What the agent in this space is doing, over the thumbnail. The cursor itself
+ * is only a few pixels at card scale, so the chip — not the crop — is what makes
+ * activity readable at a glance.
+ */
+function liveChip(activity) {
+  const chip = document.createElement("div");
+  chip.className = "live-chip";
+  const seconds = Math.round(activity.ageMs / 1000);
+  const when = seconds < 2 ? "now" : seconds + "s ago";
+  const text = document.createElement("span");
+  text.textContent =
+    (activity.name || "agent") +
+    (activity.label ? " \\u00b7 " + activity.label : "") +
+    " \\u00b7 " +
+    when;
+  chip.append(document.createElement("i"), text);
+  return chip;
+}
+
+function card(space) {
+  const wrap = document.createElement("div");
+  wrap.className = "card";
+
+  const frame = document.createElement("div");
+  frame.className =
+    "frame" + (space.thumbnail ? "" : " empty") + (space.activity ? " live" : "");
+  frame.title = space.url || "";
+  if (space.thumbnail) {
+    const img = document.createElement("img");
+    img.src = space.thumbnail;
+    img.alt = space.title || space.name;
+    // A screencast frame is the whole viewport, where the cursor is about five
+    // pixels wide in a card — unreadable. The server used to crop to the cursor;
+    // now the frames arrive continuously and the zoom happens here instead, so
+    // motion stays smooth and the action still fills the card.
+    const spot = space.activity;
+    if (spot && spot.fx != null && spot.fy != null) {
+      img.style.transformOrigin =
+        (spot.fx * 100).toFixed(1) + "% " + (spot.fy * 100).toFixed(1) + "%";
+      img.style.transform = "scale(2.4)";
+    }
+    frame.append(img);
+  } else {
+    frame.textContent = "no page yet";
+  }
+  if (space.activity) frame.append(liveChip(space.activity));
+  frame.addEventListener("click", () => act("/api/spaces/" + space.id + "/use", "POST"));
+
+  const close = document.createElement("button");
+  close.className = "close";
+  close.textContent = "\\u00d7";
+  close.title = "close this space";
+  close.addEventListener("click", (event) => {
+    event.stopPropagation();
+    act("/api/spaces/" + space.id + "/close", "POST");
+  });
+  frame.append(close);
+
+  const meta = document.createElement("div");
+  meta.className = "meta";
+
+  const name = document.createElement("span");
+  name.className = "name";
+  const dot = document.createElement("i");
+  dot.className = "dot " + space.ownership;
+  dot.title =
+    space.ownership === "user"
+      ? "yours"
+      : space.ownership === "agentDelegatedToUser"
+        ? "handed to you"
+        : "an agent is working here";
+  name.append(dot, document.createTextNode(space.name));
+
+  // The native overview labels each space with its category. The useful
+  // equivalent here is the agent profile that opened it.
+  const tag = document.createElement("span");
+  tag.className = "tag";
+  const label = space.profile
+    ? space.profile + (space.session ? " \\u00b7 " + space.session : "")
+    : space.ownership === "user"
+      ? "yours"
+      : "agent";
+  tag.textContent = label;
+  tag.title =
+    (space.profile ? "cue profile: " + space.profile : "no cue profile recorded") +
+    " \\u2014 " +
+    space.tabCount +
+    (space.tabCount === 1 ? " tab" : " tabs");
+
+  meta.append(name, tag);
+
+  // The ownership handshake, the same pair the native app puts on its Space
+  // overlay: stop hands the space back to you and the agent's cursor goes away;
+  // take over gives it back. Shown on hover so a wall of cards stays calm.
+  const controls = document.createElement("div");
+  controls.className = "controls";
+  const agentOwned = space.ownership === "agent";
+  const action = document.createElement("button");
+  action.className = "ctl" + (agentOwned ? "" : " primary");
+  action.textContent = agentOwned ? "Stop" : "Take over";
+  action.title = agentOwned
+    ? "hand this space back to you — the agent stops driving it"
+    : "let the agent drive this space again";
+  action.addEventListener("click", (event) => {
+    event.stopPropagation();
+    act("/api/spaces/" + space.id + "/" + (agentOwned ? "stop" : "takeover"), "POST");
+  });
+  controls.append(action);
+
+  wrap.append(frame, meta, controls);
+  if (space.trail?.length) wrap.append(trail(space.trail));
+  return wrap;
+}
+
+/** Rough, human ages: nobody reads a card to the second. */
+function ago(ms) {
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 5) return "just now";
+  if (seconds < 60) return seconds + "s ago";
+  const minutes = Math.round(seconds / 60);
+  return minutes < 60 ? minutes + "m ago" : Math.round(minutes / 60) + "h ago";
+}
+
+/** What the space actually did, newest first. */
+function trail(entries) {
+  const list = document.createElement("div");
+  list.className = "trail";
+  for (const entry of entries) {
+    const row = document.createElement("div");
+    const what = document.createElement("span");
+    what.textContent = entry.text;
+    const when = document.createElement("span");
+    when.textContent = ago(entry.ageMs);
+    row.append(what, when);
+    list.append(row);
+  }
+  return list;
+}
+
+function addCard() {
+  const wrap = document.createElement("div");
+  wrap.className = "card";
+  const button = document.createElement("button");
+  button.className = "add";
+  button.textContent = "+";
+  button.title = "new space";
+  button.addEventListener("click", async () => {
+    const name = prompt("Name this space", "new space");
+    if (name === null) return;
+    await act("/api/spaces", "POST", { name: name.trim() || "new space" });
+  });
+  wrap.append(button);
+  return wrap;
+}
+
+async function act(path, method, body) {
+  if (busy) return;
+  busy = true;
+  try {
+    await api(path, { method, body: body ? JSON.stringify(body) : undefined });
+    await refresh();
+  } catch (error) {
+    note.textContent = "action failed: " + error.message;
+  } finally {
+    busy = false;
+  }
+}
+
+/**
+ * Several cue profiles can drive the browser at once, so the overview groups by
+ * the profile that opened each space. Without that, a row of cards from three
+ * different agents reads as one undifferentiated pile.
+ */
+function groupByProfile(spaces) {
+  const groups = new Map();
+  for (const space of spaces) {
+    const key = space.profile || "";
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(space);
+  }
+  // Named profiles first, alphabetically; unattributed spaces last.
+  return [...groups.entries()].sort(([a], [b]) => {
+    if (!a) return 1;
+    if (!b) return -1;
+    return a.localeCompare(b);
+  });
+}
+
+function section(profile, spaces, withAddCard) {
+  const wrap = document.createElement("section");
+  wrap.className = "section";
+
+  const head = document.createElement("div");
+  head.className = "section-head";
+  const title = document.createElement("span");
+  title.className = "section-title";
+  title.textContent = profile || "not from an agent";
+  const count = document.createElement("span");
+  count.className = "section-count";
+  const sessions = new Set(spaces.map((s) => s.session).filter(Boolean));
+  count.textContent =
+    spaces.length +
+    (spaces.length === 1 ? " space" : " spaces") +
+    (sessions.size > 1 ? " \\u00b7 " + sessions.size + " sessions" : "");
+  head.append(title, count);
+
+  const body = document.createElement("div");
+  body.className = "grid";
+  body.append(...spaces.map(card));
+  if (withAddCard) body.append(addCard());
+
+  wrap.append(head, body);
+  return wrap;
+}
+
+async function refresh() {
+  try {
+    const { spaces } = await api("/api/spaces");
+    anyLive = spaces.some((space) => space.activity);
+    const groups = groupByProfile(spaces);
+
+    if (!spaces.length) {
+      const body = document.createElement("div");
+      body.className = "grid";
+      body.append(addCard());
+      const empty = document.createElement("p");
+      empty.className = "empty-state";
+      empty.textContent = "No spaces yet. Create one, or let an agent open its own.";
+      grid.replaceChildren(empty, body);
+    } else {
+      grid.replaceChildren(
+        ...groups.map(([profile, list], index) =>
+          section(profile, list, index === groups.length - 1),
+        ),
+      );
+    }
+
+    note.textContent = spaces.length
+      ? "Each space gets its own cookie jar, seeded from your logins when it is created."
+      : "";
+  } catch (error) {
+    note.textContent = "cannot reach the browser: " + error.message;
+  }
+}
+
+// Poll faster while an agent is actually working, so a card that is meant to
+// show movement gets to show some. Idle spaces do not need the traffic: every
+// refresh costs a screenshot per space.
+const IDLE_POLL_MS = 4000;
+const LIVE_POLL_MS = 400;
+let timer = null;
+
+function schedule() {
+  clearTimeout(timer);
+  timer = setTimeout(tick, anyLive ? LIVE_POLL_MS : IDLE_POLL_MS);
+}
+
+async function tick() {
+  if (!busy && !document.hidden) await refresh();
+  schedule();
+}
+
+refresh().then(schedule);
+</script>
+</body>
+</html>
+`;

--- a/package/ego-linux/src/tabs.mjs
+++ b/package/ego-linux/src/tabs.mjs
@@ -1,0 +1,109 @@
+/**
+ * Tab surface: ego.listTabs() and ego.createTab(url).
+ *
+ * Contract (package/ego-browser/src/driver/nav.ts):
+ *   listTabs()    -> { tabs: [{ targetId, title, url, active, index }] }
+ *   createTab(url)-> { targetId }
+ *
+ * `active` matters more than it looks: ensureSession() attaches its CDP session
+ * to `tabs.find(t => t.active)`, so getting it wrong points every helper at the
+ * wrong page. CDP has no "which tab is focused" query, so the DevTools HTTP
+ * endpoint is used instead — it lists targets most-recently-used first, which
+ * also tracks tabs the user switches to by hand.
+ */
+
+export function createTabsApi(cdp, { port, getScope }) {
+  async function mruOrder() {
+    if (!port) return null;
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/json/list`, {
+        signal: AbortSignal.timeout(2000),
+      });
+      if (!response.ok) return null;
+      const list = await response.json();
+      return list.filter((entry) => entry.type === "page").map((entry) => entry.id);
+    } catch {
+      return null;
+    }
+  }
+
+  return {
+    async listTabs() {
+      const { targetInfos = [] } = await cdp.call("Target.getTargets");
+      let pages = targetInfos.filter(
+        (target) => target.type === "page" && !target.url.startsWith("devtools://"),
+      );
+
+      // Scoped to the selected space, the way the native app lists only the
+      // selected Space's tabs.
+      //
+      // This was dropped once, for good reason: membership used to be inferred
+      // from which window a tab landed in, and Target.createTarget takes no
+      // window id — so every heuristic either hid a tab the harness still held
+      // ("switchTab: target not found") or leaked one space's tabs into
+      // another's list. Browser-context-backed spaces removed the guesswork:
+      // Target.getTargets reports each target's browserContextId, and a tab
+      // opened for a space is created in that context, so membership is now a
+      // fact rather than an inference.
+      //
+      // Spaces without a context — the fallback path, and spaces re-adopted
+      // after a restart — fall back to the tracked target ids, which are exact
+      // for tabs the shim opened.
+      const scope = getScope ? await getScope() : null;
+      if (scope) {
+        const scoped = pages.filter((target) =>
+          scope.browserContextId
+            ? target.browserContextId === scope.browserContextId
+            : scope.targetIds.has(target.targetId),
+        );
+        // Never hand back an empty list: a space mid-navigation, or one whose
+        // only tab the user just closed, must not look like a browser with no
+        // tabs at all.
+        if (scoped.length > 0) pages = scoped;
+      }
+
+      const order = await mruOrder();
+      if (order) {
+        const rank = new Map(order.map((id, index) => [id, index]));
+        pages.sort(
+          (a, b) =>
+            (rank.get(a.targetId) ?? Number.MAX_SAFE_INTEGER) -
+            (rank.get(b.targetId) ?? Number.MAX_SAFE_INTEGER),
+        );
+      }
+
+      // An explicit activation by the harness (switchTab, openOrReuseTab) beats
+      // the endpoint's MRU guess, which does not always reflect a programmatic
+      // Target.activateTarget — especially headless.
+      const hinted = cdp.activeHint?.();
+      const activeId =
+        hinted && pages.some((target) => target.targetId === hinted)
+          ? hinted
+          : pages[0]?.targetId;
+      return {
+        tabs: pages.map((target, index) => ({
+          targetId: target.targetId,
+          title: target.title || "",
+          url: target.url || "",
+          active: target.targetId === activeId,
+          index,
+        })),
+      };
+    },
+
+    // browserContextId places the tab in a task space's own cookie jar; without
+    // one the tab lands in the default context, which is the pre-context
+    // behaviour and still correct for spaces that have no context.
+    async createTab(url = "about:blank", browserContextId = undefined) {
+      const { targetId } = await cdp.call("Target.createTarget", {
+        url,
+        ...(browserContextId ? { browserContextId } : {}),
+      });
+      if (!targetId) throw new Error("Target.createTarget returned no targetId");
+      // Make it the active tab, matching the native behaviour where a freshly
+      // created tab is the one the agent goes on to act on.
+      await cdp.call("Target.activateTarget", { targetId }).catch(() => {});
+      return { targetId };
+    },
+  };
+}

--- a/package/ego-linux/src/task-spaces.mjs
+++ b/package/ego-linux/src/task-spaces.mjs
@@ -1,0 +1,664 @@
+import { readFileSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+
+import { agentIdentity } from "./agent-identity.mjs";
+import { STATE_DIR, TASK_SPACE_FILE } from "./paths.mjs";
+
+/**
+ * Task spaces, emulated as tracked sets of tabs.
+ *
+ * The app's Space is isolated *and* inherits your login state. On stock Chromium
+ * those two properties look like they pull apart:
+ *
+ *   Target.createBrowserContext -> real isolation, but a blank cookie jar
+ *   sharing the default profile -> your real logins, but no isolation
+ *
+ * They don't: the empty jar can be filled. A space owns a browser context seeded
+ * from the default jar at creation, so it gets both — see createSeededContext
+ * below and docs/isolation-with-inherited-logins.md. The seed is a point-in-time
+ * copy, not live shared state, and a space that fails to get a context falls
+ * back to the shared default jar.
+ *
+ * Spaces deliberately do NOT get their own browser window. That was the first
+ * design, and it was measurably worse: a headless Chrome does not render tabs in
+ * background windows, so `document.elementFromPoint` returned null for pages
+ * living in a non-foreground window. That broke hit-testing, which in turn made
+ * the harness's input-fallback path re-synthesise drags that had already landed
+ * (see driver/pointer.ts finishDragProbe) — every canvas case in the upstream
+ * e2e suite failed or double-counted strokes. One window, tracked tab sets.
+ *
+ * Each heredoc is a fresh Node process, so state lives in a file, not memory.
+ */
+
+const EMPTY = { spaces: [], selectedId: null, nextId: 1, closedSpaces: [] };
+
+/**
+ * How many idle-closed spaces to remember.
+ *
+ * Enough that a session returning from a long break still finds its own, few
+ * enough that the state file cannot grow without bound.
+ */
+const REMEMBERED_CLOSURES = 20;
+
+export function createTaskSpacesApi(cdp) {
+  /**
+   * Which space *this process* is working in.
+   *
+   * selectedId lives in a file every concurrent session shares, and each heredoc
+   * writes it on the way in. So a second agent starting up silently reassigns
+   * the first one: from that moment the first agent scoped its tab list, its
+   * navigations and its cursor to the *other* session's space. The observed
+   * symptom is a tab navigating away to an unrelated site while the agent that
+   * opened it is still working in it, and the other agent finding a stranger's
+   * page where its own should be.
+   *
+   * Once this process has chosen a space it pins it here and stops consulting
+   * the shared value. The file still records the global selection — the Spaces
+   * overview reads it, and it is the right answer for a fresh process that has
+   * not chosen yet — it simply no longer decides what an already-committed
+   * process acts on.
+   */
+  let pinnedSpaceId = null;
+
+  /** The pinned space if it still exists, else whatever the file last recorded. */
+  function effectiveSelectedId(state) {
+    if (
+      pinnedSpaceId !== null &&
+      state.spaces.some((space) => space.id === pinnedSpaceId)
+    ) {
+      return pinnedSpaceId;
+    }
+    return state.selectedId;
+  }
+
+  async function readState() {
+    try {
+      const parsed = JSON.parse(await readFile(TASK_SPACE_FILE, "utf8"));
+      return { ...EMPTY, ...parsed };
+    } catch {
+      return { ...EMPTY };
+    }
+  }
+
+  async function writeState(state) {
+    await mkdir(STATE_DIR, { recursive: true });
+    await writeFile(TASK_SPACE_FILE, JSON.stringify(state, null, 2));
+  }
+
+  async function livePageTargets() {
+    const { targetInfos = [] } = await cdp.call("Target.getTargets");
+    const live = new Map();
+    for (const target of targetInfos) {
+      if (target.type === "page" && !target.url.startsWith("devtools://")) {
+        live.set(target.targetId, target);
+      }
+    }
+    return live;
+  }
+
+  /**
+   * Re-adopt a space's pages after the browser restarted.
+   *
+   * A space is identified by target ids, and those die with the browser. A
+   * restart therefore wiped every space even though Chrome had restored the
+   * very pages they described — the overview read "No spaces yet" next to a
+   * window full of tabs. Remembered urls are what survive a restart, so they
+   * are what the pages get matched back by.
+   *
+   * Only attempted when EVERY space lost EVERY tab at once, which is the
+   * signature of a restart. Closing one space's tabs by hand leaves the others
+   * alive, and must stay a deletion — otherwise a space would resurrect itself
+   * from any other tab that happened to share its url.
+   */
+  function readoptRestoredPages(state, live) {
+    if (state.spaces.length === 0) return false;
+    if (
+      state.spaces.some((space) => (space.targetIds || []).some((id) => live.has(id)))
+    ) {
+      return false;
+    }
+
+    const claimed = new Set();
+    let changed = false;
+    for (const space of state.spaces) {
+      const wanted = new Set(space.urls || []);
+      if (wanted.size === 0) continue;
+      const matches = [...live.values()].filter(
+        (target) => !claimed.has(target.targetId) && wanted.has(target.url),
+      );
+      if (matches.length === 0) continue;
+      for (const target of matches) claimed.add(target.targetId);
+      space.targetIds = matches.map((target) => target.targetId);
+      // Browser contexts do not outlive the browser. The restored pages are in
+      // the default jar, so the space is no longer isolated and must not keep
+      // claiming a context id that now refers to nothing.
+      if (space.browserContextId) space.browserContextId = null;
+      space.restored = true;
+      changed = true;
+    }
+    return changed;
+  }
+
+  /**
+   * Close spaces that were opened and never used.
+   *
+   * A context-backed space cannot share a window with the default context, so
+   * every space is its own window, and every space starts life as a single
+   * about:blank tab. Anything that creates spaces in bulk — the e2e suite, a
+   * crashed run, an agent that gave up — therefore leaves a drift of empty
+   * windows across the desktop, which is what users actually notice.
+   *
+   * Only a space that is not selected, has *never* held a real page, holds
+   * nothing but about:blank, and has had a grace period to receive its first
+   * one is swept. "Never held a page" is the load-bearing condition: a tab is
+   * momentarily about:blank on every navigation, so judging by the current url
+   * alone would delete a working space mid-goto.
+   */
+  const ABANDONED_AFTER_MS = 120000;
+
+  async function pruneAbandoned(state, live) {
+    const doomed = state.spaces.filter((space) => {
+      if (space.id === effectiveSelectedId(state)) return false;
+      // Ever held a real page => not abandoned, only between pages.
+      if (space.lastContentAt) return false;
+      if (!space.createdAt || Date.now() - space.createdAt < ABANDONED_AFTER_MS) return false;
+      const tabs = (space.targetIds || []).map((id) => live.get(id)).filter(Boolean);
+      if (tabs.length === 0) return false;
+      return tabs.every((target) => target.url === "about:blank");
+    });
+    if (doomed.length === 0) return false;
+
+    for (const space of doomed) {
+      for (const targetId of space.targetIds) {
+        await cdp.call("Target.closeTarget", { targetId }).catch(() => {});
+      }
+      if (space.browserContextId) await disposeContext(space.browserContextId);
+    }
+    const gone = new Set(doomed.map((space) => space.id));
+    state.spaces = state.spaces.filter((space) => !gone.has(space.id));
+    return true;
+  }
+
+  /**
+   * Close spaces nobody has come back to.
+   *
+   * A space outlives the process that opened it — every heredoc is a fresh Node
+   * run — so nothing reaps one whose agent simply stopped returning. A session
+   * that ends mid-task leaves its tabs open for good, and the count only climbs;
+   * spaces from long-finished work were still holding pages days later.
+   *
+   * Idleness is measured from the last time something addressed the space, not
+   * from when its page last changed: an agent reading one page for ten minutes
+   * is working, and a space parked on a live dashboard is not. Live work keeps
+   * itself alive by continuing, since every round touches the space it uses.
+   *
+   * The selected space is never swept — it is the one someone is on right now —
+   * and EGO_LINUX_SPACE_IDLE_MIN=0 turns the sweep off for anyone who would
+   * rather clean up by hand.
+   */
+  const IDLE_MINUTES = Number(process.env.EGO_LINUX_SPACE_IDLE_MIN ?? 30);
+  const IDLE_AFTER_MS =
+    Number.isFinite(IDLE_MINUTES) && IDLE_MINUTES > 0 ? IDLE_MINUTES * 60000 : 0;
+
+  async function pruneIdle(state) {
+    if (!IDLE_AFTER_MS) return false;
+    const now = Date.now();
+    // Stamping is itself a state change worth persisting: drop it and every run
+    // would re-stamp from scratch, so nothing would ever reach the threshold.
+    let stamped = false;
+    const doomed = state.spaces.filter((space) => {
+      if (space.id === effectiveSelectedId(state)) return false;
+      // touchedAt only moves when an API call names the space, and nothing a
+      // person does at the keyboard produces one. A space handed over for a
+      // login or a captcha, or completed with keep: true — which exists purely
+      // to say "leave this page open" — would therefore go idle while it is
+      // being used, and get closed out from under them.
+      if (
+        space.ownership === "user" ||
+        space.ownership === "agentDelegatedToUser"
+      ) {
+        return false;
+      }
+      // Spaces that predate this field have no idle history, and judging them
+      // by createdAt would sweep every one of them the first time the feature
+      // runs — including whatever a colleague session is halfway through. Stamp
+      // them instead and let them earn a full idle window from here.
+      if (!space.touchedAt) {
+        space.touchedAt = now;
+        stamped = true;
+        return false;
+      }
+      return now - space.touchedAt >= IDLE_AFTER_MS;
+    });
+    if (doomed.length === 0) return stamped;
+
+    for (const space of doomed) {
+      for (const targetId of space.targetIds || []) {
+        await cdp.call("Target.closeTarget", { targetId }).catch(() => {});
+      }
+      if (space.browserContextId) await disposeContext(space.browserContextId);
+    }
+
+    // Leave a trail. Without one, an agent coming back after a long break calls
+    // useOrCreate with the same name, silently gets a brand-new empty space, and
+    // carries on believing it resumed — the tabs it had open are simply gone and
+    // nothing says so. A closed space that names itself and lists what it held
+    // turns that into something the agent can put back.
+    const closures = state.closedSpaces || [];
+    for (const space of doomed) {
+      closures.unshift({
+        name: space.name,
+        urls: (space.urls || []).filter((url) => url && url !== "about:blank"),
+        closedAt: now,
+        idleMinutes: Math.round((now - space.touchedAt) / 60000),
+      });
+    }
+    state.closedSpaces = closures.slice(0, REMEMBERED_CLOSURES);
+
+    const gone = new Set(doomed.map((space) => space.id));
+    state.spaces = state.spaces.filter((space) => !gone.has(space.id));
+    return true;
+  }
+
+  /** Drop tabs the user closed, and spaces left with none. */
+  async function reconcile(state) {
+    const live = await livePageTargets();
+    let changed = false;
+
+    for (const space of state.spaces) {
+      const kept = (space.targetIds || []).filter((id) => live.has(id));
+      if (kept.length !== (space.targetIds || []).length) {
+        space.targetIds = kept;
+        changed = true;
+      }
+      // Remembered while the pages are alive, so a restart has something to
+      // match them back by.
+      if (kept.length > 0) {
+        const urls = kept.map((id) => live.get(id).url).filter(Boolean);
+        // A space that has ever held a real page is never "opened and never
+        // used", however blank it looks right now — a tab is momentarily
+        // about:blank on every navigation.
+        if (!space.lastContentAt && urls.some((url) => url !== "about:blank")) {
+          space.lastContentAt = Date.now();
+          changed = true;
+        }
+        if (urls.join("\n") !== (space.urls || []).join("\n")) {
+          space.urls = urls;
+          changed = true;
+        }
+      }
+    }
+
+    if (readoptRestoredPages(state, live)) changed = true;
+    if (await pruneAbandoned(state, live)) changed = true;
+    if (await pruneIdle(state)) changed = true;
+
+    const surviving = state.spaces.filter((space) => space.targetIds.length > 0);
+    if (surviving.length !== state.spaces.length) {
+      // Losing its last tab is how a space ends when the user closes tabs by
+      // hand, so its context has to go the same way closeTaskSpace disposes
+      // one. Dropping the record alone would strand a live context holding a
+      // full copy of the seeded cookie jar until the browser restarts.
+      for (const space of state.spaces) {
+        if (space.targetIds.length === 0 && space.browserContextId) {
+          await disposeContext(space.browserContextId);
+        }
+      }
+      state.spaces = surviving;
+      changed = true;
+    }
+    if (!state.spaces.some((space) => space.id === state.selectedId)) {
+      state.selectedId = null;
+      changed = true;
+    }
+    if (changed) await writeState(state);
+    return { state, live };
+  }
+
+  function decorate(space, live) {
+    return {
+      ...space,
+      taskId: space.taskId ?? space.id,
+      recentTabTitles: space.targetIds
+        .map((id) => live.get(id)?.title || "")
+        .filter(Boolean),
+    };
+  }
+
+  /**
+   * The harness selects a space with useTaskSpace() and then calls handOff /
+   * takeOver / complete / close with NO arguments — they act on whatever is
+   * currently selected (see helpers.ts:326-354). Only useTaskSpace, claim and
+   * create are passed an id.
+   */
+  async function requireSpace(state, id, op) {
+    const wanted =
+      id === undefined || id === null ? effectiveSelectedId(state) : Number(id);
+    const space = state.spaces.find((candidate) => candidate.id === wanted);
+    if (!space) {
+      throw new Error(
+        id === undefined || id === null
+          ? `${op}: no task space is selected`
+          : `${op}: task space not found: ${id}`,
+      );
+    }
+    // Every API call that names a space is a session saying it is still here.
+    // That is what the idle sweep measures, and touching it in the one place
+    // they all pass through is what keeps live work from being swept out from
+    // under an agent that simply had a long think between rounds.
+    space.touchedAt = Date.now();
+    return space;
+  }
+
+  /** Bring the space's own tab to the front, so the agent lands back on it. */
+  async function focusSpace(space) {
+    const live = await livePageTargets();
+    const targetId = space.targetIds.find((id) => live.has(id));
+    if (targetId) {
+      await cdp.call("Target.activateTarget", { targetId }).catch(() => {});
+    }
+  }
+
+  /**
+   * Give a space its own cookie jar, pre-filled with the user's.
+   *
+   * Target.createBrowserContext isolates for real, but starts empty — which on
+   * its own would log the agent out of everything, so this port used to take a
+   * bare window instead and accept a shared jar. Seeding the new context from
+   * the default jar gets both properties at once: measurements and the two
+   * reproducible experiments are in docs/isolation-with-inherited-logins.md.
+   *
+   * These calls carry no sessionId, so the transport sends them at the browser
+   * level, which is where browserContextId is accepted.
+   *
+   * Returns null if the browser refuses a context, so a space degrades to the
+   * previous window-only behaviour rather than failing to open at all.
+   */
+  /**
+   * The selected space's context id, read synchronously.
+   *
+   * Sync because its only caller is the transport rewriting an outgoing payload
+   * on its way to the socket, which has nowhere to await. The state file is a
+   * few hundred bytes and the rewrite only fires on Browser.setDownloadBehavior,
+   * so this is not on any hot path.
+   */
+  function selectedContextId() {
+    try {
+      const state = JSON.parse(readFileSync(TASK_SPACE_FILE, "utf8"));
+      const wanted = effectiveSelectedId({ ...state, spaces: state.spaces ?? [] });
+      const space = state.spaces?.find((candidate) => candidate.id === wanted);
+      return space?.browserContextId ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** The space's own still-blank tab, if it has exactly that and nothing else. */
+  async function blankAnchor(space) {
+    const ids = space.targetIds || [];
+    if (ids.length !== 1) return null;
+    const live = await livePageTargets().catch(() => new Map());
+    const target = live.get(ids[0]);
+    return target && target.url === "about:blank" ? target.targetId : null;
+  }
+
+  async function disposeContext(browserContextId) {
+    await cdp
+      .call("Target.disposeBrowserContext", { browserContextId })
+      .catch(() => {});
+  }
+
+  async function createSeededContext() {
+    let browserContextId;
+    try {
+      ({ browserContextId } = await cdp.call("Target.createBrowserContext", {}));
+    } catch {
+      return null;
+    }
+    if (!browserContextId) return null;
+    try {
+      const { cookies } = await cdp.call("Storage.getCookies", {});
+      if (cookies?.length) {
+        await cdp.call("Storage.setCookies", { browserContextId, cookies });
+      }
+    } catch {
+      // An unseeded context is still a usable space, just a logged-out one.
+    }
+    return browserContextId;
+  }
+
+  return {
+    selectedContextId,
+
+    /**
+     * Remember that the selected space received a real page.
+     *
+     * This is what keeps a working space out of the abandoned sweep: its tab is
+     * about:blank again on every navigation, so the current url can never tell
+     * "never used" apart from "between pages". Recorded once, never cleared.
+     */
+    async noteContent() {
+      const state = await readState();
+      const space = state.spaces.find(
+        (candidate) => candidate.id === effectiveSelectedId(state),
+      );
+      if (!space || space.lastContentAt) return;
+      space.lastContentAt = Date.now();
+      await writeState(state);
+    },
+
+    async listTaskSpaces() {
+      const { state, live } = await reconcile(await readState());
+      return { taskSpaces: state.spaces.map((space) => decorate(space, live)) };
+    },
+
+    async createTaskSpace(name) {
+      const state = await readState();
+      const browserContextId = await createSeededContext();
+      let targetId;
+      try {
+        ({ targetId } = await cdp.call("Target.createTarget", {
+          url: "about:blank",
+          ...(browserContextId ? { browserContextId } : {}),
+        }));
+      } catch (err) {
+        // Nothing will ever reference this context if the space fails to open.
+        if (browserContextId) await disposeContext(browserContextId);
+        throw err;
+      }
+      await cdp.call("Target.activateTarget", { targetId }).catch(() => {});
+
+      const space = {
+        id: state.nextId,
+        taskId: state.nextId,
+        name: String(name ?? `task ${state.nextId}`),
+        createdAt: Date.now(),
+        touchedAt: Date.now(),
+        ownership: "agent",
+        createdBy: "agent",
+        // Which agent profile opened it — the overview's right-hand label.
+        ...agentIdentity(),
+        browserContextId,
+        targetIds: [targetId],
+      };
+      state.spaces.push(space);
+      state.nextId += 1;
+      state.selectedId = space.id;
+      pinnedSpaceId = space.id;
+
+      // useOrCreate lands here whenever it cannot find the name it was given —
+      // including when the idle sweep closed that very space while its agent was
+      // away. Handing back what the old one held is the difference between
+      // "resumed" and "started over without noticing". Consumed on use, so it is
+      // reported once rather than on every later run of the same name.
+      const closures = state.closedSpaces || [];
+      const index = closures.findIndex((entry) => entry.name === space.name);
+      if (index !== -1) {
+        const [previous] = closures.splice(index, 1);
+        state.closedSpaces = closures;
+        space.previously = {
+          closedAt: previous.closedAt,
+          idleMinutes: previous.idleMinutes,
+          urls: previous.urls,
+          note:
+            `a task space named ${JSON.stringify(space.name)} was closed after ` +
+            `${previous.idleMinutes} minutes idle; this is a new, empty one. ` +
+            (previous.urls.length
+              ? `It had these pages open: ${previous.urls.join(", ")}`
+              : "It had no pages open."),
+        };
+      }
+
+      await writeState(state);
+      return space;
+    },
+
+    async useTaskSpace(id) {
+      const state = await readState();
+      const space = await requireSpace(state, id, "useTaskSpace");
+      state.selectedId = space.id;
+      pinnedSpaceId = space.id;
+      await writeState(state);
+      await focusSpace(space);
+      return { done: true };
+    },
+
+    async claimTaskSpace(id) {
+      const state = await readState();
+      const space = await requireSpace(state, id, "claimTaskSpace");
+      space.ownership = "agent";
+      state.selectedId = space.id;
+      pinnedSpaceId = space.id;
+      await writeState(state);
+      await focusSpace(space);
+      return space;
+    },
+
+    async handOffTaskSpace(id) {
+      const state = await readState();
+      const space = await requireSpace(state, id, "handOffTaskSpace");
+      space.ownership = "agentDelegatedToUser";
+      await writeState(state);
+      return { done: true };
+    },
+
+    async takeOverTaskSpace(id) {
+      const state = await readState();
+      const space = await requireSpace(state, id, "takeOverTaskSpace");
+      space.ownership = "agent";
+      state.selectedId = space.id;
+      pinnedSpaceId = space.id;
+      await writeState(state);
+      await focusSpace(space);
+      return { done: true };
+    },
+
+    // Only the `keep: true` path reaches here; the harness routes `keep: false`
+    // to closeTaskSpace instead (helpers.ts:299-315).
+    async completeTaskSpace(id) {
+      const state = await readState();
+      const space = await requireSpace(state, id, "completeTaskSpace");
+      space.ownership = "user";
+      await writeState(state);
+      return { done: true };
+    },
+
+    async closeTaskSpace(id) {
+      const state = await readState();
+      const space = await requireSpace(state, id, "closeTaskSpace");
+      for (const targetId of space.targetIds) {
+        await cdp.call("Target.closeTarget", { targetId }).catch(() => {});
+      }
+      if (space.browserContextId) {
+        // Also drops the space's cookie jar, which is the point of having one.
+        await disposeContext(space.browserContextId);
+      }
+      state.spaces = state.spaces.filter((candidate) => candidate.id !== space.id);
+      if (state.selectedId === space.id) state.selectedId = null;
+      if (pinnedSpaceId === space.id) pinnedSpaceId = null;
+      await writeState(state);
+      return { done: true };
+    },
+
+    /**
+     * Open a tab and attribute it to the selected space, so completing that
+     * space closes the tabs it opened. Membership is tracked by the ids we
+     * create rather than inferred from which window a tab landed in, which CDP
+     * gives no way to control (Target.createTarget takes no window id). For a
+     * space with a context the browser also enforces membership, but the id
+     * list stays authoritative so context-less spaces behave identically.
+     */
+    /**
+     * What listTabs() should show: the selected space's tabs.
+     *
+     * A browser context identifies membership exactly, so it is preferred. The
+     * tracked target ids cover spaces that have no context — the fallback path,
+     * and spaces re-adopted after a restart, whose context died with the
+     * browser.
+     */
+    async selectedScope() {
+      const state = await readState();
+      if (!effectiveSelectedId(state)) return null;
+      const space = state.spaces.find(
+        (candidate) => candidate.id === effectiveSelectedId(state),
+      );
+      if (!space) return null;
+      return {
+        browserContextId: space.browserContextId || null,
+        targetIds: new Set(space.targetIds || []),
+      };
+    },
+
+    async createTabInSelectedSpace(tabs, url) {
+      const state = await readState();
+      const space = state.spaces.find(
+        (candidate) => candidate.id === effectiveSelectedId(state),
+      );
+      // A space is anchored by a tab — one with none is reaped as soon as it is
+      // reconciled — so it opens on about:blank before it has anywhere to go.
+      // Creating a second tab for the first navigation strands that anchor, and
+      // the window then shows a blank tab beside the real page for the rest of
+      // the session. Navigating the anchor is what it was opened for.
+      //
+      // Guarded on lastContentAt rather than on the tab's current url: a tab is
+      // about:blank for a moment during every navigation, so matching on the url
+      // alone would hijack a tab that is already carrying work. "Never held a
+      // page" is only true of a space that has not started yet.
+      const anchor = space && !space.lastContentAt ? await blankAnchor(space) : null;
+      if (anchor && url && url !== "about:blank") {
+        const { sessionId } = await cdp.call("Target.attachToTarget", {
+          targetId: anchor,
+          flatten: true,
+        });
+        await cdp.call("Page.navigate", { url }, sessionId);
+        await cdp.call("Target.activateTarget", { targetId: anchor }).catch(() => {});
+        return { targetId: anchor };
+      }
+
+      // Open it inside the space's context, so every tab of a space shares that
+      // space's jar rather than the first tab being isolated and the rest not.
+      let result;
+      try {
+        result = await tabs.createTab(url, space?.browserContextId);
+      } catch (error) {
+        // Browser contexts die with the browser, but the selected space's id
+        // outlives it in the state file. Chrome then rejects the create with
+        // "Failed to find browser context", which used to leave the port unable
+        // to open any tab at all after a restart. Fall back to the default jar
+        // and forget the dead id — the space stops being isolated, which is
+        // already true, rather than stopping working.
+        if (!space?.browserContextId || !/browser context/i.test(String(error?.message))) {
+          throw error;
+        }
+        space.browserContextId = null;
+        space.restored = true;
+        result = await tabs.createTab(url);
+      }
+      if (space && result.targetId) {
+        space.targetIds.push(result.targetId);
+        await writeState(state);
+      }
+      return result;
+    },
+  };
+}

--- a/package/ego-linux/src/transport.mjs
+++ b/package/ego-linux/src/transport.mjs
@@ -1,0 +1,321 @@
+/**
+ * CDP transport, shared between the harness and this shim.
+ *
+ * The harness talks to the native layer through exactly three members
+ * (see package/ego-browser/src/browser-runtime.ts):
+ *
+ *   ego.sendCDPMessage(jsonString)   — a serialized { id, method, params, sessionId? }
+ *   ego.onCDPMessage(jsonString)     — a raw protocol message, parsed by handleMessage
+ *   ego.onSendCDPMessageError(msg, code)
+ *
+ * Chrome's browser-level WebSocket speaks that exact wire format when sessions
+ * are attached with `flatten: true` (which ensureSession() does), so harness
+ * traffic is a straight passthrough.
+ *
+ * The shim also needs its own calls (Target.getTargets for listTabs, the
+ * snapshot's DOM walk, ...). Both parties share one socket, so request ids are
+ * partitioned: the harness counts up from 1, the shim from INTERNAL_ID_BASE.
+ * Responses to shim ids are consumed here and never reach the harness, which
+ * would otherwise see ids it has no pending entry for.
+ */
+
+const OPEN_TIMEOUT_MS = 10000;
+const CALL_TIMEOUT_MS = 30000;
+const INTERNAL_ID_BASE = 1_000_000;
+
+export async function connectCdp(wsUrl) {
+  const socket = new WebSocket(wsUrl);
+  socket.binaryType = "arraybuffer";
+
+  const internalPending = new Map();
+  let nextInternalId = INTERNAL_ID_BASE;
+  let runtime = null;
+  let closed = false;
+  let activeTargetId = null;
+  let attachedTargetId = null;
+  let mouseWatcher = null;
+  // Sessions the shim opened for its own reads. Their events belong to the
+  // shim, not to the harness.
+  const shimSessions = new Set();
+  const shimEvents = new Map();
+  let keyWatcher = null;
+  let navWatcher = null;
+  let viewportWatcher = null;
+  let downloadContextResolver = null;
+
+  /** Track which tab the harness last brought to the front, and which it drives. */
+  function noteActivation(payload) {
+    try {
+      const message = JSON.parse(payload);
+      if (message.method === "Input.dispatchMouseEvent") {
+        // Where the agent's pointer actually is. The harness announces intent
+        // through ego.animationHighlightMouseToPosition, but only these carry
+        // the drag path and the press itself, which is what the cursor overlay
+        // needs to look like a hand on the mouse rather than a teleport.
+        mouseWatcher?.(message.params || {});
+      } else if (
+        message.method === "Input.dispatchKeyEvent" ||
+        message.method === "Input.insertText"
+      ) {
+        // Typing is the one thing an agent does that leaves no trace until the
+        // text appears. Both paths matter: keystrokes and fill()'s bulk insert.
+        keyWatcher?.(message.params || {});
+      } else if (message.method === "Page.navigate" && message.params?.url) {
+        // Whether a space ever held a real page can only be seen as it happens:
+        // a tab is about:blank again the moment it navigates away, so polling
+        // its url later cannot tell "never used" from "between pages".
+        if (message.params.url !== "about:blank") navWatcher?.(message.params.url);
+      } else if (message.method === "Emulation.setDeviceMetricsOverride") {
+        // Emulation resizes the page's viewport, never the OS window — so a
+        // mobile layout renders as a narrow strip inside a desktop-sized window.
+        viewportWatcher?.(message.params || {});
+      } else if (message.method === "Emulation.clearDeviceMetricsOverride") {
+        // Explicitly the other half: leaving emulation has to put the window
+        // back, or it stays phone-shaped for the rest of the session.
+        viewportWatcher?.({ width: 0, height: 0 });
+      } else if (message.method === "Target.activateTarget" && message.params?.targetId) {
+        activeTargetId = message.params.targetId;
+      } else if (message.method === "Target.attachToTarget" && message.params?.targetId) {
+        // ensureSession() attaches to whatever the harness considers current —
+        // its preferredTargetId, which the shim cannot see any other way. The
+        // shim's own page reads (snapshot) must target the same tab, or the
+        // agent observes one page while acting on another.
+        attachedTargetId = message.params.targetId;
+      } else if (
+        message.method === "Target.closeTarget" &&
+        message.params?.targetId === activeTargetId
+      ) {
+        activeTargetId = null;
+      }
+    } catch {
+      // Not our concern: the send itself is what matters.
+    }
+  }
+
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`CDP WebSocket did not open within ${OPEN_TIMEOUT_MS}ms`)),
+      OPEN_TIMEOUT_MS,
+    );
+    socket.addEventListener(
+      "open",
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+    socket.addEventListener(
+      "error",
+      () => {
+        clearTimeout(timer);
+        reject(new Error(`failed to connect to CDP endpoint: ${wsUrl}`));
+      },
+      { once: true },
+    );
+  });
+
+  socket.addEventListener("message", (event) => {
+    const text =
+      typeof event.data === "string"
+        ? event.data
+        : new TextDecoder().decode(event.data);
+
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      return;
+    }
+
+    if (typeof data.id === "number" && data.id >= INTERNAL_ID_BASE) {
+      const entry = internalPending.get(data.id);
+      if (!entry) return;
+      internalPending.delete(data.id);
+      clearTimeout(entry.timer);
+      if (data.error) {
+        entry.reject(new Error(data.error.message || JSON.stringify(data.error)));
+      } else {
+        entry.resolve(data.result ?? {});
+      }
+      return;
+    }
+
+    // Events from a session the shim opened are the shim's business. Forwarding
+    // them would push them into the harness's event buffer, where drainEvents()
+    // hands them to the agent — a screencast alone would bury a task's real
+    // events under dozens of frames a second.
+    if (data.sessionId && shimSessions.has(data.sessionId)) {
+      shimEvents.get(data.method)?.(data.params || {}, data.sessionId);
+      return;
+    }
+
+    runtime?.onCDPMessage?.(text);
+  });
+
+  socket.addEventListener("close", () => {
+    closed = true;
+    for (const entry of internalPending.values()) {
+      clearTimeout(entry.timer);
+      entry.reject(new Error("browser connection closed"));
+    }
+    internalPending.clear();
+    // Mirrors the native bridge's task-level failure: every in-flight harness
+    // request fails the same way, so they are all rejected at once.
+    runtime?.onSendCDPMessageError?.(
+      "browser connection closed",
+      "EGO_CDP_CHANNEL_UNAVAILABLE",
+    );
+  });
+
+  /**
+   * Point the harness's download setup at the space the agent is working in.
+   *
+   * Browser.setDownloadBehavior with no browserContextId configures the DEFAULT
+   * context. That was right when a task space was a plain window, but a space
+   * now owns its own context — so the harness's call, which cannot know that,
+   * would arm downloads on a context nothing is downloading in. No
+   * Page.downloadWillBegin ever fires and page.waitForEvent("download") hangs
+   * until it times out.
+   *
+   * Rewriting on the way out keeps the harness unmodified and keeps the
+   * download path the harness chose, which download.path() then reads from.
+   */
+  function aimDownloadsAtCurrentSpace(payload) {
+    if (!downloadContextResolver) return payload;
+    if (!payload.includes("Browser.setDownloadBehavior")) return payload;
+    try {
+      const message = JSON.parse(payload);
+      if (message.method !== "Browser.setDownloadBehavior") return payload;
+      if (message.params?.browserContextId) return payload;
+      const browserContextId = downloadContextResolver();
+      if (!browserContextId) return payload;
+      return JSON.stringify({
+        ...message,
+        params: { ...message.params, browserContextId },
+      });
+    } catch {
+      // A payload we cannot parse is one we have no business rewriting.
+      return payload;
+    }
+  }
+
+  function assertOpen() {
+    if (closed || socket.readyState !== WebSocket.OPEN) {
+      throw new Error("CDP channel is not open");
+    }
+  }
+
+  return {
+    /** Raw passthrough for harness-authored payloads (ids below the shim's base). */
+    sendRaw(payload) {
+      assertOpen();
+      noteActivation(payload);
+      socket.send(aimDownloadsAtCurrentSpace(payload));
+    },
+
+    /**
+     * Tell the transport which browser context downloads should be armed for.
+     * Set by the shim to the selected task space; see the rewrite below.
+     */
+    setDownloadContext(resolver) {
+      downloadContextResolver = resolver;
+    },
+
+    /**
+     * The last target the harness explicitly activated, or null.
+     * CDP cannot be asked which tab is focused, so the authoritative signal is
+     * the harness's own Target.activateTarget call (what browser.switchTab and
+     * openOrReuseTab issue). Without this, currentTab() does not follow
+     * switchTab() and every helper that reads "the active tab" drifts.
+     */
+    activeHint: () => activeTargetId,
+
+    /** The target the harness's own CDP session is attached to, or null. */
+    attachedHint: () => attachedTargetId,
+
+    /**
+     * Observe the harness's mouse input as it goes out. Read-only: the callback
+     * runs before the send and its errors are swallowed by noteActivation's
+     * catch, so a watcher can never hold up or fail an action.
+     */
+    watchMouse(handler) {
+      mouseWatcher = handler;
+    },
+
+    /** Observe the harness's keyboard input, on the same read-only terms. */
+    watchKeys(handler) {
+      keyWatcher = handler;
+    },
+
+    /**
+     * Claim a session the shim opened, so its events stop at the shim.
+     * Sessions the harness opens are untouched and keep flowing to it.
+     */
+    claimSession(sessionId) {
+      if (sessionId) shimSessions.add(sessionId);
+    },
+
+    releaseSession(sessionId) {
+      shimSessions.delete(sessionId);
+    },
+
+    /** Handle one CDP event method arriving on a claimed session. */
+    onShimEvent(method, handler) {
+      shimEvents.set(method, handler);
+    },
+
+    /** Observe viewport emulation, on the same read-only terms. */
+    watchViewport(handler) {
+      viewportWatcher = handler;
+    },
+
+    /** Observe navigations to real pages, on the same read-only terms. */
+    watchNavigation(handler) {
+      navWatcher = handler;
+    },
+
+    /** The shim's own request/response calls. */
+    call(method, params = {}, sessionId = undefined) {
+      assertOpen();
+      if (method === "Target.activateTarget" && params.targetId) {
+        activeTargetId = params.targetId;
+      }
+      const id = ++nextInternalId;
+      const payload = JSON.stringify({
+        id,
+        method,
+        params,
+        ...(sessionId ? { sessionId } : {}),
+      });
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          internalPending.delete(id);
+          reject(new Error(`CDP request timed out: ${method}`));
+        }, CALL_TIMEOUT_MS);
+        internalPending.set(id, { resolve, reject, timer });
+        try {
+          socket.send(payload);
+        } catch (error) {
+          clearTimeout(timer);
+          internalPending.delete(id);
+          reject(error);
+        }
+      });
+    },
+
+    /** Route protocol traffic into the harness once its callbacks are installed. */
+    bind(egoRuntime) {
+      runtime = egoRuntime;
+    },
+
+    close() {
+      runtime = null;
+      try {
+        socket.close();
+      } catch {
+        // already gone
+      }
+    },
+  };
+}

--- a/package/ego-linux/src/window-fit.mjs
+++ b/package/ego-linux/src/window-fit.mjs
@@ -1,0 +1,107 @@
+/**
+ * Keep the browser window the size of the viewport the agent is emulating.
+ *
+ * Emulation.setDeviceMetricsOverride changes the page's viewport and nothing
+ * else, so an agent working at a phone width renders a 390px layout inside a
+ * 1280px window — a narrow strip of site with a wide band of empty chrome
+ * beside it. Watching someone work like that is the problem: it looks broken,
+ * and screenshots of it are mostly blank.
+ *
+ * Resizing is best-effort and deliberately quiet. It is cosmetic, it races the
+ * agent's own actions, and no automation result may depend on it. CDP input
+ * carries emulated-viewport coordinates, not screen coordinates, so a resize
+ * landing mid-action cannot move a click.
+ */
+
+/** Chrome's own frame around the page: tab strip, toolbar, bookmarks. */
+const CHROME_HEIGHT = 132;
+
+/**
+ * Windows narrower than this are not worth following: Chrome clamps very small
+ * widths anyway, and a sliver of a window is harder to watch than a wide one.
+ */
+const MIN_WIDTH = 360;
+
+/** At or above this the emulation is desktop-shaped; the window goes back. */
+const DESKTOP_WIDTH = 1000;
+
+export function createWindowFit(cdp) {
+  let applied = null;
+  // The size the window had before the first shrink, so leaving a phone
+  // viewport can put it back. Without this the window stays phone-shaped for
+  // the rest of the session — the emulation ends, the narrow window does not.
+  let original = null;
+
+  async function windowFor(targetId) {
+    const { windowId } = await cdp.call("Browser.getWindowForTarget", { targetId });
+    return windowId;
+  }
+
+  async function restore(targetId) {
+    if (!original) return;
+    try {
+      const windowId = await windowFor(targetId);
+      await cdp.call("Browser.setWindowBounds", {
+        windowId,
+        bounds: { ...original, windowState: "normal" },
+      });
+      original = null;
+      applied = null;
+    } catch {
+      // Same rule as shrinking: cosmetic, never fatal.
+    }
+  }
+
+  return {
+    /**
+     * @param {{width?: number, height?: number, mobile?: boolean}} metrics
+     * @param {string|null} targetId The tab the emulation applies to.
+     */
+    async follow(metrics, targetId) {
+      if (!targetId) return;
+      const width = Number(metrics?.width);
+      const height = Number(metrics?.height);
+
+      // Clearing the override (0x0) or emulating a desktop both mean "stop
+      // being phone-shaped".
+      const emulatingPhone =
+        Number.isFinite(width) &&
+        Number.isFinite(height) &&
+        width >= MIN_WIDTH &&
+        width < DESKTOP_WIDTH;
+
+      if (!emulatingPhone) {
+        await restore(targetId);
+        return;
+      }
+
+      const key = `${targetId}:${width}x${height}`;
+      if (key === applied) return;
+
+      try {
+        const windowId = await windowFor(targetId);
+        if (!original) {
+          const { bounds } = await cdp.call("Browser.getWindowBounds", { windowId });
+          if (bounds) {
+            original = { left: bounds.left, top: bounds.top, width: bounds.width, height: bounds.height };
+          }
+        }
+        await cdp.call("Browser.setWindowBounds", {
+          windowId,
+          bounds: {
+            width: Math.round(width),
+            height: Math.round(height + CHROME_HEIGHT),
+            windowState: "normal",
+          },
+        });
+        // Only now: a resize that failed has to be retryable, and marking it
+        // done beforehand would wedge the window at whatever size it was.
+        applied = key;
+      } catch {
+        // A tab that closed, a window the compositor refuses to resize, a
+        // headless browser with no window at all — none of it is a failure of
+        // the action the agent was performing.
+      }
+    },
+  };
+}

--- a/package/ego-linux/test/agent-identity.test.mjs
+++ b/package/ego-linux/test/agent-identity.test.mjs
@@ -1,0 +1,97 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { agentIdentity } from "../src/agent-identity.mjs";
+
+const MARKER = "/.config/cue/runtime/";
+
+/**
+ * Run a case against a controlled environment.
+ *
+ * agentIdentity reads the ambient environment, and this suite runs inside
+ * exactly the kind of session it is built to detect — on a cue-managed machine
+ * the real profile would leak into every assertion. So each case starts from an
+ * environment with the marker, the session id and the panel flag stripped out.
+ */
+function withEnv(overrides, run) {
+  const saved = { ...process.env };
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value === "string" && value.includes(MARKER)) delete process.env[key];
+  }
+  delete process.env.CLAUDE_CODE_SESSION_ID;
+  delete process.env.EGO_LINUX_PANEL;
+  Object.assign(process.env, overrides);
+  try {
+    return run();
+  } finally {
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, saved);
+  }
+}
+
+describe("agent identity", () => {
+  it("names the cue profile that launched the session", () => {
+    const identity = withEnv(
+      { CLAUDE_CONFIG_DIR: "/home/someone/.config/cue/runtime/coolify/claude" },
+      () => agentIdentity("/tmp"),
+    );
+    assert.equal(identity.profile, "coolify");
+  });
+
+  it("falls back to a .cue.profile pin, walking up from the working directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ego-identity-"));
+    const nested = join(root, "project", "packages", "app");
+    await mkdir(nested, { recursive: true });
+    await writeFile(join(root, ".cue.profile"), "medusa\n");
+
+    const identity = withEnv({}, () => agentIdentity(nested));
+    assert.equal(identity.profile, "medusa");
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("prefers the launching profile over a pin file", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ego-identity-"));
+    await writeFile(join(root, ".cue.profile"), "pinned\n");
+
+    const identity = withEnv(
+      { CLAUDE_CONFIG_DIR: "/home/someone/.config/cue/runtime/coolify/claude" },
+      () => agentIdentity(root),
+    );
+    assert.equal(identity.profile, "coolify", "the live session wins over a directory default");
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("claims nothing for the panel's own daemon", () => {
+    // The daemon inherits whichever session started it, but a space created by
+    // hand from the panel is the user's — attributing it would be a lie.
+    const identity = withEnv(
+      {
+        EGO_LINUX_PANEL: "1",
+        CLAUDE_CONFIG_DIR: "/home/someone/.config/cue/runtime/coolify/claude",
+        CLAUDE_CODE_SESSION_ID: "dae81a3c-1f45-417f",
+      },
+      () => agentIdentity("/tmp"),
+    );
+    assert.deepEqual(identity, { profile: null, session: null });
+  });
+
+  it("shortens the session id to something a card can show", () => {
+    const identity = withEnv(
+      { CLAUDE_CODE_SESSION_ID: "dae81a3c-1f45-417f-9f27-759398198057" },
+      () => agentIdentity("/tmp"),
+    );
+    assert.equal(identity.session, "dae81a3c");
+  });
+
+  it("reports nothing rather than guessing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ego-identity-"));
+    const identity = withEnv({}, () => agentIdentity(root));
+    assert.deepEqual(identity, { profile: null, session: null });
+    await rm(root, { recursive: true, force: true });
+  });
+});

--- a/package/ego-linux/test/blank-anchor.test.mjs
+++ b/package/ego-linux/test/blank-anchor.test.mjs
@@ -1,0 +1,113 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SANDBOX = await mkdtemp(join(tmpdir(), "ego-anchor-test-"));
+process.env.XDG_STATE_HOME = join(SANDBOX, "state");
+process.env.EGO_LINUX_SPACE_IDLE_MIN = "0";
+
+const { STATE_DIR, TASK_SPACE_FILE } = await import("../src/paths.mjs");
+const { createTaskSpacesApi } = await import("../src/task-spaces.mjs");
+
+/** A browser holding one tab for the space, at whatever url the test sets. */
+function fakeCdp(anchorUrl) {
+  const calls = [];
+  return {
+    calls,
+    async call(method, params) {
+      calls.push({ method, params });
+      if (method === "Target.getTargets") {
+        return {
+          targetInfos: [
+            { type: "page", targetId: "anchor", url: anchorUrl, browserContextId: "ctx" },
+          ],
+        };
+      }
+      if (method === "Target.attachToTarget") return { sessionId: "s1" };
+      if (method === "Target.createTarget") return { targetId: "fresh-tab" };
+      return {};
+    },
+  };
+}
+
+const tabsApi = (cdp) => ({
+  async createTab(url, browserContextId) {
+    return cdp.call("Target.createTarget", { url, browserContextId });
+  },
+});
+
+async function seed(space) {
+  await mkdir(STATE_DIR, { recursive: true });
+  await writeFile(
+    TASK_SPACE_FILE,
+    JSON.stringify({ spaces: [space], selectedId: 1, nextId: 2 }),
+  );
+}
+
+const baseSpace = {
+  id: 1,
+  taskId: 1,
+  name: "work",
+  createdAt: Date.now(),
+  touchedAt: Date.now(),
+  ownership: "agent",
+  browserContextId: "ctx",
+  targetIds: ["anchor"],
+};
+
+describe("the space's blank anchor tab is used, not stranded", () => {
+  it("navigates the anchor instead of opening a second tab", async () => {
+    await seed({ ...baseSpace });
+    const cdp = fakeCdp("about:blank");
+    const api = createTaskSpacesApi(cdp);
+
+    const result = await api.createTabInSelectedSpace(
+      tabsApi(cdp),
+      "https://example.com",
+    );
+
+    assert.equal(result.targetId, "anchor", "the anchor is what comes back");
+    assert.ok(
+      cdp.calls.some(
+        (c) => c.method === "Page.navigate" && c.params.url === "https://example.com",
+      ),
+      "the anchor is navigated",
+    );
+    assert.ok(
+      !cdp.calls.some((c) => c.method === "Target.createTarget"),
+      "and no second tab is opened — this is the blank tab people were seeing",
+    );
+  });
+
+  it("opens a new tab once the space has started work", async () => {
+    // A tab is about:blank for a moment during every navigation, so reusing on
+    // url alone would hijack a tab already carrying work. lastContentAt is what
+    // separates "not started" from "between pages".
+    await seed({ ...baseSpace, lastContentAt: Date.now() });
+    const cdp = fakeCdp("about:blank");
+    const api = createTaskSpacesApi(cdp);
+
+    const result = await api.createTabInSelectedSpace(
+      tabsApi(cdp),
+      "https://example.com",
+    );
+
+    assert.equal(result.targetId, "fresh-tab");
+    assert.ok(!cdp.calls.some((c) => c.method === "Page.navigate"));
+  });
+
+  it("opens a new tab when the anchor already holds a page", async () => {
+    await seed({ ...baseSpace });
+    const cdp = fakeCdp("https://already.example");
+    const api = createTaskSpacesApi(cdp);
+
+    const result = await api.createTabInSelectedSpace(
+      tabsApi(cdp),
+      "https://example.com",
+    );
+
+    assert.equal(result.targetId, "fresh-tab", "an occupied tab is never taken");
+  });
+});

--- a/package/ego-linux/test/crash-mark.test.mjs
+++ b/package/ego-linux/test/crash-mark.test.mjs
@@ -1,0 +1,76 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { clearStaleCrashMark } from "../src/chrome.mjs";
+
+/**
+ * Build a profile directory whose Preferences carry the given profile block.
+ *
+ * No browser is launched here on purpose. The end-to-end effect needs a real
+ * Chrome and is therefore sensitive to machine load — what has to be exact is
+ * the rule itself: a profile that starts out marked never clears the mark on
+ * its own, so the launcher must clear it before Chrome reads it.
+ */
+async function profileWith(profileBlock) {
+  const dir = await mkdtemp(join(tmpdir(), "ego-crash-mark-"));
+  await mkdir(join(dir, "Default"), { recursive: true });
+  if (profileBlock !== undefined) {
+    await writeFile(
+      join(dir, "Default", "Preferences"),
+      JSON.stringify({ profile: profileBlock, bookmark_bar: { show_on_all_tabs: true } }),
+    );
+  }
+  return dir;
+}
+
+async function exitTypeOf(dir) {
+  return JSON.parse(await readFile(join(dir, "Default", "Preferences"), "utf8")).profile?.exit_type;
+}
+
+describe("clearStaleCrashMark", () => {
+  it("clears a mark left by an ungraceful kill", async () => {
+    const dir = await profileWith({ exit_type: "Crashed", name: "ego lite — agent" });
+    try {
+      assert.equal(await clearStaleCrashMark(dir), true, "reports that it changed something");
+      assert.equal(await exitTypeOf(dir), "Normal");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps every other preference intact", async () => {
+    const dir = await profileWith({ exit_type: "Crashed", name: "ego lite — agent", avatar_index: 26 });
+    try {
+      await clearStaleCrashMark(dir);
+      const prefs = JSON.parse(await readFile(join(dir, "Default", "Preferences"), "utf8"));
+      assert.equal(prefs.profile.name, "ego lite — agent", "sibling keys survive");
+      assert.equal(prefs.profile.avatar_index, 26);
+      assert.deepEqual(prefs.bookmark_bar, { show_on_all_tabs: true }, "other top-level blocks survive");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves an unmarked profile untouched", async () => {
+    const dir = await profileWith({ exit_type: "Normal" });
+    try {
+      const before = await readFile(join(dir, "Default", "Preferences"), "utf8");
+      assert.equal(await clearStaleCrashMark(dir), false, "reports that it changed nothing");
+      assert.equal(await readFile(join(dir, "Default", "Preferences"), "utf8"), before);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("is a no-op on a profile that has no Preferences yet", async () => {
+    const dir = await profileWith(undefined);
+    try {
+      assert.equal(await clearStaleCrashMark(dir), false, "a fresh profile is not an error");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/package/ego-linux/test/cursor-navigation.test.mjs
+++ b/package/ego-linux/test/cursor-navigation.test.mjs
@@ -1,0 +1,97 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { createCursorApi } from "../src/cursor.mjs";
+
+/** Records what the cursor asks of CDP, and hands back the shim event hooks. */
+function fakeCdp() {
+  const calls = [];
+  const events = new Map();
+  const claimed = [];
+  return {
+    calls,
+    events,
+    claimed,
+    attachedHint: () => "target-1",
+    onShimEvent(method, handler) {
+      events.set(method, handler);
+    },
+    claimSession(sessionId) {
+      claimed.push(sessionId);
+    },
+    async call(method, params, sessionId) {
+      calls.push({ method, params, sessionId });
+      if (method === "Target.attachToTarget") return { sessionId: "session-1" };
+      return {};
+    },
+  };
+}
+
+/** The payload each render carries, pulled back out of the injected expression. */
+function renderedPayloads(cdp) {
+  return cdp.calls
+    .filter((call) => call.method === "Runtime.evaluate")
+    .map((call) => {
+      const source = call.params.expression;
+      const json = source.slice(source.lastIndexOf(")(") + 2, -1);
+      return JSON.parse(json);
+    });
+}
+
+const listTabs = async () => ({
+  tabs: [{ targetId: "target-1", active: true }],
+});
+
+describe("the cursor survives a navigation", () => {
+  it("subscribes to loads, and redraws when one fires", async () => {
+    const cdp = fakeCdp();
+    const cursor = createCursorApi(cdp, { listTabs });
+
+    assert.ok(
+      cdp.events.has("Page.loadEventFired"),
+      "a load handler is registered up front",
+    );
+
+    await cursor.watchPage();
+    assert.deepEqual(cdp.claimed, ["session-1"], "the session is claimed");
+    assert.ok(
+      cdp.calls.some((c) => c.method === "Page.enable"),
+      "and Page is enabled, or the load event never arrives",
+    );
+
+    const before = renderedPayloads(cdp).length;
+    // A navigation replaces the document the overlay lives in. This is the
+    // event that has to put it back.
+    cdp.events.get("Page.loadEventFired")();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const drawn = renderedPayloads(cdp);
+    assert.ok(drawn.length > before, "the load triggers a render");
+
+    const last = drawn[drawn.length - 1];
+    assert.equal(last.visible, true, "and the overlay is visible");
+    assert.equal(
+      last.placed,
+      true,
+      "placed, so an untouched page still shows the cursor",
+    );
+    assert.equal(last.read, null, "any read from the old document is dropped");
+  });
+
+  it("claims each session once, however many renders happen", async () => {
+    const cdp = fakeCdp();
+    const cursor = createCursorApi(cdp, { listTabs });
+
+    await cursor.watchPage();
+    await cursor.watchPage();
+    cursor.moveTo(10, 10);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    assert.deepEqual(cdp.claimed, ["session-1"]);
+    assert.equal(
+      cdp.calls.filter((c) => c.method === "Page.enable").length,
+      1,
+      "Page.enable is not re-sent on every render",
+    );
+  });
+});

--- a/package/ego-linux/test/cursor.js
+++ b/package/ego-linux/test/cursor.js
@@ -1,0 +1,211 @@
+const fixture = process.env.FIXTURE_URL;
+const HOST = "document.getElementById('ego-agent-cursor-overlay')";
+const SHADOW = `${HOST}.__egoShadow`;
+const probe = (expression) => page.evaluate(expression);
+
+await page.goto(fixture);
+await page.waitForLoadState();
+
+const center = await page.elementCenter("loc=css:#click-button");
+await page.mouse.click(center.x, center.y, { label: "counting" });
+
+// The overlay is drawn fire-and-forget so it can never delay an action, which
+// means the injection may still be in flight when the click returns.
+for (let attempt = 0; attempt < 40; attempt += 1) {
+  if (await probe(`!!${HOST}`)) break;
+  await page.waitForTimeout(50);
+}
+
+console.log("1. overlay present:      " + (await probe(`!!${HOST}`)));
+
+const transform = await probe(`${SHADOW}.getElementById('pointer').style.transform`);
+// Drop the function name before reading the numbers — translate3d carries a 3.
+const args = String(transform).replace(/^[^(]*\(/, "");
+const [x, y] = (args.match(/-?[\d.]+/g) || []).map(Number);
+console.log(
+  "2. cursor tracks click:  " +
+    (Math.abs(x - center.x) < 1 && Math.abs(y - center.y) < 1) +
+    ` (${transform} vs ${center.x},${center.y})`,
+);
+
+console.log("3. badge text:           " + (await probe(`${SHADOW}.getElementById('text').textContent`)));
+
+// The load-bearing property: pointer-events:none, so the harness's own
+// elementFromPoint hit-tests (wheel and drag fallbacks) still see the page.
+console.log("4. hit test at cursor:   " + (await probe(`document.elementFromPoint(${center.x}, ${center.y}).id`)));
+console.log("5. click still landed:   " + (await probe("document.getElementById('count').textContent")));
+
+const snap = await page.snapshotRaw({ scope: "full_page" });
+console.log("6. overlay in snapshot:  " + snap.content.includes("ego-agent-cursor"));
+
+// A wheel carries coordinates that default to (0, 0) but moves no pointer:
+// following them would snap the cursor into the corner on every scroll.
+// The move first is not decoration: the snapshot above started a read sweep,
+// which walks the cursor along the page for its own reasons, and this would
+// otherwise measure that instead of the wheel.
+await page.mouse.move(center.x, center.y);
+await page.waitForTimeout(300);
+const beforeWheel = await probe(`${SHADOW}.getElementById('pointer').style.transform`);
+await page.mouse.wheel(0, 200);
+await page.waitForTimeout(200);
+const afterScroll = await probe(`${SHADOW}.getElementById('pointer').style.transform`);
+console.log("7. cursor held on wheel: " + (afterScroll === beforeWheel));
+
+// Press and release are asserted apart, because a click's own press lasts 25ms
+// — the held floor is what makes it visible, not something a test can catch.
+const pressState = () => probe(`${SHADOW}.getElementById('pointer').className`);
+await page.mouse.move(center.x, center.y);
+await page.mouse.down();
+await page.waitForTimeout(80);
+console.log("8. pressed on down:      " + ((await pressState()) === "press"));
+
+await page.mouse.up();
+await page.waitForTimeout(400);
+console.log("9. released on up:       " + ((await pressState()) === ""));
+
+// The cursor marks the element it is working on, so it has to travel with that
+// element when the page scrolls — not stay pinned to the screen.
+const onScreen = () =>
+  probe(`(() => {
+    const r = ${SHADOW}.getElementById('arrow').getBoundingClientRect();
+    return Math.round(r.top);
+  })()`);
+// The fixture is shorter than the viewport, so give it somewhere to scroll to.
+await page.evaluate("document.body.style.minHeight = '2400px'");
+const beforeScroll = await onScreen();
+await page.evaluate("window.scrollTo(0, 220)");
+await page.waitForTimeout(250);
+const afterScrollTop = await onScreen();
+console.log(
+  "10. travels with page:   " +
+    (Math.abs(beforeScroll - afterScrollTop - 220) <= 2) +
+    ` (${beforeScroll} -> ${afterScrollTop})`,
+);
+await page.evaluate("window.scrollTo(0, 0)");
+await page.waitForTimeout(250);
+
+// The shape and the label both come from whatever is under the cursor.
+const shownShape = () =>
+  probe(`[...${SHADOW}.querySelectorAll('svg.shape.on')].map(s => s.id).join()`);
+const badgeText = () => probe(`${SHADOW}.getElementById('text').textContent`);
+
+// A plain <button> is `cursor: default` in every browser — the link is what
+// actually asks for a hand, and the overlay follows the page rather than
+// inventing its own idea of what looks clickable.
+const link = await page.elementCenter("loc=css:a");
+await page.mouse.move(link.x, link.y);
+await page.waitForTimeout(200);
+console.log("11. hand over a link:    " + (await shownShape()));
+console.log("12. names what it is on: " + (await badgeText()));
+
+const field = await page.elementCenter("loc=css:#name-input");
+await page.mouse.move(field.x, field.y);
+await page.waitForTimeout(200);
+console.log("13. beam over a field:   " + (await shownShape()));
+
+// fill() dispatches no pointer event, so this is the one action that would
+// otherwise happen entirely unannounced.
+await page.locator("#name-input").fill("Ada");
+await page.waitForTimeout(200);
+console.log("14. says it is typing:   " + (await badgeText()));
+console.log("15. marks the field:     " + (await probe(`${SHADOW}.getElementById('ring').className`)));
+await page.waitForTimeout(1000);
+console.log("16. lets go when done:   " + (await probe(`${SHADOW}.getElementById('ring').className`) === ""));
+
+// The highlighter: a marker an agent draws to explain something, rather than a
+// real selection, which would fight its own work on the page.
+const bandCount = () => probe(`${SHADOW}.getElementById('bands').children.length`);
+const byText = await ego.highlight("must survive the snapshot", { note: "explaining this" });
+await page.waitForTimeout(500);
+console.log("17. highlight lines:     " + byText.lines);
+console.log("18. bands drawn:         " + (await bandCount()));
+console.log("19. note in badge:       " + (await badgeText()));
+
+await ego.highlight("h1", { note: "the heading" });
+await page.waitForTimeout(600);
+console.log(
+  "20. band matches text:   " +
+    (await probe(`(() => {
+      const range = document.createRange();
+      range.selectNodeContents(document.querySelector('h1'));
+      const want = range.getBoundingClientRect();
+      const band = ${SHADOW}.getElementById('bands').children[0].getBoundingClientRect();
+      return Math.round(Math.abs(band.width - want.width)) + ',' + Math.round(Math.abs(band.left - want.left));
+    })()`)),
+);
+
+const miss = await ego.highlight("no such words appear anywhere on this page");
+console.log("21. miss draws nothing:  " + (miss.done === false && miss.lines === 0));
+
+await ego.clearHighlight();
+await page.waitForTimeout(200);
+console.log("22. cleared:             " + ((await bandCount()) === 0));
+
+// Reading is most of what an agent does and it dispatches no input at all, so
+// a sweep is the only thing that tells a watcher what was taken in. It runs
+// itself inside the page, which is why this waits rather than awaits.
+await page.snapshotRaw({ scope: "full_page" });
+await page.waitForTimeout(300);
+console.log("23. says what it reads:  " + (await badgeText()));
+console.log("24. marks the lines:     " + ((await bandCount()) > 0));
+
+// Real input outranks the narration of a read that has already happened —
+// including a move back to where the harness last left the cursor.
+await page.mouse.move(center.x, center.y);
+await page.waitForTimeout(150);
+const sweepDone = await probe(`document.getElementById('ego-agent-cursor-overlay').__egoSweep.done`);
+console.log("25. input ends the read: " + sweepDone);
+
+// The trail the Spaces panel reads: transitions, not events, so a burst of
+// keystrokes is one entry rather than sixty.
+const trail = await probe(`(() => {
+  const log = document.getElementById('ego-agent-cursor-overlay').__egoLog || [];
+  return log.map(e => e.text).join(' | ');
+})()`);
+console.log("26. trail:               " + trail);
+
+// The cursor marks the element it is working on, so a long scroll carries it
+// off the screen entirely — and the window went blank while the agent worked.
+// The badge is what stays behind, docked to the edge and pointing back at it.
+await page.evaluate("document.body.style.minHeight = '3000px'");
+await page.mouse.move(center.x, center.y);
+await page.waitForTimeout(250);
+await page.evaluate("window.scrollTo(0, 1400)");
+await page.waitForTimeout(250);
+const docked = JSON.parse(
+  await probe(`(() => {
+    const badge = ${SHADOW}.getElementById('badge').getBoundingClientRect();
+    const arrow = ${SHADOW}.getElementById('arrow').getBoundingClientRect();
+    return JSON.stringify({
+      gone: arrow.bottom < 0,
+      onScreen:
+        badge.top >= 0 && badge.left >= 0 &&
+        badge.bottom <= innerHeight && badge.right <= innerWidth,
+      hint: ${SHADOW}.getElementById('hint').textContent,
+      // Being in the right place is not the same as being drawn there. The
+      // pointer is a composited layer sitting at a page coordinate, and one
+      // scrolled out of view is not rasterised at all — a badge parented to it
+      // measures perfectly and paints nothing.
+      independent: !${SHADOW}.getElementById('pointer')
+        .contains(${SHADOW}.getElementById('badge')),
+    });
+  })()`),
+);
+console.log("27. cursor leaves view:  " + docked.gone);
+console.log("28. badge stays in it:   " + docked.onScreen);
+console.log("29. and points back:     " + docked.hint);
+console.log("30. drawn independently: " + docked.independent);
+
+// A nudge between two fields and a jump across the page should not take the
+// same time; one duration for both made the first crawl and the second snap.
+await page.evaluate("window.scrollTo(0, 0)");
+await page.waitForTimeout(250);
+const moveFor = async (x, y) => {
+  await page.mouse.move(x, y);
+  await page.waitForTimeout(80);
+  return parseInt(await probe(`${SHADOW}.getElementById('pointer').style.transitionDuration`), 10);
+};
+await moveFor(center.x, center.y);
+const near = await moveFor(center.x + 6, center.y);
+const far = await moveFor(30, 30);
+console.log("31. motion scales:       " + (near < far) + ` (${near}ms vs ${far}ms)`);

--- a/package/ego-linux/test/endpoint.test.mjs
+++ b/package/ego-linux/test/endpoint.test.mjs
@@ -1,0 +1,74 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { waitForEndpoint } from "../src/chrome.mjs";
+
+const PORT_FILE = "DevToolsActivePort";
+
+/** Chrome's port file: the port on the first line, the browser path on the second. */
+function portFile(port) {
+  return `${port}\n/devtools/browser/8f1c0b7e-0000-4000-8000-000000000000\n`;
+}
+
+/** Stand in for Chrome's /json/version endpoint. */
+async function startFakeDevTools() {
+  const server = createServer((req, res) => {
+    if (req.url !== "/json/version") {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    const { port } = server.address();
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ webSocketDebuggerUrl: `ws://127.0.0.1:${port}/devtools/browser/fake` }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return { server, port: server.address().port };
+}
+
+/** A port number nothing listens on — bound to learn a free one, then released. */
+async function deadPort() {
+  const { server, port } = await startFakeDevTools();
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+describe("waitForEndpoint", () => {
+  it("keeps probing when Chrome rewrites its port file", async () => {
+    const profileDir = await mkdtemp(join(tmpdir(), "ego-endpoint-"));
+    // A launch that loses the ProcessSingleton race publishes a port that never
+    // listens; the process that survives rewrites the file a beat later. Probing
+    // only the first value read is the bug this guards.
+    await writeFile(join(profileDir, PORT_FILE), portFile(await deadPort()));
+    const live = await startFakeDevTools();
+    const rewrite = setTimeout(() => {
+      writeFile(join(profileDir, PORT_FILE), portFile(live.port)).catch(() => {});
+    }, 400);
+
+    try {
+      const endpoint = await waitForEndpoint(profileDir, { timeoutMs: 8000 });
+      assert.equal(endpoint.port, live.port, "returns the port that actually answers");
+      assert.match(endpoint.wsUrl, /^ws:\/\/127\.0\.0\.1:\d+\/devtools\/browser\//);
+    } finally {
+      clearTimeout(rewrite);
+      await new Promise((resolve) => live.server.close(resolve));
+      await rm(profileDir, { recursive: true, force: true });
+    }
+  });
+
+  it("names the port it could not reach when it gives up", async () => {
+    const profileDir = await mkdtemp(join(tmpdir(), "ego-endpoint-"));
+    const dead = await deadPort();
+    await writeFile(join(profileDir, PORT_FILE), portFile(dead));
+
+    try {
+      await assert.rejects(() => waitForEndpoint(profileDir, { timeoutMs: 1200 }), new RegExp(String(dead)));
+    } finally {
+      await rm(profileDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/package/ego-linux/test/exit.test.mjs
+++ b/package/ego-linux/test/exit.test.mjs
@@ -1,0 +1,101 @@
+import { after, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BIN = join(HERE, "..", "bin", "ego-browser.mjs");
+
+// Its own profile and state dir, so `npm test` never stops the browser an agent
+// session is currently driving.
+const SANDBOX = await mkdtemp(join(tmpdir(), "ego-exit-test-"));
+const TEST_ENV = {
+  XDG_STATE_HOME: join(SANDBOX, "state"),
+  EGO_LINUX_PROFILE: join(SANDBOX, "profile"),
+};
+const PREFERENCES = join(SANDBOX, "profile", "Default", "Preferences");
+const BROWSER_STATE = join(SANDBOX, "state", "ego-lite-linux", "browser.json");
+
+function runCli(args, { stdin = null, timeout = 120000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [BIN, ...args], {
+      env: { ...process.env, ...TEST_ENV },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`timed out after ${timeout}ms\n${stdout}\n${stderr}`));
+    }, timeout);
+    child.stdout.on("data", (c) => (stdout += c));
+    child.stderr.on("data", (c) => (stderr += c));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) reject(new Error(`exit ${code}\n${stdout}\n${stderr}`));
+      else resolve(stdout);
+    });
+    if (stdin === null) child.stdin.end();
+    else child.stdin.end(stdin);
+  });
+}
+
+/**
+ * Chrome stamps exit_type "Crashed" while it runs and rewrites it to "Normal"
+ * only on a graceful exit, so this is the same signal that decides whether the
+ * next launch greets the user with "Restore pages?".
+ */
+async function readExitType() {
+  try {
+    return JSON.parse(await readFile(PREFERENCES, "utf8")).profile?.exit_type ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function waitForExitType(want, timeoutMs = 10000) {
+  const deadline = Date.now() + timeoutMs;
+  let seen = null;
+  while (Date.now() < deadline) {
+    seen = await readExitType();
+    if (seen === want) return seen;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return seen;
+}
+
+after(async () => {
+  try {
+    const state = JSON.parse(await readFile(BROWSER_STATE, "utf8"));
+    if (state.pid) process.kill(state.pid, "SIGTERM");
+  } catch {
+    // nothing running
+  }
+  await new Promise((r) => setTimeout(r, 1000));
+  await rm(SANDBOX, { recursive: true, force: true, maxRetries: 5, retryDelay: 300 }).catch(() => {});
+});
+
+describe("stopping the backing browser", () => {
+  it("exits cleanly, so the next launch offers no crash restore", async () => {
+    await runCli(["--headless"], { stdin: 'console.log("tabs=" + (await browser.listTabs()).length)' });
+    // Chrome writes Preferences a beat after start, so this is the precondition
+    // the real assertion below depends on, not a race of its own.
+    assert.equal(
+      await waitForExitType("Crashed", 20000),
+      "Crashed",
+      "Chrome marks a running profile as Crashed",
+    );
+
+    await runCli(["--stop"]);
+
+    assert.equal(
+      await waitForExitType("Normal"),
+      "Normal",
+      "a SIGTERMed Chrome leaves exit_type Crashed, which is what triggers the Restore pages bubble",
+    );
+  });
+});

--- a/package/ego-linux/test/fixture/deep.html
+++ b/package/ego-linux/test/fixture/deep.html
@@ -1,0 +1,4 @@
+<meta charset="utf-8" />
+<title>deep frame</title>
+<p>Deeply nested iframe content</p>
+<button id="deep-button">Deep button</button>

--- a/package/ego-linux/test/fixture/frame.html
+++ b/package/ego-linux/test/fixture/frame.html
@@ -1,0 +1,5 @@
+<meta charset="utf-8" />
+<title>inner frame</title>
+<h2>Inside the iframe</h2>
+<button id="frame-button">Frame button</button>
+<iframe src="./deep.html" title="deep frame" width="300" height="100"></iframe>

--- a/package/ego-linux/test/fixture/index.html
+++ b/package/ego-linux/test/fixture/index.html
@@ -1,0 +1,26 @@
+<meta charset="utf-8" />
+<title>ego linux port fixture</title>
+<h1>Helper e2e fixture</h1>
+<p>Some intro text that must survive the snapshot.</p>
+
+<button id="click-button" onclick="document.getElementById('count').textContent = 'clicked'">
+  Increment counter
+</button>
+<span id="count">0</span>
+
+<label for="name-input">Your name</label>
+<input id="name-input" type="text" placeholder="type a name" />
+
+<input type="checkbox" id="agree" checked />
+<label for="agree">I agree</label>
+
+<a href="/nav-target">Go to nav target</a>
+
+<select id="pick">
+  <option>alpha</option>
+  <option>beta</option>
+</select>
+
+<div style="display: none">hidden text must not appear</div>
+
+<iframe src="./frame.html" title="nested frame" width="400" height="200"></iframe>

--- a/package/ego-linux/test/idle-close-trail.test.mjs
+++ b/package/ego-linux/test/idle-close-trail.test.mjs
@@ -1,0 +1,106 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SANDBOX = await mkdtemp(join(tmpdir(), "ego-trail-test-"));
+process.env.XDG_STATE_HOME = join(SANDBOX, "state");
+
+const { STATE_DIR, TASK_SPACE_FILE } = await import("../src/paths.mjs");
+const { createTaskSpacesApi } = await import("../src/task-spaces.mjs");
+
+const MINUTE = 60000;
+
+function fakeCdp() {
+  return {
+    async call(method) {
+      if (method === "Target.getTargets") {
+        return {
+          targetInfos: [
+            { type: "page", targetId: "t-1", url: "https://foxglove.example/a" },
+          ],
+        };
+      }
+      if (method === "Target.createTarget") return { targetId: "new-tab" };
+      if (method === "Target.createBrowserContext") return { browserContextId: "ctx" };
+      return {};
+    },
+  };
+}
+
+async function seedIdleSpace() {
+  const at = Date.now() - 90 * MINUTE;
+  await mkdir(STATE_DIR, { recursive: true });
+  await writeFile(
+    TASK_SPACE_FILE,
+    JSON.stringify({
+      spaces: [
+        {
+          id: 1,
+          taskId: 1,
+          name: "long running work",
+          createdAt: at,
+          touchedAt: at,
+          lastContentAt: at,
+          ownership: "agent",
+          targetIds: ["t-1"],
+          urls: ["https://foxglove.example/a", "about:blank"],
+        },
+      ],
+      selectedId: null,
+      nextId: 2,
+      closedSpaces: [],
+    }),
+  );
+}
+
+describe("an idle-closed space leaves something to come back to", () => {
+  it("records what it held when the sweep closes it", async () => {
+    process.env.EGO_LINUX_SPACE_IDLE_MIN = "30";
+    await seedIdleSpace();
+
+    await createTaskSpacesApi(fakeCdp()).listTaskSpaces();
+
+    const state = JSON.parse(await readFile(TASK_SPACE_FILE, "utf8"));
+    assert.equal(state.spaces.length, 0, "the space is closed");
+    assert.equal(state.closedSpaces.length, 1, "and remembered");
+
+    const [closure] = state.closedSpaces;
+    assert.equal(closure.name, "long running work");
+    assert.deepEqual(
+      closure.urls,
+      ["https://foxglove.example/a"],
+      "about:blank is not worth handing back",
+    );
+    assert.ok(closure.idleMinutes >= 89, "with how long it had sat");
+  });
+
+  it("hands that back to whoever asks for the name again", async () => {
+    process.env.EGO_LINUX_SPACE_IDLE_MIN = "30";
+    await seedIdleSpace();
+    const api = createTaskSpacesApi(fakeCdp());
+    await api.listTaskSpaces();
+
+    // What useOrCreate does once it cannot find the name it was given.
+    const space = await api.createTaskSpace("long running work");
+
+    assert.ok(space.previously, "the new space knows it is a replacement");
+    assert.deepEqual(space.previously.urls, ["https://foxglove.example/a"]);
+    assert.match(space.previously.note, /closed after \d+ minutes idle/);
+    assert.match(space.previously.note, /this is a new, empty one/);
+
+    // Reported once: a later space of the same name is simply a new space.
+    const again = await api.createTaskSpace("long running work");
+    assert.equal(again.previously, undefined);
+  });
+
+  it("says nothing for a name that was never closed", async () => {
+    process.env.EGO_LINUX_SPACE_IDLE_MIN = "0";
+    await seedIdleSpace();
+    const api = createTaskSpacesApi(fakeCdp());
+
+    const space = await api.createTaskSpace("something else entirely");
+    assert.equal(space.previously, undefined);
+  });
+});

--- a/package/ego-linux/test/idle-sweep.test.mjs
+++ b/package/ego-linux/test/idle-sweep.test.mjs
@@ -1,0 +1,160 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Its own state dir, for the reason the other suites have one: `npm test` must
+// not read — or sweep — the task spaces a real session is driving.
+const SANDBOX = await mkdtemp(join(tmpdir(), "ego-idle-test-"));
+process.env.XDG_STATE_HOME = join(SANDBOX, "state");
+
+// Imported after that assignment: paths.mjs resolves its directories at module
+// load, so a static import would bind the real ones first.
+const { STATE_DIR, TASK_SPACE_FILE } = await import("../src/paths.mjs");
+const { createTaskSpacesApi } = await import("../src/task-spaces.mjs");
+
+const MINUTE = 60000;
+
+/** Both spaces' tabs are alive, so nothing but the idle rule can remove them. */
+function fakeCdp(closed) {
+  return {
+    async call(method, params) {
+      if (method === "Target.getTargets") {
+        return {
+          targetInfos: [
+            { type: "page", targetId: "t-live", url: "https://example.com/a" },
+            { type: "page", targetId: "t-idle", url: "https://example.com/b" },
+          ],
+        };
+      }
+      if (method === "Target.closeTarget") closed.push(params.targetId);
+      return {};
+    },
+  };
+}
+
+function space(id, targetId, touchedAt) {
+  const at = Date.now() - 90 * MINUTE;
+  return {
+    id,
+    taskId: id,
+    name: `space ${id}`,
+    createdAt: at,
+    // Set, so pruneAbandoned leaves these alone and only the idle rule applies.
+    lastContentAt: at,
+    ...(touchedAt === undefined ? {} : { touchedAt }),
+    ownership: "agent",
+    targetIds: [targetId],
+  };
+}
+
+async function seed(spaces, selectedId = null) {
+  await mkdir(STATE_DIR, { recursive: true });
+  await writeFile(
+    TASK_SPACE_FILE,
+    JSON.stringify({ spaces, selectedId, nextId: 99 }),
+  );
+}
+
+describe("idle task space sweep", () => {
+  it("closes a space nobody came back to, and leaves a live one alone", async () => {
+    process.env.EGO_LINUX_SPACE_IDLE_MIN = "30";
+    const now = Date.now();
+    await seed([
+      space(1, "t-live", now - 5 * MINUTE),
+      space(2, "t-idle", now - 31 * MINUTE),
+    ]);
+
+    const closed = [];
+    const { taskSpaces } = await createTaskSpacesApi(
+      fakeCdp(closed),
+    ).listTaskSpaces();
+
+    assert.deepEqual(
+      taskSpaces.map((s) => s.id),
+      [1],
+      "the space touched five minutes ago survives",
+    );
+    assert.deepEqual(closed, ["t-idle"], "and the idle one's tab is closed");
+  });
+
+  it("never sweeps the selected space, however long it has sat", async () => {
+    process.env.EGO_LINUX_SPACE_IDLE_MIN = "30";
+    const now = Date.now();
+    await seed([space(2, "t-idle", now - 300 * MINUTE)], 2);
+
+    const closed = [];
+    const { taskSpaces } = await createTaskSpacesApi(
+      fakeCdp(closed),
+    ).listTaskSpaces();
+
+    assert.deepEqual(taskSpaces.map((s) => s.id), [2]);
+    assert.deepEqual(closed, [], "the space someone is on is not swept");
+  });
+
+  it("gives a space with no idle history a full window instead of sweeping it", async () => {
+    // The migration case: every space that predates touchedAt would otherwise be
+    // judged by createdAt and swept the first time this ran — including one a
+    // colleague session is halfway through.
+    process.env.EGO_LINUX_SPACE_IDLE_MIN = "30";
+    await seed([space(1, "t-live", undefined), space(2, "t-idle", undefined)]);
+
+    const closed = [];
+    const { taskSpaces } = await createTaskSpacesApi(
+      fakeCdp(closed),
+    ).listTaskSpaces();
+
+    assert.deepEqual(
+      taskSpaces.map((s) => s.id),
+      [1, 2],
+      "an unstamped space is stamped, not closed",
+    );
+    assert.deepEqual(closed, []);
+
+    // The stamp has to persist, or every run would re-stamp and nothing would
+    // ever reach the threshold.
+    const again = await createTaskSpacesApi(fakeCdp([])).listTaskSpaces();
+    for (const s of again.taskSpaces) {
+      assert.ok(s.touchedAt, `space ${s.id} kept its stamp`);
+    }
+  });
+
+  it("leaves a space the user was given, however long it has sat", async () => {
+    // The keep: true path sets ownership "user" precisely to say "leave this
+    // page open", and a handoff sets "agentDelegatedToUser" while a person is
+    // logging in. Neither produces an API call, so both would look idle.
+    process.env.EGO_LINUX_SPACE_IDLE_MIN = "30";
+    const long = Date.now() - 300 * MINUTE;
+    await seed([
+      { ...space(1, "t-live", long), ownership: "user" },
+      { ...space(2, "t-idle", long), ownership: "agentDelegatedToUser" },
+    ]);
+
+    const closed = [];
+    const { taskSpaces } = await createTaskSpacesApi(
+      fakeCdp(closed),
+    ).listTaskSpaces();
+
+    assert.deepEqual(
+      taskSpaces.map((s) => s.id),
+      [1, 2],
+      "a space in a person's hands is never swept",
+    );
+    assert.deepEqual(closed, []);
+  });
+
+  it("can be turned off entirely", async () => {
+    process.env.EGO_LINUX_SPACE_IDLE_MIN = "0";
+    const now = Date.now();
+    await seed([space(2, "t-idle", now - 5000 * MINUTE)]);
+
+    const closed = [];
+    const { taskSpaces } = await createTaskSpacesApi(
+      fakeCdp(closed),
+    ).listTaskSpaces();
+
+    assert.deepEqual(taskSpaces.map((s) => s.id), [2]);
+    assert.deepEqual(closed, [], "nothing is swept when the sweep is disabled");
+  });
+});

--- a/package/ego-linux/test/interact.js
+++ b/package/ego-linux/test/interact.js
@@ -1,0 +1,44 @@
+const fixture = process.env.FIXTURE_URL;
+const read = (id) => page.evaluate(`document.getElementById('${id}').textContent`);
+const value = (id) => page.evaluate(`document.getElementById('${id}').value`);
+
+await page.goto(fixture);
+await page.waitForLoadState();
+
+const snap = await page.snapshotRaw({ scope: "full_page" });
+const refOf = (predicate) => snap.refs.find(predicate)?.backendNodeId;
+const buttonRef = refOf(
+  (ref) => ref.role === "button" && String(ref.name).includes("Increment counter"),
+);
+console.log("1. button ref:            " + buttonRef);
+
+// The ref-map contract: @N must resolve to real page coordinates.
+const center = await page.elementCenter("@" + buttonRef);
+console.log("2. @ref center:           " + JSON.stringify(center));
+
+// Pointer path: a real CDP-synthesised click at those coordinates.
+await page.mouse.click(center.x, center.y);
+console.log("3. after mouse click:     " + (await read("count")));
+
+// Stable locator emitted by the snapshot must resolve back.
+const locCenter = await page.elementCenter("loc=css:#click-button");
+console.log("4. loc=css center:        " + JSON.stringify(locCenter));
+
+// Playwright-style locator, auto-waiting click.
+await page.locator("#click-button").click();
+console.log("5. after locator click:   " + (await read("count")));
+
+await page.locator("#name-input").fill("Vikt");
+console.log("6. locator fill:          " + (await value("name-input")));
+
+// Refs inside the deeply nested iframe.
+const deepRef = refOf((ref) => String(ref.name).includes("Deep button"));
+console.log("7. deep iframe ref:       " + JSON.stringify(await page.elementCenter("@" + deepRef)));
+
+// getByRole over the accessible names the snapshot reports.
+console.log("8. getByRole count:       " + (await page.getByRole("button", { name: "Increment counter" }).count()));
+
+const shot = await page.screenshot();
+console.log("9. screenshot:            " + shot);
+
+console.log("10. tabs:                 " + JSON.stringify(await browser.listTabs()));

--- a/package/ego-linux/test/port.test.mjs
+++ b/package/ego-linux/test/port.test.mjs
@@ -1,0 +1,185 @@
+import { after, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BIN = join(HERE, "..", "bin", "ego-browser.mjs");
+const FIXTURE_URL = `file://${join(HERE, "fixture", "index.html")}`;
+
+// The suite drives a browser of its own, in its own profile and state dir.
+// Sharing the default ones would make `npm test` hijack — and on teardown kill —
+// whatever browser the user's agent sessions are currently driving.
+const SANDBOX = await mkdtemp(join(tmpdir(), "ego-linux-test-"));
+const TEST_ENV = {
+  XDG_STATE_HOME: join(SANDBOX, "state"),
+  EGO_LINUX_PROFILE: join(SANDBOX, "profile"),
+};
+const TEST_BROWSER_STATE = join(SANDBOX, "state", "ego-lite-linux", "browser.json");
+
+/** Run a script through the real CLI, exactly as an agent would. */
+function runScript(scriptPath, { timeout = 120000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [BIN, "--headless"], {
+      env: { ...process.env, ...TEST_ENV, FIXTURE_URL },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`timed out after ${timeout}ms\n${stdout}\n${stderr}`));
+    }, timeout);
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(new Error(`exit ${code}\n${stdout}\n${stderr}`));
+        return;
+      }
+      resolve(stdout);
+    });
+
+    readFile(scriptPath, "utf8").then(
+      (code) => child.stdin.end(code),
+      (error) => reject(error),
+    );
+  });
+}
+
+after(async () => {
+  try {
+    const state = JSON.parse(await readFile(TEST_BROWSER_STATE, "utf8"));
+    if (state.pid) process.kill(state.pid, "SIGTERM");
+  } catch {
+    // nothing running
+  }
+  // Chrome keeps writing to its profile while shutting down, so a removal
+  // racing that hits ENOTEMPTY. Cleanup is best-effort — a leftover temp dir is
+  // not a test failure.
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  await rm(SANDBOX, { recursive: true, force: true, maxRetries: 5, retryDelay: 300 }).catch(
+    () => {},
+  );
+});
+
+describe("ego-browser Linux port", () => {
+  it("observes a page: navigation, tabs, refs and nested iframes", async () => {
+    const out = await runScript(join(HERE, "smoke.js"));
+
+    assert.match(out, /TITLE:\s+ego linux port fixture/, "page title read back");
+    assert.match(out, /TABS:\s+\d+ \(active: 1\)/, "exactly one tab reports active");
+
+    // Snapshot content: the semantic tree the agent reads.
+    assert.match(out, /Helper e2e fixture/, "page text is in the snapshot");
+    assert.match(out, /button "Increment counter" \[ref=\d+/, "button carries a ref");
+    assert.match(out, /link "Go to nav target".*url=\/nav-target/, "link exposes its href");
+    assert.match(out, /textbox "Your name".*loc=css:#name-input/, "input gets a stable locator");
+
+    // Iframe piercing, two levels deep — the case the native snapshot is built for.
+    assert.match(out, /iframe "nested frame"/, "first-level iframe is entered");
+    assert.match(out, /iframe "deep frame"/, "second-level iframe is entered");
+    assert.match(out, /button "Deep button" \[ref=\d+/, "element inside the deep iframe gets a ref");
+
+    // Layout-driven visibility, not a DOM dump.
+    assert.doesNotMatch(out, /hidden text must not appear/, "display:none content is excluded");
+  });
+
+  it("acts on a page: refs, locators, pointer input and screenshots", async () => {
+    const out = await runScript(join(HERE, "interact.js"));
+
+    assert.match(out, /2\. @ref center:\s+\{"x":\d/, "@ref resolves to coordinates");
+    assert.match(out, /3\. after mouse click:\s+clicked/, "a synthesised click reaches the element");
+    assert.match(out, /5\. after locator click:\s+clicked/, "locator click reaches the element");
+    assert.match(out, /6\. locator fill:\s+Vikt/, "locator fill writes into the input");
+    assert.match(out, /7\. deep iframe ref:\s+\{"x":\d/, "a ref inside the deep iframe resolves");
+    assert.match(out, /8\. getByRole count:\s+1/, "getByRole matches the computed accessible name");
+    assert.match(out, /9\. screenshot:\s+\/.*\.png/, "screenshot round trips to a file");
+  });
+
+  it("draws the agent's cursor without disturbing the page it acts on", async () => {
+    const out = await runScript(join(HERE, "cursor.js"));
+
+    assert.match(out, /1\. overlay present:\s+true/, "the overlay is injected on a click");
+    assert.match(out, /2\. cursor tracks click:\s+true/, "the cursor sits where the click landed");
+    assert.match(out, /3\. badge text:\s+Claude · counting/, "the task state label is shown");
+
+    // The overlay must stay invisible to everything the harness relies on.
+    assert.match(out, /4\. hit test at cursor:\s+click-button/, "elementFromPoint still sees the page");
+    assert.match(out, /5\. click still landed:\s+clicked/, "the click reached the element");
+    assert.match(out, /6\. overlay in snapshot:\s+false/, "the overlay is absent from the agent's snapshot");
+    assert.match(out, /7\. cursor held on wheel:\s+true/, "a scroll does not drag the cursor to (0, 0)");
+
+    // The pressed look tracks the button, not a fixed animation: it holds for as
+    // long as the button is down, and lets go when it comes up.
+    assert.match(out, /8\. pressed on down:\s+true/, "the cursor holds pressed while the button is down");
+    assert.match(out, /9\. released on up:\s+true/, "and springs back once it is released");
+
+    // It marks an element, so it is anchored to the page rather than the screen.
+    assert.match(out, /10\. travels with page:\s+true/, "the cursor scrolls with the element it is on");
+
+    // Shape and label both come from whatever sits under the cursor.
+    assert.match(out, /11\. hand over a link:\s+hand/, "a link gets the hand, as the page itself asks");
+    assert.match(out, /12\. names what it is on:\s+Claude · Go to nav target/, "the badge names it unprompted");
+    assert.match(out, /13\. beam over a field:\s+beam/, "a text field gets the beam");
+
+    // fill() dispatches no pointer event at all, so this is the action that
+    // would otherwise happen with nothing on screen to explain it.
+    assert.match(out, /14\. says it is typing:\s+Claude · typing…/, "typing is announced");
+    assert.match(out, /15\. marks the field:\s+on/, "and the field being typed into is ringed");
+    assert.match(out, /16\. lets go when done:\s+true/, "the ring clears once the keystrokes stop");
+
+    // The highlighter — a marker drawn to explain something, not a selection.
+    assert.match(out, /17\. highlight lines:\s+1/, "a phrase is found by its text and measured per line");
+    assert.match(out, /18\. bands drawn:\s+1/, "and gets a band");
+    assert.match(out, /19\. note in badge:\s+Claude · explaining this/, "the note says why");
+    assert.match(out, /20\. band matches text:\s+[0-2],[0-2]/, "the band sits on the text, within 2px");
+    assert.match(out, /21\. miss draws nothing:\s+true/, "text that is not there draws nothing");
+    assert.match(out, /22\. cleared:\s+true/, "and it can be wiped off again");
+
+    // Reading dispatches no input at all, so without the sweep a snapshotting
+    // agent drew nothing and the window looked idle while it worked.
+    assert.match(out, /23\. says what it reads:\s+Claude · reading “.+”/, "the badge names the line being read");
+    assert.match(out, /24\. marks the lines:\s+true/, "and the lines it has passed are marked");
+    assert.match(out, /25\. input ends the read:\s+true/, "real input takes the cursor back from the sweep");
+
+    // The trail the Spaces panel reads back. One entry per transition: the
+    // fill() above sent dozens of key events and must appear once.
+    assert.match(out, /26\. trail:.*clicked Increment counter/, "a click is recorded by what it hit");
+    assert.match(out, /26\. trail:.*typed into Your name/, "named by the field's own label, not its placeholder");
+    assert.match(out, /26\. trail:.*highlighted explaining this/, "so is a highlight, by its note");
+    assert.match(out, /26\. trail:.*read Helper e2e fixture/, "and a read, by what it started on");
+
+    // Anchored to its element, the cursor rides a long scroll off the screen —
+    // which used to leave the window blank while the agent was still working.
+    assert.match(out, /27\. cursor leaves view:\s+true/, "a long scroll carries the cursor off screen");
+    assert.match(out, /28\. badge stays in it:\s+true/, "but the badge stays legible");
+    assert.match(out, /29\. and points back:\s+↑/, "pointing back the way the cursor went");
+    // Measuring in the right place is not proof of being drawn there: a badge
+    // parented to the off-screen pointer passes check 28 and paints nothing.
+    assert.match(out, /30\. drawn independently:\s+true/, "and does not depend on the off-screen pointer layer");
+    assert.match(out, /31\. motion scales:\s+true/, "a nudge and a jump do not take the same time");
+  });
+
+  it("emulates task spaces with their own windows, ownership and lifecycle", async () => {
+    const out = await runScript(join(HERE, "spaces.js"));
+
+    assert.match(out, /1\. created:\s+\{"id":\d+.*"ownership":"agent"/, "a space is created agent-owned");
+    assert.match(out, /2\. alpha page:\s+ego linux port fixture/, "the agent works inside the space");
+    assert.match(out, /3\. second space: \{"id":\d+/, "a second, independent space is created");
+    assert.match(out, /4\. beta page:\s+about:blank#beta/, "the second space navigates on its own");
+    assert.match(out, /5\. back in alpha:ego linux port fixture/, "switching returns the agent to that space's page");
+    assert.match(out, /7\. after handOff:\["agentDelegatedToUser"/, "handOff flips ownership");
+    assert.match(out, /8\. after cleanup:\[\]/, "completing a space closes its window");
+  });
+});

--- a/package/ego-linux/test/reap.test.mjs
+++ b/package/ego-linux/test/reap.test.mjs
@@ -1,0 +1,120 @@
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Same isolation the other suites use: point the module's paths at a sandbox
+// before importing it, so this never reaps a browser a real session is driving.
+const SANDBOX = await mkdtemp(join(tmpdir(), "ego-reap-test-"));
+process.env.XDG_STATE_HOME = join(SANDBOX, "state");
+process.env.EGO_LINUX_PROFILE = join(SANDBOX, "profile");
+
+// Imported after that assignment on purpose: paths.mjs resolves its directories
+// at import time.
+const { reapOrphanedBrowsers } = await import("../src/chrome.mjs");
+
+// A stand-in for Chrome: it only has to sit still and carry the argv the reaper
+// reads back out of /proc. Spawning the real browser would make the outcome
+// depend on a working Chrome install.
+const STANDIN = join(SANDBOX, "standin.mjs");
+
+const spawned = [];
+
+/** Spawn a stand-in carrying `args`, and wait until /proc has its cmdline. */
+async function standIn(...args) {
+  const child = spawn(process.execPath, [STANDIN, ...args], { stdio: "ignore" });
+  spawned.push(child);
+  await new Promise((resolve, reject) => {
+    child.once("spawn", resolve);
+    child.once("error", reject);
+  });
+  return child;
+}
+
+function alive(child) {
+  try {
+    process.kill(child.pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Settle for `ms` so a delivered SIGTERM has actually landed. */
+const settle = (ms = 300) => new Promise((resolve) => setTimeout(resolve, ms));
+
+before(async () => {
+  await mkdir(SANDBOX, { recursive: true });
+  await writeFile(STANDIN, "setTimeout(() => {}, 60_000);\n");
+});
+
+after(async () => {
+  for (const child of spawned) child.kill("SIGKILL");
+  await rm(SANDBOX, { recursive: true, force: true, maxRetries: 5, retryDelay: 300 }).catch(
+    () => {},
+  );
+});
+
+describe("reapOrphanedBrowsers", () => {
+  it("terminates an ego browser whose profile directory is gone", async () => {
+    const gone = join(SANDBOX, "deleted-profile");
+
+    // The reaper is machine-global: it signals any browser carrying our class
+    // whose profile is gone, whoever started it. The suites run in parallel and
+    // several of them launch a browser, which runs this same reaper — and to it
+    // our stand-in is a textbook orphan, so it can be signalled out from under
+    // this test between the spawn and the measurement. That is the reaper
+    // working, not failing, and it left nothing for ours to count.
+    //
+    // Re-arm and measure again rather than serialise the whole suite for it
+    // (`--test-concurrency=1` costs ~17s a run). A stand-in that is still alive
+    // and still unsignalled is a real failure and asserts on the spot, so this
+    // can never turn a broken reaper green.
+    for (let attempt = 0; ; attempt += 1) {
+      const orphan = await standIn("--class=ego-lite-linux", `--user-data-dir=${gone}`);
+
+      const reaped = await reapOrphanedBrowsers();
+      await settle();
+
+      if (reaped === 0 && !alive(orphan) && attempt < 5) continue; // stolen; retry
+
+      assert.equal(reaped, 1, "exactly the one orphan is signalled");
+      assert.equal(alive(orphan), false, "the orphan is gone");
+      return;
+    }
+  });
+
+  it("leaves a browser whose profile directory still exists", async () => {
+    const live = join(SANDBOX, "live-profile");
+    await mkdir(live, { recursive: true });
+    const browser = await standIn("--class=ego-lite-linux", `--user-data-dir=${live}`);
+
+    const reaped = await reapOrphanedBrowsers();
+    await settle();
+
+    assert.equal(reaped, 0, "a reachable profile is not an orphan");
+    assert.equal(alive(browser), true, "the browser survives");
+  });
+
+  it("ignores renderers and non-ego processes with a missing profile", async () => {
+    const gone = join(SANDBOX, "also-deleted");
+    // Renderers inherit --user-data-dir; killing the browser takes them along,
+    // so signalling them individually would race that teardown.
+    const renderer = await standIn(
+      "--class=ego-lite-linux",
+      "--type=renderer",
+      `--user-data-dir=${gone}`,
+    );
+    // Some other Chrome on this machine is not ours to touch.
+    const foreign = await standIn(`--user-data-dir=${gone}`);
+
+    const reaped = await reapOrphanedBrowsers();
+    await settle();
+
+    assert.equal(reaped, 0, "neither is a reap candidate");
+    assert.equal(alive(renderer), true, "the renderer survives");
+    assert.equal(alive(foreign), true, "the foreign browser survives");
+  });
+});

--- a/package/ego-linux/test/smoke.js
+++ b/package/ego-linux/test/smoke.js
@@ -1,0 +1,16 @@
+const fixture = process.env.FIXTURE_URL;
+
+await page.goto(fixture);
+await page.waitForLoadState();
+
+const info = await page.info();
+console.log("URL:      " + info.url);
+console.log("TITLE:    " + info.title);
+
+const tabs = await browser.listTabs();
+console.log("TABS:     " + tabs.length + " (active: " + tabs.filter((t) => t.active).length + ")");
+
+const snap = await page.snapshotRaw({ scope: "full_page", includeStableLocator: true });
+console.log("REFS:     " + snap.refs.length);
+console.log("--- SNAPSHOT ---");
+console.log(snap.content);

--- a/package/ego-linux/test/snapshot-refs.test.mjs
+++ b/package/ego-linux/test/snapshot-refs.test.mjs
@@ -1,0 +1,138 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createSnapshotApi } from "../src/snapshot.mjs";
+
+// Minimal DOMSnapshot.captureSnapshot payload: two buttons, one inside the
+// viewport and one 5000 px below it. Enough to exercise the scope split without
+// dragging a real browser into a unit test.
+const S = {
+  EMPTY: 0,
+  HTML: 1,
+  BODY: 2,
+  BUTTON: 3,
+  TEXT: 4,
+  VISIBLE: 5,
+  BELOW: 6,
+  URL: 7,
+};
+
+function capturedFixture() {
+  return {
+    strings: [
+      "",
+      "HTML",
+      "BODY",
+      "BUTTON",
+      "#text",
+      "Visible button",
+      "Below the fold",
+      "https://example.test/",
+    ],
+    documents: [
+      {
+        documentURL: S.URL,
+        nodes: {
+          //            html body btn-a btn-b  text-a text-b
+          parentIndex: [-1, 0, 1, 1, 2, 3],
+          nodeType: [1, 1, 1, 1, 3, 3],
+          nodeName: [S.HTML, S.BODY, S.BUTTON, S.BUTTON, S.TEXT, S.TEXT],
+          nodeValue: [S.EMPTY, S.EMPTY, S.EMPTY, S.EMPTY, S.VISIBLE, S.BELOW],
+          backendNodeId: [1, 2, 100, 200, 101, 201],
+          attributes: [[], [], [], [], [], []],
+        },
+        // Both buttons are laid out; the second sits 5000 px down, well past a
+        // 800 px viewport. Their label text carries the same bounds so the
+        // accessible name resolves the way it would in a real capture.
+        layout: {
+          nodeIndex: [2, 3, 4, 5],
+          bounds: [
+            [0, 10, 120, 30],
+            [0, 5000, 120, 30],
+            [0, 10, 120, 30],
+            [0, 5000, 120, 30],
+          ],
+          text: [S.EMPTY, S.EMPTY, S.VISIBLE, S.BELOW],
+        },
+      },
+    ],
+  };
+}
+
+function makeApi() {
+  const calls = [];
+  const cdp = {
+    async call(method) {
+      calls.push(method);
+      if (method === "Target.attachToTarget") return { sessionId: "sess-1" };
+      if (method === "Page.getLayoutMetrics") {
+        return {
+          cssVisualViewport: {
+            pageX: 0,
+            pageY: 0,
+            clientWidth: 1280,
+            clientHeight: 800,
+          },
+        };
+      }
+      if (method === "DOMSnapshot.captureSnapshot") return capturedFixture();
+      return {};
+    },
+  };
+  const listTabs = async () => ({
+    tabs: [{ targetId: "tab-1", active: true }],
+  });
+  return { api: createSnapshotApi(cdp, { listTabs }), calls };
+}
+
+const refIds = (result) => result.refs.map((ref) => ref.backendNodeId).sort();
+
+test("viewport scope keeps off-screen elements addressable", async () => {
+  // The regression this pins: refs used to be collected inside the same branch
+  // that emitted a line, so anything outside the viewport was left out of the
+  // refMap entirely and `@N` came back as "Unknown ref". Callers then had to
+  // pick between a cheap snapshot and usable refs. Rendering is scoped; being
+  // addressable is not.
+  const { api } = makeApi();
+  const result = await api.snapshot({ scope: "only_within_viewport" });
+
+  assert.ok(
+    result.content.includes("Visible button"),
+    "the in-viewport button is rendered",
+  );
+  assert.ok(
+    !result.content.includes("Below the fold"),
+    "the off-screen button is not rendered",
+  );
+  assert.deepEqual(
+    refIds(result),
+    [100, 200],
+    "both buttons stay in the refMap, on-screen or not",
+  );
+});
+
+test("full_page renders and addresses everything", async () => {
+  const { api } = makeApi();
+  const result = await api.snapshot({ scope: "full_page" });
+
+  assert.ok(result.content.includes("Visible button"));
+  assert.ok(result.content.includes("Below the fold"));
+  assert.deepEqual(refIds(result), [100, 200]);
+});
+
+test("viewport scope still costs one layout-metrics round trip", async () => {
+  // Scoping is applied while rendering an already-decoded document, so the only
+  // extra CDP traffic it buys is the viewport read. Worth pinning: if this ever
+  // grows a second capture, the scope option stops being nearly free.
+  const { api, calls } = makeApi();
+  await api.snapshot({ scope: "only_within_viewport" });
+
+  assert.equal(
+    calls.filter((m) => m === "DOMSnapshot.captureSnapshot").length,
+    1,
+  );
+  assert.equal(
+    calls.filter((m) => m === "Page.getLayoutMetrics").length,
+    1,
+  );
+});

--- a/package/ego-linux/test/space-pinning.test.mjs
+++ b/package/ego-linux/test/space-pinning.test.mjs
@@ -1,0 +1,110 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Its own state dir: this suite rewrites the task-space file to imitate a second
+// session, and must never do that to the spaces a real session is driving.
+const SANDBOX = await mkdtemp(join(tmpdir(), "ego-pin-test-"));
+process.env.XDG_STATE_HOME = join(SANDBOX, "state");
+// The idle sweep is a separate concern; keep it out of these assertions.
+process.env.EGO_LINUX_SPACE_IDLE_MIN = "0";
+
+const { STATE_DIR, TASK_SPACE_FILE } = await import("../src/paths.mjs");
+const { createTaskSpacesApi } = await import("../src/task-spaces.mjs");
+
+const fakeCdp = {
+  async call(method) {
+    if (method === "Target.getTargets") {
+      return {
+        targetInfos: [
+          { type: "page", targetId: "t-a", url: "https://a.example", browserContextId: "ctx-a" },
+          { type: "page", targetId: "t-b", url: "https://b.example", browserContextId: "ctx-b" },
+        ],
+      };
+    }
+    return {};
+  },
+};
+
+function space(id, targetId, browserContextId) {
+  const at = Date.now();
+  return {
+    id,
+    taskId: id,
+    name: `space ${id}`,
+    createdAt: at,
+    touchedAt: at,
+    lastContentAt: at,
+    ownership: "agent",
+    browserContextId,
+    targetIds: [targetId],
+  };
+}
+
+async function seed(selectedId) {
+  await mkdir(STATE_DIR, { recursive: true });
+  await writeFile(
+    TASK_SPACE_FILE,
+    JSON.stringify({
+      spaces: [space(1, "t-a", "ctx-a"), space(2, "t-b", "ctx-b")],
+      selectedId,
+      nextId: 3,
+    }),
+  );
+}
+
+/** What a concurrently running second session does on its way in. */
+async function otherSessionSelects(id) {
+  const state = JSON.parse(await readFile(TASK_SPACE_FILE, "utf8"));
+  state.selectedId = id;
+  await writeFile(TASK_SPACE_FILE, JSON.stringify(state));
+}
+
+describe("a process stays in the space it chose", () => {
+  it("ignores a second session reassigning the shared selection", async () => {
+    await seed(null);
+    const api = createTaskSpacesApi(fakeCdp);
+    await api.useTaskSpace(1);
+
+    // The exact race: another agent starts up and claims the shared selection
+    // while this one is still working.
+    await otherSessionSelects(2);
+
+    const scope = await api.selectedScope();
+    assert.equal(
+      scope.browserContextId,
+      "ctx-a",
+      "scope still points at the space this process chose",
+    );
+    assert.ok(scope.targetIds.has("t-a"), "and at its tab");
+    assert.ok(
+      !scope.targetIds.has("t-b"),
+      "not the other session's tab — this is what navigated a stranger's page",
+    );
+
+    // requireSpace with no id is what every unqualified call resolves through.
+    const current = await api.completeTaskSpace();
+    assert.deepEqual(current, { done: true });
+    const after = JSON.parse(await readFile(TASK_SPACE_FILE, "utf8"));
+    assert.equal(
+      after.spaces.find((s) => s.id === 1).ownership,
+      "user",
+      "an unqualified call acted on the pinned space, not the reassigned one",
+    );
+    assert.equal(
+      after.spaces.find((s) => s.id === 2).ownership,
+      "agent",
+      "and left the other session's space untouched",
+    );
+  });
+
+  it("still follows the file when this process has not chosen yet", async () => {
+    // A fresh heredoc that never names a space is exactly who the shared value
+    // is for — pinning must not break it.
+    await seed(2);
+    const scope = await createTaskSpacesApi(fakeCdp).selectedScope();
+    assert.equal(scope.browserContextId, "ctx-b");
+  });
+});

--- a/package/ego-linux/test/spaces-server-unit.test.mjs
+++ b/package/ego-linux/test/spaces-server-unit.test.mjs
@@ -1,0 +1,243 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { __createCastPoolForTest, startSpacesServer } from "../src/spaces-server.mjs";
+import { SPACES_HTML } from "../src/spaces-ui.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Minimal cdp stand-in: lets the test pretend to attach to a target, wait, and
+ * detach — and see when each call resolves. The shim forwards cdp events on
+ * `onShimEvent` and claims/releases sessions around them; both no-ops here.
+ */
+function fakeCdp() {
+  const handlers = new Map();
+  const calls = [];
+  const sessions = new Set();
+  let nextId = 0;
+
+  function record(method, params, sessionId) {
+    const id = ++nextId;
+    const call = { id, method, params, sessionId, resolve: null, reject: null };
+    return new Promise((resolve, reject) => {
+      call.resolve = resolve;
+      call.reject = reject;
+      calls.push(call);
+    });
+  }
+
+  return {
+    calls,
+    onShimEvent(method, handler) {
+      handlers.set(method, handler);
+    },
+    claimSession(sessionId) {
+      sessions.add(sessionId);
+    },
+    releaseSession(sessionId) {
+      sessions.delete(sessionId);
+    },
+    call(method, params, sessionId) {
+      return record(method, params, sessionId);
+    },
+    /** Resolve the next pending call for `method` with a given result. */
+    fulfill(method, result = {}) {
+      const call = calls.find((entry) => entry.method === method && entry.resolve);
+      if (!call) throw new Error(`no pending ${method} call`);
+      calls.splice(calls.indexOf(call), 1);
+      call.resolve(result);
+    },
+    /** Fail the next pending call for `method`. */
+    fail(method, error = new Error("boom")) {
+      const call = calls.find((entry) => entry.method === method && entry.resolve);
+      if (!call) throw new Error(`no pending ${method} call`);
+      calls.splice(calls.indexOf(call), 1);
+      call.reject(error);
+    },
+    /** Default results for methods whose return value the test does not care about. */
+    autoFulfill(method, result = {}) {
+      const original = this.call.bind(this);
+      this.call = (m, p, s) => (m === method ? Promise.resolve(result) : original(m, p, s));
+    },
+  };
+}
+
+/**
+ * Minimal ego stand-in. The server only calls a handful of methods; the rest
+ * can be left to throw.
+ */
+function fakeEgo() {
+  const created = [];
+  return {
+    created,
+    async listTaskSpaces() {
+      return { taskSpaces: [] };
+    },
+    async createTaskSpace(name) {
+      const space = { id: created.length + 1, name, ownership: "agent", targetIds: [] };
+      created.push(space);
+      return space;
+    },
+    async useTaskSpace() {},
+    async handOffTaskSpace() {},
+    async takeOverTaskSpace() {},
+    async closeTaskSpace() {},
+  };
+}
+
+let server = null;
+afterEach(async () => {
+  if (server) {
+    await server.close();
+    server = null;
+  }
+});
+
+describe("spaces-server request handling", () => {
+  it("refuses a request body bigger than 1 MiB with 413", async () => {
+    const shim = { ego: fakeEgo(), cdp: fakeCdp() };
+    server = await startSpacesServer(shim);
+    const oversize = "x".repeat(2 * 1024 * 1024);
+    const response = await fetch(`http://127.0.0.1:${server.port}/api/spaces`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: `{"name":"${oversize}"}`,
+    });
+    assert.equal(response.status, 413);
+    const body = await response.json();
+    assert.match(body.error, /too large/i);
+    // The request never reached ego, so no space was created.
+    assert.equal(shim.ego.created.length, 0);
+  });
+
+  it("accepts a request body under the cap and creates a space", async () => {
+    const shim = { ego: fakeEgo(), cdp: fakeCdp() };
+    server = await startSpacesServer(shim);
+    const response = await fetch(`http://127.0.0.1:${server.port}/api/spaces`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "fine" }),
+    });
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.space.name, "fine");
+  });
+
+  it("serves /api/health", async () => {
+    const shim = { ego: fakeEgo(), cdp: fakeCdp() };
+    server = await startSpacesServer(shim);
+    const response = await fetch(`http://127.0.0.1:${server.port}/api/health`);
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true });
+  });
+});
+
+describe("createCastPool().closeAll()", () => {
+  it("awaits detach for every session before releasing it", async () => {
+    const cdp = fakeCdp();
+    // Page.startScreencast and Page.captureScreenshot resolve immediately so
+    // open() finishes; only Target.attach and Target.detach are gated, which
+    // is what the test needs to inspect.
+    cdp.autoFulfill("Page.startScreencast");
+    cdp.autoFulfill("Page.captureScreenshot");
+
+    const pool = createPoolFor(cdp);
+
+    // Each frameFor() opens a cast: Target.attach -> claimSession -> cast
+    // recorded. Capture two so closeAll has two sessions to release.
+    const pending1 = pool.frameFor("t1");
+    cdp.fulfill("Target.attachToTarget", { sessionId: "s1" });
+    await pending1;
+
+    const pending2 = pool.frameFor("t2");
+    cdp.fulfill("Target.attachToTarget", { sessionId: "s2" });
+    await pending2;
+
+    const released = [];
+    const realRelease = cdp.releaseSession.bind(cdp);
+    cdp.releaseSession = (sessionId) => {
+      released.push(sessionId);
+      realRelease(sessionId);
+    };
+
+    const closePromise = pool.closeAll();
+    // closeAll() must NOT have released any session before detach resolves.
+    assert.equal(released.length, 0, "no session released before detach");
+
+    cdp.fulfill("Target.detachFromTarget");
+    cdp.fulfill("Target.detachFromTarget");
+    await closePromise;
+
+    assert.deepEqual(released.sort(), ["s1", "s2"], "every session released after its detach");
+  });
+
+  it("still releases sessions when detach rejects", async () => {
+    const cdp = fakeCdp();
+    cdp.autoFulfill("Page.startScreencast");
+    cdp.autoFulfill("Page.captureScreenshot");
+    const pool = createPoolFor(cdp);
+
+    const pending = pool.frameFor("t1");
+    cdp.fulfill("Target.attachToTarget", { sessionId: "s1" });
+    await pending;
+
+    let released = false;
+    const realRelease = cdp.releaseSession.bind(cdp);
+    cdp.releaseSession = (id) => {
+      if (id === "s1") released = true;
+      realRelease(id);
+    };
+
+    const closePromise = pool.closeAll();
+    cdp.fail("Target.detachFromTarget", new Error("browser gone"));
+    await closePromise;
+
+    assert.equal(released, true, "session released even when detach fails");
+  });
+});
+
+/**
+ * Reach into spaces-server.mjs to grab the cast pool factory. The export is
+ * only used by this test; renaming it would break a regression check, not
+ * any caller.
+ */
+function createPoolFor(cdp) {
+  return __createCastPoolForTest(cdp);
+}
+
+/**
+ * Static XSS regression.
+ *
+ * The Spaces overview is served from loopback, but any page in the agent's
+ * own browser can hit it. A space name flows from the client into the
+ * rendered DOM. The page renders it through textContent / createTextNode,
+ * which the browser turns into a literal string — so the worst case today
+ * is a name that shows up escaped in the card. This test fails the moment
+ * someone replaces one of those safe assignments with innerHTML.
+ */
+describe("Spaces overview does not inject user-controlled strings", () => {
+  it("renders user-controlled fields through textContent or createTextNode only", async () => {
+    const source = await readFile(join(HERE, "..", "src", "spaces-ui.mjs"), "utf8");
+    // Allow `innerHTML` inside the static template (it has no user data).
+    // What we forbid is dynamically assigning user-controlled strings to it.
+    const dynamicInnerHTML = /\.innerHTML\s*=\s*[^"'`\s]/.test(source);
+    assert.equal(dynamicInnerHTML, false, "no dynamic innerHTML assignment");
+    // document.write would bypass textContent entirely.
+    assert.equal(/document\.write/.test(source), false, "no document.write");
+    // Both spots that put a name into the DOM must use a safe sink.
+    assert.match(source, /createTextNode\(space\.name\)/, "space.name goes through createTextNode");
+    assert.match(source, /name\.append\(dot,/, "name is appended, never set as HTML");
+  });
+
+  it("ships the page content verbatim (no script injection surface in SPACES_HTML)", () => {
+    // The HTML is one big template literal; this test fails if the export
+    // regresses to building it from a string concatenation that would let
+    // untrusted values land in markup.
+    assert.match(SPACES_HTML, /^<!doctype html>/);
+    assert.match(SPACES_HTML, /<\/html>\s*$/);
+  });
+});

--- a/package/ego-linux/test/spaces-server.test.mjs
+++ b/package/ego-linux/test/spaces-server.test.mjs
@@ -1,0 +1,216 @@
+import { after, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BIN = join(HERE, "..", "bin", "ego-browser.mjs");
+const FIXTURE_URL = `file://${join(HERE, "fixture", "index.html")}`;
+
+// Its own profile and state dir, for the reason port.test.mjs has one: `npm test`
+// must not hijack — and on teardown kill — the browser a real session is driving.
+const SANDBOX = await mkdtemp(join(tmpdir(), "ego-spaces-test-"));
+process.env.XDG_STATE_HOME = join(SANDBOX, "state");
+process.env.EGO_LINUX_PROFILE = join(SANDBOX, "profile");
+
+// Imported after that assignment on purpose: paths.mjs resolves its directories
+// at module load, so a static import would bind the real ones first.
+const { createEgoShim } = await import("../src/shim.mjs");
+const { startSpacesServer } = await import("../src/spaces-server.mjs");
+
+const shim = await createEgoShim({ headless: true });
+const server = await startSpacesServer(shim);
+const BASE = `http://127.0.0.1:${server.port}`;
+
+/** The panel's own window is 1280 wide; an active card is cropped to 16/10. */
+const FOLLOW_CROP = { width: 760, height: 475 };
+
+async function api(path, options) {
+  const response = await fetch(BASE + path, options);
+  return { status: response.status, body: await response.json() };
+}
+
+/** Run a heredoc through the real CLI, against the browser this suite started. */
+function runScript(source, { timeout = 120000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [BIN], {
+      env: { ...process.env, FIXTURE_URL },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`timed out after ${timeout}ms\n${stdout}\n${stderr}`));
+    }, timeout);
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) reject(new Error(`exit ${code}\n${stdout}\n${stderr}`));
+      else resolve(stdout);
+    });
+    child.stdin.end(source);
+  });
+}
+
+/**
+ * Width and height from a JPEG's start-of-frame marker. Enough to tell an
+ * active space's crop from a whole-page thumbnail without a decoder.
+ */
+function jpegSize(dataUri) {
+  const buffer = Buffer.from(String(dataUri).split(",")[1], "base64");
+  for (let i = 2; i < buffer.length - 9; ) {
+    if (buffer[i] !== 0xff) {
+      i += 1;
+      continue;
+    }
+    const marker = buffer[i + 1];
+    const isStartOfFrame =
+      marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+    if (isStartOfFrame) {
+      return { width: buffer.readUInt16BE(i + 7), height: buffer.readUInt16BE(i + 5) };
+    }
+    i += 2 + buffer.readUInt16BE(i + 2);
+  }
+  return null;
+}
+
+after(async () => {
+  server.close();
+  shim.close();
+  try {
+    const state = JSON.parse(
+      await readFile(join(SANDBOX, "state", "ego-lite-linux", "browser.json"), "utf8"),
+    );
+    if (state.pid) process.kill(state.pid, "SIGTERM");
+  } catch {
+    // nothing running
+  }
+  // Chrome keeps writing to its profile while shutting down, so a removal racing
+  // that hits ENOTEMPTY. A leftover temp dir is not a test failure.
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  await rm(SANDBOX, { recursive: true, force: true, maxRetries: 5, retryDelay: 300 }).catch(
+    () => {},
+  );
+});
+
+describe("Spaces overview server", () => {
+  it("answers a health probe, which is how the CLI finds a live daemon", async () => {
+    const { status, body } = await api("/api/health");
+    assert.equal(status, 200);
+    assert.deepEqual(body, { ok: true });
+  });
+
+  it("creates a space and describes it with a thumbnail", async () => {
+    const created = await api("/api/spaces", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "idle space" }),
+    });
+    assert.equal(created.status, 200);
+    assert.equal(created.body.space.name, "idle space");
+
+    const { body } = await api("/api/spaces");
+    const space = body.spaces.find((candidate) => candidate.name === "idle space");
+    assert.ok(space, "the new space is listed");
+    assert.equal(space.ownership, "agent");
+    assert.equal(space.tabCount, 1);
+    assert.match(space.thumbnail, /^data:image\/jpeg;base64,/, "a card gets a picture");
+
+    // Nothing has acted in it, so there is nothing to report and no reason to zoom.
+    assert.equal(space.activity, null);
+    assert.ok(
+      jpegSize(space.thumbnail).width > FOLLOW_CROP.width,
+      "an idle card shows the whole page, not a crop",
+    );
+  });
+
+  it("reports what an agent is doing, and where on the card it is working", async () => {
+    await runScript(`
+      await taskSpaces.useOrCreate("busy space");
+      await page.goto(process.env.FIXTURE_URL);
+      await page.waitForLoadState();
+      const point = await page.elementCenter("loc=css:#click-button");
+      await page.mouse.click(point.x, point.y, { label: "counting clicks" });
+    `);
+
+    const { body } = await api("/api/spaces");
+    const space = body.spaces.find((candidate) => candidate.name === "busy space");
+    assert.ok(space, "the space the agent worked in is listed");
+
+    // The panel and the agent are separate processes with separate CDP
+    // connections; this only works because the overlay leaves its state in the
+    // page, where the server reads it back.
+    assert.equal(space.activity?.name, "Claude");
+    assert.equal(space.activity?.label, "counting clicks");
+    assert.ok(space.activity.ageMs >= 0 && space.activity.ageMs < 30000);
+
+    // Frames now arrive by screencast, which delivers the whole viewport and
+    // cannot crop. The card zooms to the cursor itself, so what the server has
+    // to supply is where the cursor is — as a fraction of the viewport, which
+    // survives whatever size the frame happens to be.
+    const { fx, fy } = space.activity;
+    assert.ok(
+      typeof fx === "number" && fx >= 0 && fx <= 1,
+      "the cursor's horizontal position travels with the card",
+    );
+    assert.ok(
+      typeof fy === "number" && fy >= 0 && fy <= 1,
+      "the cursor's vertical position travels with the card",
+    );
+
+    const size = jpegSize(space.thumbnail);
+    assert.ok(size && size.width > 0 && size.height > 0, "a frame is served");
+
+    // The trail travels the same way and outlives the activity window, so a
+    // space that has gone quiet still says what it did.
+    assert.ok(space.trail?.length, "the card carries a trail of what happened");
+    assert.match(space.trail[0].text, /^clicked /, "newest first");
+    assert.ok(space.trail[0].ageMs >= 0, "aged, not timestamped");
+  });
+
+  it("refuses a cross-origin caller", async () => {
+    // Loopback is not a boundary here: any page in the agent's own browser can
+    // reach this server, and it can create and close spaces.
+    const { status } = await api("/api/spaces", {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: "https://evil.example" },
+      body: JSON.stringify({ name: "not yours" }),
+    });
+    assert.equal(status, 403);
+  });
+
+  it("closes a space and forgets it", async () => {
+    // Creates its own rather than reusing another case's, so this still means
+    // something when run alone through --test-name-pattern.
+    const { body: created } = await api("/api/spaces", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "closeable space" }),
+    });
+    const target = created.space;
+
+    const closed = await api(`/api/spaces/${target.id}/close`, { method: "POST" });
+    assert.equal(closed.status, 200);
+
+    const { body: after } = await api("/api/spaces");
+    assert.ok(
+      !after.spaces.some((candidate) => candidate.id === target.id),
+      "the closed space is gone from the overview",
+    );
+  });
+
+  it("404s an unknown route", async () => {
+    const { status } = await api("/api/nope");
+    assert.equal(status, 404);
+  });
+});

--- a/package/ego-linux/test/spaces.js
+++ b/package/ego-linux/test/spaces.js
@@ -1,0 +1,29 @@
+const fixture = process.env.FIXTURE_URL;
+
+const alpha = await taskSpaces.useOrCreate("port smoke alpha");
+console.log("1. created:      " + JSON.stringify({ id: alpha.id, name: alpha.name, ownership: alpha.ownership }));
+
+await page.goto(fixture);
+await page.waitForLoadState();
+console.log("2. alpha page:   " + (await page.title()));
+
+const beta = await taskSpaces.useOrCreate("port smoke beta");
+console.log("3. second space: " + JSON.stringify({ id: beta.id, name: beta.name }));
+await page.goto("about:blank#beta");
+console.log("4. beta page:    " + (await page.url()));
+
+// Switching back must put the agent on alpha's page again. Note this asserts
+// where the agent lands, not a per-space tab list — listTabs is browser-wide on
+// this port (see README).
+await taskSpaces.switch(alpha.id);
+console.log("5. back in alpha:" + (await page.title()));
+
+console.log("6. list:         " + JSON.stringify((await taskSpaces.list()).map((s) => ({ id: s.id, name: s.name, ownership: s.ownership }))));
+
+// Handing off flips ownership the way the native overlay does.
+await taskSpaces.handOff(alpha.id);
+console.log("7. after handOff:" + JSON.stringify((await taskSpaces.list()).map((s) => s.ownership)));
+
+await taskSpaces.complete(alpha.id, { keep: false });
+await taskSpaces.complete(beta.id, { keep: false });
+console.log("8. after cleanup:" + JSON.stringify(await taskSpaces.list()));

--- a/package/ego-linux/test/window-fit.test.mjs
+++ b/package/ego-linux/test/window-fit.test.mjs
@@ -1,0 +1,132 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { createWindowFit } from "../src/window-fit.mjs";
+
+/** A cdp double that records the bounds it was asked to set. */
+function fakeCdp() {
+  const calls = [];
+  return {
+    calls,
+    async call(method, params) {
+      calls.push({ method, params });
+      if (method === "Browser.getWindowForTarget") return { windowId: 7 };
+      if (method === "Browser.getWindowBounds") {
+        return { bounds: { left: 20, top: 40, width: 1280, height: 900 } };
+      }
+      return {};
+    },
+    bounds() {
+      return calls.find((c) => c.method === "Browser.setWindowBounds")?.params.bounds ?? null;
+    },
+  };
+}
+
+describe("createWindowFit", () => {
+  it("shrinks the window to a phone viewport", async () => {
+    const cdp = fakeCdp();
+    await createWindowFit(cdp).follow({ width: 390, height: 844, mobile: true }, "T1");
+
+    const bounds = cdp.bounds();
+    assert.ok(bounds, "the window is resized");
+    assert.equal(bounds.width, 390, "as wide as the viewport the agent emulates");
+    assert.ok(
+      bounds.height > 844,
+      "taller than the viewport, because the window also has to hold Chrome's own chrome",
+    );
+  });
+
+  it("leaves a desktop-sized emulation alone", async () => {
+    const cdp = fakeCdp();
+    await createWindowFit(cdp).follow({ width: 1280, height: 800 }, "T1");
+    assert.equal(cdp.bounds(), null, "the window is already that size");
+  });
+
+  it("does nothing for a cleared override it never shrank", async () => {
+    const cdp = fakeCdp();
+    // clearDeviceMetricsOverride arrives as a 0x0 set on some paths.
+    await createWindowFit(cdp).follow({ width: 0, height: 0 }, "T1");
+    assert.equal(cdp.bounds(), null, "there is no earlier size to go back to");
+  });
+
+  it("puts the window back when the emulation is cleared", async () => {
+    const cdp = fakeCdp();
+    const fit = createWindowFit(cdp);
+    await fit.follow({ width: 390, height: 844 }, "T1");
+    await fit.follow({ width: 0, height: 0 }, "T1");
+
+    const resizes = cdp.calls.filter((c) => c.method === "Browser.setWindowBounds");
+    assert.equal(resizes.length, 2, "shrunk, then restored");
+    assert.equal(resizes[1].params.bounds.width, 1280, "back to the size it had before");
+    assert.equal(resizes[1].params.bounds.height, 900);
+  });
+
+  it("puts the window back when emulation returns to desktop", async () => {
+    const cdp = fakeCdp();
+    const fit = createWindowFit(cdp);
+    await fit.follow({ width: 390, height: 844 }, "T1");
+    await fit.follow({ width: 1280, height: 800 }, "T1");
+
+    const resizes = cdp.calls.filter((c) => c.method === "Browser.setWindowBounds");
+    assert.equal(resizes[1].params.bounds.width, 1280, "a phone window does not outlive the phone viewport");
+  });
+
+  it("retries a resize that failed", async () => {
+    let failNext = true;
+    const calls = [];
+    const flaky = {
+      async call(method, params) {
+        if (method === "Browser.setWindowBounds" && failNext) {
+          failNext = false;
+          throw new Error("compositor said no");
+        }
+        calls.push({ method, params });
+        if (method === "Browser.getWindowForTarget") return { windowId: 7 };
+        if (method === "Browser.getWindowBounds") {
+          return { bounds: { left: 0, top: 0, width: 1280, height: 900 } };
+        }
+        return {};
+      },
+    };
+    const fit = createWindowFit(flaky);
+    await fit.follow({ width: 390, height: 844 }, "T1");
+    await fit.follow({ width: 390, height: 844 }, "T1");
+
+    const resizes = calls.filter((c) => c.method === "Browser.setWindowBounds");
+    assert.equal(resizes.length, 1, "the second attempt is not skipped as a duplicate");
+  });
+
+  it("refuses a sliver Chrome would clamp anyway", async () => {
+    const cdp = fakeCdp();
+    await createWindowFit(cdp).follow({ width: 120, height: 600 }, "T1");
+    assert.equal(cdp.bounds(), null, "too narrow to be worth following");
+  });
+
+  it("does not resize without a tab to resize", async () => {
+    const cdp = fakeCdp();
+    await createWindowFit(cdp).follow({ width: 390, height: 844 }, null);
+    assert.equal(cdp.calls.length, 0, "nothing to act on");
+  });
+
+  it("resizes once for a repeated emulation", async () => {
+    const cdp = fakeCdp();
+    const fit = createWindowFit(cdp);
+    await fit.follow({ width: 390, height: 844 }, "T1");
+    await fit.follow({ width: 390, height: 844 }, "T1");
+
+    const resizes = cdp.calls.filter((c) => c.method === "Browser.setWindowBounds");
+    assert.equal(resizes.length, 1, "an unchanged viewport is not re-applied");
+  });
+
+  it("never lets a refusing browser fail the action", async () => {
+    const angry = {
+      async call() {
+        throw new Error("no window here");
+      },
+    };
+    await assert.doesNotReject(
+      createWindowFit(angry).follow({ width: 390, height: 844 }, "T1"),
+      "resizing is cosmetic; an automation step must not fail on it",
+    );
+  });
+});

--- a/skills/ego-browser/references/install.md
+++ b/skills/ego-browser/references/install.md
@@ -75,7 +75,7 @@ The browser persists between invocations — each heredoc is its own short-lived
 
 #### How Linux differs from the macOS app
 
-- **`listTabs` is browser-wide**, not per task space. Task spaces still work (own tabs, ownership, `switch` / `claim` / `handOff` / `complete`), but CDP cannot place a tab in a chosen window, so per-space tab lists are not reproducible.
+- **`listTabs` is scoped to the selected space** — each task space reports only its own tabs, the way the macOS app does. (The Spaces overview deliberately reads `Target.getTargets` directly, since it needs every space's tabs.)
 - **Spaces are isolated, but their login state is a copy.** Each space gets its own cookie jar, seeded from yours when the space is created — so your logins are there, but a login made inside one space does not appear in the others, and `localStorage` / IndexedDB / service workers are not carried at all.
 - **Snapshot content is rebuilt** from `DOMSnapshot.captureSnapshot`. Refs (`@N`) are exact — they are real CDP `backendNodeId`s — but the tree's wording differs from the native snapshot.
 
@@ -99,9 +99,9 @@ command -v ego-browser
 Once the command exists, verify the runtime with a minimal heredoc:
 
 ```bash
-ego-browser nodejs <<'EOF'
+ego-browser <<'JS'
 console.log('ego-browser ready')
-EOF
+JS
 ```
 
 Printing `ego-browser ready` means the environment is ready.

--- a/skills/ego-browser/references/install.md
+++ b/skills/ego-browser/references/install.md
@@ -2,26 +2,30 @@
 
 Read this file only when ego lite isn't installed yet, or when the user asks to install ego lite. For day-to-day browser work, go back to `SKILL.md`.
 
-The ego-browser skill depends on the ego lite browser: the `ego-browser` command is provided by the ego lite app. Once ego lite is installed and you've gone through onboarding once, the environment is ready and there are no further environment issues.
+The ego-browser skill depends on a browser it can drive. On macOS that is the ego lite app, which provides the `ego-browser` command. On Linux there is no app bundle: the same harness drives a stock Chrome/Chromium over CDP. Either way, once the install is done the `ego-browser` command is on PATH and there are no further environment issues.
 
 ego lite website: https://lite.ego.app/
 
-## Install steps (macOS only)
+## Install steps
 
-The install script lives at `scripts/install.sh` in this skill and supports macOS only. It will:
+One script covers both platforms — it reads `uname -s` and runs the matching flow, so you do not have to pick:
+
+```bash
+sh skills/ego-browser/scripts/install.sh
+```
+
+On an unsupported platform it stops with `unsupported platform: <name>` rather than half-installing.
+
+### macOS
+
+The script will:
 
 - Download the ego lite installer (a DMG) for your CPU architecture (arm64 / x64).
 - Install `ego lite.app` to `/Applications` (falling back to `~/Applications` when needed).
 - Strip the quarantine attribute to keep Gatekeeper from blocking the first launch.
 - After installing, launch the `ego lite` app.
 
-Run the script (use the script's actual path under this skill's directory):
-
-```bash
-sh skills/ego-browser/scripts/install.sh
-```
-
-After installing, the script opens the ego lite app directly. If ego lite is already installed, the script skips the download and opens the app directly.
+If ego lite is already installed, the script skips the download and opens the app directly.
 
 After the script opens the ego lite app, the user completes the first-run onboarding in the app:
 
@@ -30,9 +34,56 @@ After the script opens the ego lite app, the user completes the first-run onboar
 
 Onboarding is a step the user completes in the GUI. After the script opens ego lite, wait for the user to confirm they've finished onboarding before continuing.
 
+### Linux
+
+There is nothing to download. The script builds the harness in `package/ego-browser` and links the CDP shim from `package/ego-linux` onto PATH as `ego-browser`, so run it from a checkout of this repository.
+
+Requires Node >= 22 and any Chrome/Chromium/Brave/Edge on PATH. The script checks both before touching anything and stops with a clear error rather than half-installing. Set `EGO_LINUX_CHROME` to an absolute path to point it at a browser that is not on PATH, and `EGO_LINUX_BIN_DIR` to link somewhere other than `~/.local/bin`.
+
+There is no GUI onboarding step: when the script finishes, the command is ready.
+
+Two follow-ups it deliberately does not run for you, because both touch user data:
+
+```bash
+ego-browser --import-chrome-profile       # inherit the user's real logins
+ego-browser --install-desktop-entry       # app launcher icon
+```
+
+Equivalent by hand, if you would rather see each step:
+
+```bash
+cd <repo>/package/ego-browser
+CI=true npm ci && CI=true npm run build   # CI=true is required, not cosmetic: the
+                                          # prepare script runs lefthook install,
+                                          # which fails when core.hooksPath is set
+
+ln -sf <repo>/package/ego-linux/bin/ego-browser.mjs ~/.local/bin/ego-browser
+```
+
+#### Linux-only commands
+
+| Command | What it does |
+|---|---|
+| `ego-browser --status` | backing browser connection state |
+| `ego-browser --open` | open the shared agent browser window |
+| `ego-browser --stop` | stop it and clear the profile lock |
+| `ego-browser --import-chrome-profile` | copy the real Chrome profile in |
+| `ego-browser --install-desktop-entry` | app launcher entry + icon |
+| `ego-browser --headless` | run headless (first launch only) |
+
+The browser persists between invocations — each heredoc is its own short-lived Node process, so the browser is what survives, not the process.
+
+#### How Linux differs from the macOS app
+
+- **`listTabs` is browser-wide**, not per task space. Task spaces still work (own tabs, ownership, `switch` / `claim` / `handOff` / `complete`), but CDP cannot place a tab in a chosen window, so per-space tab lists are not reproducible.
+- **Spaces are isolated, but their login state is a copy.** Each space gets its own cookie jar, seeded from yours when the space is created — so your logins are there, but a login made inside one space does not appear in the others, and `localStorage` / IndexedDB / service workers are not carried at all.
+- **Snapshot content is rebuilt** from `DOMSnapshot.captureSnapshot`. Refs (`@N`) are exact — they are real CDP `backendNodeId`s — but the tree's wording differs from the native snapshot.
+
+Full details: `package/ego-linux/README.md`.
+
 ## After installing: confirm `ego-browser` is available
 
-Once the user has finished onboarding, confirm the command is ready:
+Confirm the command is ready:
 
 ```bash
 command -v ego-browser
@@ -61,7 +112,20 @@ Once the environment is ready, return to the user's original task and continue w
 
 ## Troubleshooting
 
-- **Not macOS**: the script supports macOS only (`uname -s` is `Darwin`). On other platforms, have the user download and install from the ego lite website at https://lite.ego.app/.
+Any platform:
+
+- **Command still unavailable after installing**: confirm `~/.local/bin` is on the PATH (see above).
+- **Unsupported platform**: the script covers macOS and Linux. Elsewhere, have the user download and install from the ego lite website at https://lite.ego.app/.
+
+macOS:
+
 - **Download failed**: the script retries 3 times automatically; if it still fails, it's usually a network issue — have the user check their network and retry.
 - **Gatekeeper still blocks it**: the script already tries to strip quarantine; if the first launch is still blocked, have the user allow ego lite manually under System Settings → Privacy & Security.
-- **Command still unavailable after onboarding**: confirm `~/.local/bin` is on the PATH (see above); or have the user reopen ego lite, finish onboarding, and retry.
+- **Command still unavailable after onboarding**: have the user reopen ego lite, finish onboarding, and retry.
+
+Linux:
+
+- **"no Chrome/Chromium/Brave/Edge found on PATH"**: install one, or set `EGO_LINUX_CHROME` to an absolute path.
+- **"Chrome did not expose a DevTools port"**: a killed browser left a profile lock. `ego-browser --stop` clears it, then retry.
+- **Clicks land on nothing / coordinates look wrong**: page zoom. The launcher pins the agent profile to 100%, but if a page was zoomed manually, reset it.
+- **Duplicate drag events under heavy load**: `driver/pointer.ts` `finishDragProbe` waits a fixed 50 ms before re-synthesising a drag, so a trusted `mouseup` that lands later can be delivered twice. Retry when the machine is quieter.

--- a/skills/ego-browser/references/install.md
+++ b/skills/ego-browser/references/install.md
@@ -128,4 +128,3 @@ Linux:
 - **"no Chrome/Chromium/Brave/Edge found on PATH"**: install one, or set `EGO_LINUX_CHROME` to an absolute path.
 - **"Chrome did not expose a DevTools port"**: a killed browser left a profile lock. `ego-browser --stop` clears it, then retry.
 - **Clicks land on nothing / coordinates look wrong**: page zoom. The launcher pins the agent profile to 100%, but if a page was zoomed manually, reset it.
-- **Duplicate drag events under heavy load**: `driver/pointer.ts` `finishDragProbe` waits a fixed 50 ms before re-synthesising a drag, so a trusted `mouseup` that lands later can be delivered twice. Retry when the machine is quieter.

--- a/skills/ego-browser/references/task-spaces.md
+++ b/skills/ego-browser/references/task-spaces.md
@@ -1,0 +1,122 @@
+# Task spaces — ownership, handoff, and completion policy
+
+The full contract behind the summary in `SKILL.md`. Read this before any
+claim / handoff / takeover / complete edge case.
+
+## Naming and reuse
+
+`nameOrId` can be a task space name, numeric id, or digit-only numeric id
+string. String values match `name`/`taskId` first, then digit-only strings fall
+back to numeric id. Number values match existing numeric ids only; if no
+matching id exists, `taskSpaces.useOrCreate` fails instead of creating a new
+space.
+
+Use a short name for the active user goal when creating a new task space. Keep
+reusing that task space for follow-up questions, corrections, refinements,
+re-checks, and result validation, even if you previously thought the task was
+complete. Choose a new task space only when the user clearly starts a separate,
+unrelated goal. Prefer using the numeric `id` returned by
+`taskSpaces.useOrCreate` (for example, `task.id`) to resume a known task in
+later rounds and avoid name collisions.
+
+For any follow-up on the same user goal — including continue, corrections,
+retries, validation, user-reported problems, or work after
+`taskSpaces.complete(..., { keep: true })` — resume the original task space
+first if it still exists. Do not create a new task space for the same goal
+unless the user asks for a fresh space, starts an unrelated goal, or the
+original space is unavailable after checking. If a new space is necessary,
+state why.
+
+After explicit user confirmation, to continue work from an existing user-owned,
+inactive, or unassigned task space, use `await taskSpaces.list()` to find the
+space, call `await taskSpaces.claim(id)` to take ownership and select it, then
+use `await browser.listTabs()` and `await browser.switchTab(targetId)` to
+select the exact tab before acting.
+
+## Ownership policy
+
+Every task space has `ownership: 'agent' | 'agentDelegatedToUser' | 'user'`;
+the facades treat user-owned spaces differently:
+
+| Call | When the target space is user-owned |
+|---|---|
+| `taskSpaces.switch` | throws — agent-owned spaces only |
+| `taskSpaces.claim` | claims it (ownership transfers to the agent), then selects it |
+| `taskSpaces.handOff` | skipped — resolves `{ done: false, skipped: 'user-owned' }` |
+| `taskSpaces.complete(…, { keep: true })` | skipped — resolves `{ done: false, skipped: 'user-owned' }` |
+| `taskSpaces.complete(…, { keep: false })` | claims it, then closes it |
+| `taskSpaces.takeOver` / `waitForAgentControl` | no ownership check |
+
+`taskSpaces.handOff` and `taskSpaces.complete` resolve `{ done: true }` when
+the operation actually happened. Check `done` before telling the user the
+handoff/cleanup is finished — a `skipped` result usually means you targeted a
+space that was never yours.
+
+## Completion and cleanup
+
+**`taskSpaces.complete(nameOrId, { keep })` must occupy its own dedicated final
+heredoc, and run only after a prior heredoc's output has confirmed the task is
+genuinely done.** `keep` is required and defaults by policy to `false`: close
+the task space after completion unless there is a concrete reason to leave the
+live page visible.
+
+Use `{ keep: true }` only when the user explicitly asks to keep the page open,
+the task needs manual user action in that exact page, or the result cannot be
+delivered well as a URL, file, artifact, or summary. Do not keep a task space
+open merely because a page was visited, a document was created, or a screenshot
+was used for verification.
+
+When passing a string that may create a new task space, the string should
+reflect the task's intent (e.g. `'search github issues'`); don't use literal
+placeholders.
+
+**If the task space needs to be preserved after the task ends, keep only the
+tabs that need to be shown to the user.** Keep loose awareness of how many tabs
+are open — a quick `(await browser.listTabs()).length` is enough; there's no
+need to spend a dedicated round just to check. When scratch tabs (search-result
+pages, cross-check pages, and other one-off pages) pile up, close them as you
+go rather than letting them all accumulate for the end. When finishing with
+`{ keep: true }` to leave pages for the user, clear out the remaining scratch
+tabs so only the pages worth showing stay open. Close a single tab with
+`await browser.closeTab(targetId)` (`targetId` comes from `browser.listTabs()`
+or an `openOrReuseTab` return value).
+
+## Control handoff
+
+Only one side — agent or user — holds control of a task space at any time.
+While the user holds control, any browser operation by the agent fails with a
+"user is controlling" message — do not retry it; follow the steps below to
+resume.
+
+A "user is controlling" error is a hard stop on the whole task — not an
+obstacle to route around. It means the user has deliberately taken the browser
+back, often because your current approach is going wrong. Honoring it *is* the
+correct outcome here; pushing the goal forward anyway is the failure. The only
+thing you may do is **ask the user and wait**.
+
+An "inactive", "not assigned to an agent", or similar task-space error is also
+a hard stop with the same confirmation requirement. Resume only after explicit
+user confirmation, then start with `await taskSpaces.claim(id)`.
+
+**Handing off**: When the task requires user intervention (e.g. login, captcha,
+manual confirmation), call `await taskSpaces.handOff(nameOrId)` to give control
+to the user, and tell them exactly what to do. Omitting `nameOrId` uses the
+currently selected task space; pass `task.id` across heredoc rounds to avoid
+ambiguity.
+
+**Regaining control**: Take control back *only* after the user explicitly
+confirms — through an Ask (your harness's button/option prompt, e.g. "Continue"
+vs "Finish task") or a "continue" message in chat. Then start a new heredoc
+with `await taskSpaces.takeOver(nameOrId)` and resume; if the user chooses to
+finish, close out with `await taskSpaces.complete(nameOrId, { keep })`. Never
+call `taskSpaces.takeOver` on your own to grab control back — it has no
+ownership check and will seize the browser away from the user.
+
+**Unexpected takeover**: The user can take over at any time via the browser GUI
+— the same effect as the agent calling `taskSpaces.handOff`. Do not retry the
+failed operation and do not auto-takeover; surface the Ask above (Continue /
+Finish) and resume only when the user picks Continue.
+
+`await taskSpaces.waitForAgentControl(nameOrId)` is a read-only blocking poll
+(it never takes control); use it only to wait inside the current heredoc for a
+handoff you initiated.

--- a/skills/ego-browser/scripts/install.sh
+++ b/skills/ego-browser/scripts/install.sh
@@ -12,6 +12,12 @@ APP_PATH="/Applications/$APP_BUNDLE_NAME"
 USER_APP_PATH="$HOME/Applications/$APP_BUNDLE_NAME"
 EGO_BROWSER_HELPER_NAME="ego-browser"
 
+# Linux: there is no .dmg to mount, so the CLI is linked from this repo instead.
+LINUX_BIN_DIR="${EGO_LINUX_BIN_DIR:-$HOME/.local/bin}"
+# Keep in sync with CHROME_CANDIDATES in package/ego-linux/src/chrome.mjs.
+LINUX_CHROME_CANDIDATES="google-chrome google-chrome-stable chromium chromium-browser brave-browser microsoft-edge"
+LINUX_MIN_NODE_MAJOR=22
+
 # Temporary directories created when mounting the DMG; cleaned up on exit.
 TEMP_DIR=""
 MOUNT_DIR=""
@@ -212,9 +218,7 @@ install_ego_lite() {
 	die "cannot find $APP_NAME app or pkg in mounted DMG"
 }
 
-main() {
-	[ "$(uname -s)" = "Darwin" ] || die "this script only supports macOS"
-
+main_macos() {
 	# Install first if not present; otherwise use the ego-browser bundled inside the app.
 	installed_app_path=$(find_ego_lite_app || true)
 	if [ -z "$installed_app_path" ]; then
@@ -229,6 +233,77 @@ main() {
 
 	log "Launching $APP_NAME ..."
 	exec open "$installed_app_path"
+}
+
+# Linux has no ego lite app bundle. The same harness under package/ego-browser
+# drives a stock Chrome/Chromium over CDP through the shim in package/ego-linux,
+# so the install is a build plus a symlink rather than a download.
+main_linux() {
+	script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+	repo_root=$(CDPATH= cd -- "$script_dir/../../.." && pwd)
+	harness_dir="$repo_root/package/ego-browser"
+	shim_bin="$repo_root/package/ego-linux/bin/ego-browser.mjs"
+	link_path="$LINUX_BIN_DIR/$EGO_BROWSER_HELPER_NAME"
+
+	[ -f "$harness_dir/package.json" ] ||
+		die "cannot find the harness at $harness_dir — run this script from a checkout of this repository"
+	[ -f "$shim_bin" ] ||
+		die "cannot find the Linux shim at $shim_bin — this checkout predates Linux support"
+
+	require_command node
+	node_major=$(node -p 'process.versions.node.split(".")[0]')
+	[ "$node_major" -ge "$LINUX_MIN_NODE_MAJOR" ] ||
+		die "node >= $LINUX_MIN_NODE_MAJOR is required; found $(node -v)"
+
+	# The port drives a stock browser over CDP, so one of these must exist.
+	found_chrome=""
+	if [ -n "${EGO_LINUX_CHROME:-}" ] && [ -x "${EGO_LINUX_CHROME:-}" ]; then
+		found_chrome="$EGO_LINUX_CHROME"
+	else
+		for candidate in $LINUX_CHROME_CANDIDATES; do
+			if command -v "$candidate" >/dev/null 2>&1; then
+				found_chrome=$(command -v "$candidate")
+				break
+			fi
+		done
+	fi
+	[ -n "$found_chrome" ] ||
+		die "no Chrome/Chromium/Brave/Edge found on PATH (looked for: $LINUX_CHROME_CANDIDATES). Install one, or set EGO_LINUX_CHROME to an absolute path."
+	log "Using browser: $found_chrome"
+
+	# CI=true is required, not cosmetic: the harness's prepare script runs
+	# `lefthook install`, which fails on any machine with a global core.hooksPath.
+	log "Building the harness in $harness_dir ..."
+	(cd "$harness_dir" && CI=true npm ci && CI=true npm run build) ||
+		die "harness build failed"
+
+	mkdir -p "$LINUX_BIN_DIR"
+	ln -sf "$shim_bin" "$link_path"
+	log "Linked $link_path -> $shim_bin"
+
+	case ":$PATH:" in
+	*":$LINUX_BIN_DIR:"*) ;;
+	*) log "warning: $LINUX_BIN_DIR is not on PATH. Add it, or run: export PATH=\"$LINUX_BIN_DIR:\$PATH\"" ;;
+	esac
+
+	"$link_path" --help >/dev/null 2>&1 ||
+		die "installed $link_path but it failed to run"
+
+	log ""
+	log "ego-browser is installed. Optional next steps (both touch user data, so they are not automatic):"
+	log "  ego-browser --import-chrome-profile    inherit your real logins"
+	log "  ego-browser --install-desktop-entry    add an app launcher icon"
+}
+
+# Pick the flow by OS rather than refusing everything that is not macOS. The
+# cleanup trap above is a no-op on Linux: nothing sets TEMP_DIR or DMG_ATTACHED
+# on that path.
+main() {
+	case "$(uname -s)" in
+	Darwin) main_macos ;;
+	Linux) main_linux ;;
+	*) die "unsupported platform: $(uname -s) (supported: macOS, Linux)" ;;
+	esac
 }
 
 main

--- a/skills/ego-browser/scripts/install.sh
+++ b/skills/ego-browser/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #v1.5 2026.06.04 17:16
 
-set -eu
+set -euo pipefail
 
 # Default package URL and installation paths.
 DMG_URL_ARM64="https://cdn.ego.app/channel/egobrowser_npx_referral/setup/macos/arm64/egolite.dmg"
@@ -273,9 +273,12 @@ main_linux() {
 
 	# CI=true is required, not cosmetic: the harness's prepare script runs
 	# `lefthook install`, which fails on any machine with a global core.hooksPath.
+	log "Installing harness dependencies in $harness_dir ..."
+	(cd "$harness_dir" && CI=true npm ci) ||
+		die "npm ci failed in $harness_dir"
 	log "Building the harness in $harness_dir ..."
-	(cd "$harness_dir" && CI=true npm ci && CI=true npm run build) ||
-		die "harness build failed"
+	(cd "$harness_dir" && CI=true npm run build) ||
+		die "npm run build failed in $harness_dir"
 
 	mkdir -p "$LINUX_BIN_DIR"
 	ln -sf "$shim_bin" "$link_path"


### PR DESCRIPTION
## What this adds

`skills/ego-browser/scripts/install.sh` previously opened with

    [ "$(uname -s)" = "Darwin" ] || die "this script only supports macOS"

so the only way to run the harness on Linux was to fork the repo. This PR adds the missing half instead of replacing the existing one.

- **The macOS flow is untouched.** `main()` was renamed to `main_macos()` and lost exactly one line — the guard above. Every DMG function (`install_ego_lite`, `find_ego_lite_app`, `strip_quarantine_attributes`, `cleanup`, the `trap`) is byte-identical.
- **A new `main()` dispatches on `uname -s`**: `Darwin` → the existing flow, `Linux` → the new one, anything else → `unsupported platform: <name>` rather than a macOS-specific message.
- **`package/ego-linux`** (new, 39 files) supplies the `globalThis.ego` object the macOS app injects natively, backed by a stock Chrome/Chromium over CDP.

## Why it does not touch `package/ego-browser`

`package/ego-browser` is unchanged in this PR — 0 files. Every helper, locator, driver and format runs as-is on both platforms; the port is a backing implementation, not a second harness. The test suite below is what checks it.

## Install on Linux

A build plus a symlink — there is nothing to download:

    sh skills/ego-browser/scripts/install.sh

It verifies Node >= 22 and a browser on PATH *before* touching anything. `EGO_LINUX_CHROME` points it at a browser that is not on PATH; `EGO_LINUX_BIN_DIR` links somewhere other than `~/.local/bin`. There is no GUI onboarding step on Linux: when the script returns, the command is ready.

## Verification

Run on Linux against an unmodified `package/ego-browser`:

| Check | Result |
|---|---|
| `package/ego-linux` suite | **61/61 pass** (54 original + 7 new unit tests) |
| `sh skills/ego-browser/scripts/install.sh` end to end | Pass — `npm ci`, build, symlink, post-install smoke check |
| Dispatcher, `uname` stubbed to `Darwin` | Enters the DMG flow — reaches `require_command hdiutil` |
| Dispatcher, `uname` stubbed to `FreeBSD` | `error: unsupported platform: FreeBSD (supported: macOS, Linux)` |
| `sh -n` on the installer | Clean |

## Review fixes (over PR #234)

- **spaces-server: await detach before release.** `closeAll` / `retain` / the two error paths in `open()` used to fire `Target.detachFromTarget` and immediately call `releaseSession`; frames in flight were forwarded into `drainEvents` (→ the agent). Now `Promise.all` + `await` waits for each detach to settle before the release. Backed by a regression test (`closeAll awaits detach` + `release still happens when detach fails`).
- **spaces-server: 1 MiB body cap.** A caller on loopback could OOM the daemon. New `ResponseError(413)` in `readBody`; the 413 response carries `Connection: close` so `server.close()` does not stall on the half-written socket. Tested.
- **chrome: `EGO_LINUX_CDP_URL` returns a port.** The previous shape was `{ wsUrl, launched: false }` with no port, which silently disabled MRU tab ordering in `createTabsApi`. Now the port is parsed from the URL and best-effort probed; a dead endpoint is surfaced instead of hanging.
- **bin/ego-browser: detached spawns swallow `error`.** Detached + `unref`'d, an unhandled `'error'` on the child process kills Node — exactly what `--spaces` is trying to avoid. Extracted `spawnDetached` helper used by `openPanelWindow`, `runSpacesDaemon`, and `openSpaces`.
- **install.sh: `set -euo pipefail`** + split `npm ci` / `npm run build` so each dies with its own message.
- **install.md: align with code.** `listTabs` is scoped to the selected space (was described as browser-wide). Dropped the macOS-only `nodejs` prefix from the example to match `SKILL.md`; the shim still accepts it for backward compatibility.
- **package.json: drop the unused `bin` entry.** The symlink in `install.sh` is the canonical install path.
- **Static XSS regression** on `spaces-ui.mjs` — fails the moment any user-controlled field is assigned via `innerHTML` instead of `textContent` / `createTextNode`.

## Scope

Carved down from a working Linux fork to the platform-support core. Deliberately **not** included:

- fork branding (root `README.md`), fork-specific docs and experiments
- site learnings packs
- fork CI / lefthook workarounds
- a `driver/pointer.ts` drag-timing fix that is platform-agnostic — belongs in its own PR