### PR TITLE
fix(ego-browser): reject an unrecordable viewport instead of a 0x0 screencast

### DIFF
--- a/package/ego-browser/src/driver/screencast.test.mjs
+++ b/package/ego-browser/src/driver/screencast.test.mjs
@@ -729,3 +729,78 @@ test("stopScreencast surfaces an encoder frame failure and still finalizes", asy
     restore();
   }
 });
+
+test("startScreencast refuses to size a recording while a dialog is open", async () => {
+  const module = await import("../../dist/src/driver/screencast.js");
+  let recorderCreated = false;
+  const restore = module.__testing.setOverrides({
+    ensureSession: async () => "session-1",
+    pageInfo: async () => ({ dialog: { type: "confirm", message: "ok?" } }),
+    subscribeBrowserEvent: () => () => {},
+    browserCdp: async () => ({ result: {} }),
+    createRecorder: () => {
+      recorderCreated = true;
+      return { async start() {}, writeFrame() {}, async stop() {} };
+    },
+  });
+  try {
+    await assert.rejects(
+      () => module.startScreencast({ path: "artifacts/run.webm" }),
+      /JavaScript dialog is open.*explicit size/s,
+    );
+    assert.equal(recorderCreated, false, "no encoder is started");
+  } finally {
+    await module.stopScreencast().catch(() => {});
+    restore();
+  }
+});
+
+test("startScreencast reports an unusable viewport instead of a 0x0 recording", async () => {
+  const module = await import("../../dist/src/driver/screencast.js");
+  const restore = module.__testing.setOverrides({
+    ensureSession: async () => "session-1",
+    pageInfo: async () => ({ w: 0, h: 0 }),
+    subscribeBrowserEvent: () => () => {},
+    browserCdp: async () => ({ result: {} }),
+    createRecorder: () => ({
+      async start() {},
+      writeFrame() {},
+      async stop() {},
+    }),
+  });
+  try {
+    await assert.rejects(
+      () => module.startScreencast({ path: "artifacts/run.webm" }),
+      /could not derive a recordable size.*w: 0, h: 0/s,
+    );
+  } finally {
+    await module.stopScreencast().catch(() => {});
+    restore();
+  }
+});
+
+test("startScreencast rejects a viewport that scales below the encoder minimum", async () => {
+  const module = await import("../../dist/src/driver/screencast.js");
+  const restore = module.__testing.setOverrides({
+    ensureSession: async () => "session-1",
+    // Scaling 1000x2 to fit 800 leaves a height of 1, below the 2-pixel floor
+    // the explicit-size path already enforces.
+    pageInfo: async () => ({ w: 1000, h: 2 }),
+    subscribeBrowserEvent: () => () => {},
+    browserCdp: async () => ({ result: {} }),
+    createRecorder: () => ({
+      async start() {},
+      writeFrame() {},
+      async stop() {},
+    }),
+  });
+  try {
+    await assert.rejects(
+      () => module.startScreencast({ path: "artifacts/run.webm" }),
+      /could not derive a recordable size/,
+    );
+  } finally {
+    await module.stopScreencast().catch(() => {});
+    restore();
+  }
+});

--- a/package/ego-browser/src/driver/screencast.ts
+++ b/package/ego-browser/src/driver/screencast.ts
@@ -167,13 +167,29 @@ export async function stopScreencast() {
   if (stopError) throw stopError;
 }
 
