### PR TITLE
fix(ego-browser): report an actionable error when ffmpeg is a batch shim

### DIFF
--- a/package/ego-browser/src/video-recorder.test.mjs
+++ b/package/ego-browser/src/video-recorder.test.mjs
@@ -387,3 +387,69 @@ test("VideoRecorder explains how to configure a missing ffmpeg executable", asyn
     /FFmpeg executable was not found.*EGO_BROWSER_FFMPEG_PATH/,
   );
 });
+
+test("VideoRecorder explains a batch shim ffmpeg path rejected by the OS", async () => {
+  const { VideoRecorder } = await import("../dist/src/video-recorder.js");
+  const recorder = new VideoRecorder({
+    outputPath: "/tmp/recording.webm",
+    size: { width: 640, height: 480 },
+    ffmpegPath: "C:\\tools\\ffmpeg.cmd",
+    // Windows throws EINVAL synchronously out of spawn() for a .cmd/.bat
+    // target, so it never reaches the process "error" event.
+    spawnProcess() {
+      throw Object.assign(new Error("spawn EINVAL"), { code: "EINVAL" });
+    },
+  });
+
+  await assert.rejects(
+    () => recorder.start(),
+    /ffmpeg\.cmd.*batch shim.*EGO_BROWSER_FFMPEG_PATH at the ffmpeg executable/s,
+  );
+});
+
+test("VideoRecorder reports a missing executable thrown synchronously", async () => {
+  const { VideoRecorder } = await import("../dist/src/video-recorder.js");
+  const recorder = new VideoRecorder({
+    outputPath: "/tmp/recording.webm",
+    size: { width: 640, height: 480 },
+    spawnProcess() {
+      throw Object.assign(new Error("spawn ffmpeg ENOENT"), { code: "ENOENT" });
+    },
+  });
+
+  await assert.rejects(
+    () => recorder.start(),
+    /FFmpeg executable was not found.*EGO_BROWSER_FFMPEG_PATH/,
+  );
+});
+
+test("VideoRecorder passes through an unrecognized spawn failure", async () => {
+  const { VideoRecorder } = await import("../dist/src/video-recorder.js");
+  const recorder = new VideoRecorder({
+    outputPath: "/tmp/recording.webm",
+    size: { width: 640, height: 480 },
+    ffmpegPath: "/usr/bin/ffmpeg",
+    spawnProcess() {
+      throw Object.assign(new Error("spawn EACCES"), { code: "EACCES" });
+    },
+  });
+
+  await assert.rejects(() => recorder.start(), /spawn EACCES/);
+});
+
+test("VideoRecorder stop after a failed start does not invent an exit code", async () => {
+  const { VideoRecorder } = await import("../dist/src/video-recorder.js");
+  const recorder = new VideoRecorder({
+    outputPath: "/tmp/recording.webm",
+    size: { width: 640, height: 480 },
+    ffmpegPath: "C:\\tools\\ffmpeg.cmd",
+    spawnProcess() {
+      throw Object.assign(new Error("spawn EINVAL"), { code: "EINVAL" });
+    },
+  });
+
+  await assert.rejects(() => recorder.start(), /batch shim/);
+  // The startup failure is the only error worth reporting; stopping a recorder
+  // that never started must not raise "ffmpeg exited with code undefined".
+  await recorder.stop();
+});

