### PR TITLE
docs(ego-browser): guard skill helper contract

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -6,6 +6,7 @@ on:
       - ".github/workflows/quality-gates.yml"
       - "lefthook.yml"
       - "package/ego-browser/**"
+      - "skills/ego-browser/SKILL.md"
       - "skills/ego-browser/learnings/**"
   push:
     branches:
@@ -15,6 +16,7 @@ on:
       - ".github/workflows/quality-gates.yml"
       - "lefthook.yml"
       - "package/ego-browser/**"
+      - "skills/ego-browser/SKILL.md"
       - "skills/ego-browser/learnings/**"
 
 jobs:
@@ -72,4 +74,3 @@ jobs:
       - name: Validate site skills
         working-directory: package/ego-browser
         run: npm run validate:site-skills
-

--- a/package/ego-browser/src/legacy-skill-guard.test.mjs
+++ b/package/ego-browser/src/legacy-skill-guard.test.mjs
@@ -1,12 +1,20 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import {
+  LEGACY_GLOBAL_HELPERS,
   LEGACY_TASK_SPACE_REPLACEMENTS,
   STALE_SKILL_PREFIX,
   installLegacySkillGuards,
 } from "../dist/src/legacy-skill-guard.js";
 import { resetSink } from "../dist/src/output-sink.js";
+
+const SKILL_URL = new URL(
+  "../../../skills/ego-browser/SKILL.md",
+  import.meta.url,
+);
 
 const EXPECTED_TASK_SPACE_REPLACEMENTS = {
   listTaskSpaces: "taskSpaces.list()",
@@ -65,3 +73,36 @@ test("legacy skill guards cover only the removed task-space global surface", () 
   }
   resetSink();
 });
+
+test("the current skill examples do not call removed global helpers", () => {
+  const skill = readFileSync(fileURLToPath(SKILL_URL), "utf8");
+  const examples = executableCodeBlocks(skill);
+
+  assert.notEqual(examples, "", "SKILL.md must contain executable examples");
+
+  for (const helper of LEGACY_GLOBAL_HELPERS) {
+    const unqualifiedCall = new RegExp(
+      `(?<![\\w.])${escapeRegExp(helper)}(?=\\s*\\()`,
+      "g",
+    );
+    assert.doesNotMatch(
+      examples,
+      unqualifiedCall,
+      `SKILL.md must use the current facade instead of ${helper}(...)`,
+    );
+  }
+});
+
+function executableCodeBlocks(markdown) {
+  return [
+    ...markdown.matchAll(
+      /```(?:bash|js|javascript|ts|typescript)\n([\s\S]*?)```/g,
+    ),
+  ]
+    .map((match) => match[1])
+    .join("\n");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/package/ego-browser/src/legacy-skill-guard.ts
+++ b/package/ego-browser/src/legacy-skill-guard.ts
@@ -6,7 +6,7 @@ type InstallTarget = Record<string, unknown>;
  * Globals removed when the agent-facing API moved to Playwright-style facades.
  * Keep this list as the single cleanup source for both embedded and direct-CLI runs.
  */
-const LEGACY_GLOBAL_HELPERS = [
+export const LEGACY_GLOBAL_HELPERS = [
   "click",
   "dblclick",
   "hover",

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -126,8 +126,8 @@ EOF
 
 ## Runtime map
 
-- `page`: navigation and state (`goto`, `reload`, `url`, `title`, `info`), semantic locators, waits, `snapshot`, `screenshot`, `screencast`, `evaluate`, `keyboard`, `mouse`, downloads, and event draining.
-- `page.locator(selector)`: chaining and filtering; `first` / `nth` / `last`; click, hover, `dragTo`, `scrollIntoViewIfNeeded`, form, keyboard, upload, state-read, collection, element-evaluate, screenshot, and wait methods.
+- `page`: navigation and state (`goto`, `reload`, `url`, `title`, `info`), semantic locators, waits, `snapshot`, `screenshot`, `screencast`, `evaluate`, keyboard (`press`, `down`, `up`, `insertText`, `type`), mouse, downloads, and event draining.
+- `page.locator(selector)`: chaining and filtering; `first` / `nth` / `last`; click, hover, `dragTo`, `scrollIntoViewIfNeeded`, form, keyboard (`press`, `pressSequentially`), upload, state-read, collection, element-evaluate, screenshot, and wait methods.
 - `browser`: `listTabs`, `currentTab`, `switchTab`, `openOrReuseTab`, `closeTab`, `ensureRealTab`, `iframeTarget`.
 - `taskSpaces`: `list`, `switch`, `new`, `useOrCreate`, `claim`, `complete`, `handOff`, `takeOver`, `waitForAgentControl`.
 - `fetch.server` performs Node-side requests; `fetch.browser` performs requests in the current page origin. Use `cdp` only as an escape hatch.


### PR DESCRIPTION
## Summary

Make the current Playwright-style keyboard surface explicit in the canonical ego-browser Skill and prevent executable examples from drifting back to removed global helpers. Also ensure changes to the canonical Skill trigger the repository quality-gates workflow.

This is the repository-side portion of #260. The hosted documentation examples still need to be updated in their publishing source.

## Related issue

Related to #260

## Changes

- Document the current `page.keyboard` and locator keyboard methods in `skills/ego-browser/SKILL.md`.
- Add a regression test that scans executable Skill examples for unqualified calls to removed global helpers.
- Reuse the runtime's legacy-helper list as the test's source of truth.
- Run quality gates when the canonical Skill changes, not only when site learnings change.

## Verification

```text
npm test                         # 312 passed
npm run validate:site-skills     # passed
npm run validate:agent-style     # passed
npm run typecheck                # passed
npm audit --audit-level=moderate # 0 vulnerabilities
prettier --check                 # passed for changed package files
git diff --check                 # passed
```

A real-browser E2E run passed 43/45 cases (518 assertions), including helper surface, Task Spaces, and both keyboard suites. Two unrelated environment/flaky cases failed:

- screencast recording: the Ego subprocess could not find FFmpeg, although it is installed at `/opt/homebrew/bin/ffmpeg` on the host;
- concert ticket rush: inventory remained `2` instead of decrementing to `1`.

## Impact

- [ ] Public helper API or behavior
- [x] Agent skill or instructions
- [ ] Site learning
- [ ] Installation or update flow
- [x] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

No runtime helper behavior changes. The test only guards examples against APIs already removed on `dev`.

## Checklist

- [x] The PR targets the correct base branch (`dev` for normal changes; only `dev` may target `main`).
- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is explained above.
- [x] Relevant tests and validation commands pass locally.
- [x] Public helper JSDoc and agent-facing documentation are updated when the helper surface changes.
- [x] No credentials, tokens, cookies, personal data, or other secrets are included.
- [ ] A release-note label is selected (`feat`, `fix`, `docs`, `chore`, `ci`, or `refactor`). The repository currently exposes none of these labels, so `documentation` was applied instead.