+// An explicit size is rejected below 2 pixels, but the derived one used to go
+// through unchecked: page.info() reports { dialog } (no w/h) while a JavaScript
+// dialog is open and w/h of 0 for a tab that is not really there, and both
+// collapse to 0x0 here, which reaches ffmpeg as scale=0:0 and fails with an
+// encoder error that says nothing about the real cause.
 async function defaultSize() {
   const info = await dependencies.pageInfo();
+  if (info && "dialog" in info) {
+    throw new Error(
+      "page.screencast.start cannot measure the page while a JavaScript dialog is open. Handle the dialog first, or pass an explicit size.",
+    );
+  }
   const scale = Math.min(1, 800 / Math.max(info.w, info.h));
-  return evenSize({
+  const size = evenSize({
     width: Math.floor(info.w * scale),
     height: Math.floor(info.h * scale),
   });
+  if (!(size.width >= 2) || !(size.height >= 2)) {
+    throw new Error(
+      `page.screencast.start could not derive a recordable size from the current viewport (w: ${info.w}, h: ${info.h}). Restore the real tab, or pass an explicit size.`,
+    );
+  }
+  return size;
 }
 
 function evenSize(size: Size) {


### PR DESCRIPTION
## Summary

`page.screencast.start()` validates an explicitly passed `size` (rejecting anything under 2 pixels with a clear message) but never validates the size it derives itself. Two reachable states make that derived size `0x0`, which reaches ffmpeg as `scale=0:0` and fails with an encoder error that says nothing about the real cause:

- **A JavaScript dialog is open.** `page.info()` then returns `{ dialog }` with no `w`/`h`, so `Math.min(1, 800 / Math.max(undefined, undefined))` is `NaN`, and `NaN & ~1` is `0`.
- **The tab reports a zero viewport** — the `w: 0` / `h: 0` state SKILL.md already warns agents about ("stop screenshot/coordinate work until the real tab or viewport is restored").

A third case needs no zero at all: an extreme aspect ratio such as `1000x2` scales to a height of `1`, again below the floor the explicit path enforces.

## Related issue

No existing issue — found while auditing the screencast path alongside #251 (the other half of "recording fails for a reason the agent cannot act on").

## Changes

- `src/driver/screencast.ts` — `defaultSize()` now fails fast with an actionable message instead of handing a degenerate size to the encoder:
  - a pending dialog is named explicitly, pointing at the same remedy SKILL.md gives (handle the dialog first) or passing an explicit `size`;
  - any derived size below the 2-pixel floor reports the viewport it actually read (`w: 0, h: 0`), so the agent can tell "no usable tab" from "encoder problem".
  The check runs on the **computed** size, so the extreme-aspect-ratio case is covered too, and it happens before the recorder is created — no encoder process is started and nothing needs cleaning up.
- `src/driver/screencast.test.mjs` — 3 tests: the dialog case (also asserting no encoder is created), the zero-viewport case, and the `1000x2` scale-below-minimum case.

No behavior change for any viewport that already produced a valid recording: the arithmetic is untouched, only a guard is added after it.

## Verification

Run from `package/ego-browser` (Windows 11, Node 24; tests inject `pageInfo` via the existing `__testing.setOverrides` seam, so they are platform-neutral):

```text
npm test                      -> 318 pass, 0 fail (315 existing + 3 new)
npm run typecheck             -> ok
npm run validate:site-skills  -> site skills ok
npm audit --audit-level=moderate -> 0 vulnerabilities
```

Degenerate-size arithmetic confirmed directly before writing the fix:

```text
{ dialog }      -> scale NaN -> floor(NaN) -> evenSize 0 x 0
{ w: 0, h: 0 }  -> 0 x 0
{ w: 1000, h: 2 } -> 800 x 1 -> evenSize 800 x 0
```

Revert-check: with `src/driver/screencast.ts` reverted and the new tests kept, all three fail (17 pass / 3 fail); with the fix, 20 pass.

## Impact

- [x] Public helper API or behavior
- [ ] Agent skill or instructions
- [ ] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

A start that previously produced a broken recording (or a confusing ffmpeg error) now fails immediately with the reason. Recordings that worked before are unaffected — the guard only rejects sizes the encoder could not have used. Independent of #251; both touch the screencast failure path but different files, and either can merge first.

## Checklist

- [x] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained above.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [x] A release-note label is selected (`fix`).