--- a/package/ego-browser/src/video-recorder.ts
+++ b/package/ego-browser/src/video-recorder.ts
@@ -15,6 +15,31 @@ type VideoRecorderOptions = {
 
 const FPS = 25;
 const MAX_STDERR_LENGTH = 64 * 1024;
+const BATCH_SHIM = /\.(?:cmd|bat)$/i;
+
+/**
+ * Map a spawn failure to guidance the caller can act on. ENOENT means nothing
+ * was found at the path; EINVAL on a .cmd/.bat means the file exists but
+ * Windows will not launch a batch shim directly (Node refuses it since the
+ * CVE-2024-27980 mitigation), which is easy to hit because package managers
+ * install ffmpeg that way and the ENOENT message points users at this path.
+ */
+function startupError(error: unknown, ffmpegPath: string) {
+  const code = (error as any)?.code;
+  if (code === "ENOENT") {
+    return new Error(
+      "FFmpeg executable was not found. Install ffmpeg or set EGO_BROWSER_FFMPEG_PATH.",
+      { cause: error },
+    );
+  }
+  if (code === "EINVAL" && BATCH_SHIM.test(ffmpegPath)) {
+    return new Error(
+      `FFmpeg path ${JSON.stringify(ffmpegPath)} is a batch shim, which cannot be launched directly. Point EGO_BROWSER_FFMPEG_PATH at the ffmpeg executable itself.`,
+      { cause: error },
+    );
+  }
+  return error;
+}
 
 export class VideoRecorder {
   private _options: VideoRecorderOptions;
@@ -83,13 +108,19 @@ export class VideoRecorder {
       this._tempOutputPath,
     ];
     const spawnProcess = this._options.spawnProcess ?? spawn;
-    this._process = spawnProcess(
+    const ffmpegPath =
       this._options.ffmpegPath ??
-        process.env.EGO_BROWSER_FFMPEG_PATH ??
-        "ffmpeg",
-      args,
-      { stdio: ["pipe", "ignore", "pipe"] },
-    );
+      process.env.EGO_BROWSER_FFMPEG_PATH ??
+      "ffmpeg";
+    try {
+      this._process = spawnProcess(ffmpegPath, args, {
+        stdio: ["pipe", "ignore", "pipe"],
+      });
+    } catch (error) {
+      // Windows refuses to launch a .cmd/.bat shim directly and reports EINVAL
+      // synchronously, so this never reaches the "error" event handled below.
+      throw startupError(error, ffmpegPath);
+    }
     this._exitPromise = new Promise((resolve) => {
       this._process.once("close", (code, signal) => resolve({ code, signal }));
       this._process.once("error", (error) => resolve({ error }));
@@ -108,13 +139,7 @@ export class VideoRecorder {
         this._process.once("error", reject);
       });
     } catch (error) {
-      if ((error as any)?.code === "ENOENT") {
-        throw new Error(
-          "FFmpeg executable was not found. Install ffmpeg or set EGO_BROWSER_FFMPEG_PATH.",
-          { cause: error },
-        );
-      }
-      throw error;
+      throw startupError(error, ffmpegPath);
     }
   }
 
@@ -142,6 +167,13 @@ export class VideoRecorder {
   }
 
   private async _stop() {
+    // start() never produced a process (it threw, and already reported why).
+    // Without this guard the missing stdin/exit promise would surface as a
+    // second, misleading "ffmpeg exited with code undefined".
+    if (!this._process) {
+      await this._removeTempOutput();
+      return;
+    }
     if (this._lastFrame && this._firstFrameTimestamp !== undefined) {
       const elapsed = Math.max(this._now() - this._lastFrameReceivedAt, 1000);
       const finalFrameNumber = Math.floor(


### PR DESCRIPTION
## Summary

Screencast recording fails with a bare `Error: spawn EINVAL` — no mention of ffmpeg, the path, or a remedy — whenever `EGO_BROWSER_FFMPEG_PATH` points at a `.cmd`/`.bat` shim, which is how Chocolatey, npm wrappers, and several scoop configurations install ffmpeg on Windows. The failure lands on the exact remediation path the existing error message recommends, and it leaves the recorder half-constructed so the follow-up `stop()` reports a second, invented error: `ffmpeg exited with code undefined`.

Root cause: Node refuses to launch a batch file without a shell (the CVE-2024-27980 mitigation) and reports it by **throwing EINVAL synchronously out of `spawn()`**. `VideoRecorder.start()` assigns `this._process = spawnProcess(...)` outside any try/catch, so that throw bypasses the ENOENT-to-guidance mapping that handles the process `"error"` event, and `this._process` / `this._exitPromise` are never assigned.

## Related issue

No existing issue — found while checking whether `page.screencast` works on Windows, in the same Windows-readiness sweep as #223/#224/#226/#228.

## Reproduction

Windows 11, Node 24, against the built bundle:

```text
> ffmpegPath = C:\...\ffmpeg.cmd   (any batch shim; contents irrelevant)
before:  start FAILED -> Error | spawn EINVAL
         stop  FAILED -> Error | ffmpeg exited with code undefined
after:   start FAILED -> Error | FFmpeg path "C:\...\ffmpeg.cmd" is a batch shim, which cannot be
                          launched directly. Point EGO_BROWSER_FFMPEG_PATH at the ffmpeg executable itself.
         stop  OK
```

## Changes

- `src/video-recorder.ts` — the `spawn()` call is wrapped so a synchronous failure is routed through the same mapping as the async `"error"` event. Both paths now call one `startupError()` helper: ENOENT keeps today's exact wording, EINVAL on a `.cmd`/`.bat` target explains the batch-shim limitation and names the offending path, and any other failure propagates unchanged.
- `_stop()` returns early (after cleaning up the temp path) when no process was ever created, so a failed start reports only its own cause instead of a fabricated exit code.
- `src/video-recorder.test.mjs` — 4 tests: batch-shim guidance, synchronous ENOENT, unrecognized codes passing through untouched, and `stop()` after a failed start staying quiet.

Deliberately not doing: re-spawning batch shims through `shell: true`. That would put a user-supplied path and the filter string (commas, colons, parentheses) through a shell parser on Windows for a marginal convenience — the executable is one setting away, and this repo prefers the smaller change.

## Verification

Run from `package/ego-browser` (Windows 11, Node 24; the new tests inject `spawnProcess`, so they are platform-neutral and assert the same behavior on any OS):

```text
npm test                      -> 315 pass, 0 fail (311 existing + 4 new)
npm run typecheck             -> ok
npm run validate:site-skills  -> site skills ok
npm audit --audit-level=moderate -> 0 vulnerabilities
```

Revert-check: with `src/video-recorder.ts` reverted and the new tests kept, "explains a batch shim ffmpeg path rejected by the OS", "reports a missing executable thrown synchronously", and "stop after a failed start does not invent an exit code" all fail (11 pass / 3 fail); with the fix, 15 pass.

## Impact

- [x] Public helper API or behavior
- [ ] Agent skill or instructions
- [ ] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

Error reporting only — no successful recording changes behavior. The ENOENT message is byte-identical to today's (its existing test is untouched and still passes), so nothing that matches on that string breaks. `stop()` after a *successful* start is unchanged; only the never-started case is newly quiet.

## Checklist

- [x] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained above.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [x] A release-note label is selected (`fix`).
