### PR TITLE
feat(ego-browser): reclaim idle agent task spaces to release renderers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Task spaces are isolated browsing contexts with an ownership model (`agent` / `u
 - `useOrCreateTaskSpace(nameOrId)` reuses an agent-owned space or creates a new one; it no longer auto-claims user-owned spaces. Use `claimTaskSpace(nameOrId)` to take ownership of a user-owned space. Ids are numeric; prefer `task.id` over names across rounds.
 - `switchTaskSpace` requires agent ownership; `newTaskSpace` creates; `completeTaskSpace(nameOrId, { keep })` finishes (`keep` is mandatory).
 - Control handoff: `handOffTaskSpace` / `takeOverTaskSpace` / `waitForAgentControl`.
+- Idle reclamation (`src/taskspace-reclaim.ts` + `src/taskspace-activity.ts`): `run.ts` `execute()` runs `reclaimIdleTaskSpaces()` once before the agent script, auto-closing agent-owned task spaces left idle by earlier sessions so their renderer processes don't pile up. `helpers.ts` `selectTaskSpace` touches a per-space timestamp (persisted atomically to `EGO_RECLAIM_STATE_FILE`, default `~/.local/share/ego/reclaim-state.json`). First-sight seeding skips spaces with no record (created before this feature shipped, or in use by a concurrent session) — they only become reclaimable after the idle window elapses. Only `ownership === "agent"` is ever reclaimed. Env: `EGO_RECLAIM_IDLE_S` (default 7200s = 2h), `EGO_RECLAIM_MAX_SPACES` (default 8), `EGO_RECLAIM_DISABLE` (1/true). Tests: `src/taskspace-{activity,reclaim}.test.mjs`.
 
 ## Key Directories
 - `package/ego-browser/src/` — runtime, helpers, resolver, drivers, learning subsystem.

--- a/package/ego-browser/src/helpers.test.mjs
+++ b/package/ego-browser/src/helpers.test.mjs
@@ -18,9 +18,18 @@ import {
 function withEgo(ego, fn) {
   const previous = globalThis.ego;
   globalThis.ego = ego;
+  // Disable idle reclamation so task-space helper call sequences stay
+  // deterministic; reclamation has its own suite.
+  const prevReclaimDisable = process.env.EGO_RECLAIM_DISABLE;
+  process.env.EGO_RECLAIM_DISABLE = "1";
   return Promise.resolve()
     .then(fn)
     .finally(() => {
+      if (prevReclaimDisable === undefined) {
+        delete process.env.EGO_RECLAIM_DISABLE;
+      } else {
+        process.env.EGO_RECLAIM_DISABLE = prevReclaimDisable;
+      }
       if (previous === undefined) {
         delete globalThis.ego;
       } else {

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -23,6 +23,8 @@ import {
   siteSkillsForUrl as siteSkillsForUrlCore,
   wrapBrowserTool,
 } from "./learning/index.js";
+import { reclaimConfig, touchTaskSpace } from "./taskspace-activity.js";
+import { reclaimIdleTaskSpaces } from "./taskspace-reclaim.js";
 
 export { NAME } from "./state.js";
 export { cdp, evaluate } from "./cdp-eval.js";
@@ -191,6 +193,11 @@ export async function newTaskSpace(name) {
  * @returns {Promise<{taskId:string,id:number,name:string,createdBy?:string,ownership?:string,recentTabTitles?:string[]}>}
  */
 export async function useOrCreateTaskSpace(nameOrId) {
+  try {
+    await reclaimIdleTaskSpaces();
+  } catch {
+    // Idle reclamation must never block task-space use.
+  }
   const spaces = await listTaskSpaces();
   const existing = findMatchingTaskSpace(spaces, nameOrId);
   if (!existing) {
@@ -247,6 +254,13 @@ async function selectTaskSpace(ego, space, op: string) {
     throw new Error(`${op} requires ego.useTaskSpace`);
   }
   assertNoEgoError(await ego.useTaskSpace(taskSpaceNumericId(space, op)), op);
+  if (isAgentOwned(space.ownership) && !reclaimConfig().disabled) {
+    try {
+      await touchTaskSpace(taskSpaceNumericId(space, op));
+    } catch {
+      // Activity tracking is best-effort; never block a select.
+    }
+  }
   return space;
 }
 

--- a/package/ego-browser/src/run.ts
+++ b/package/ego-browser/src/run.ts
@@ -7,6 +7,7 @@ import {
 import { formatCliLogValue } from "./format.js";
 import * as helpers from "./helpers.js";
 import { bufferOutput, flushSink, resetSink } from "./output-sink.js";
+import { reclaimIdleTaskSpaces } from "./taskspace-reclaim.js";
 
 type WritableLike = {
   write(chunk: string): unknown;
@@ -109,6 +110,13 @@ async function execute(code: string, stdout: WritableLike) {
   resetSink();
   const context = await executionContext();
   Object.assign(globalThis, context);
+  try {
+    await reclaimIdleTaskSpaces();
+  } catch (error) {
+    console.log(
+      `[ego-reclaim] warning: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
   const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
   const names = Object.keys(context);
   const values = Object.values(context);

--- a/package/ego-browser/src/state.ts
+++ b/package/ego-browser/src/state.ts
@@ -37,6 +37,7 @@ export const state = {
   defaultTimeout: 10000,
   // Last observed Network domain state on the default session (tracked in cdp()).
   networkDomainEnabled: false,
+  reclaimDone: false,
 };
 
 export async function send(req) {

--- a/package/ego-browser/src/taskspace-activity.test.mjs
+++ b/package/ego-browser/src/taskspace-activity.test.mjs
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  loadActivity,
+  reclaimConfig,
+  reclaimStateFile,
+  saveActivity,
+  touchTaskSpace,
+} from "../dist/src/taskspace-activity.js";
+
+async function withStateFile(fn) {
+  const dir = mkdtempSync(join(tmpdir(), "ego-act-"));
+  const file = join(dir, "state.json");
+  const prev = process.env.EGO_RECLAIM_STATE_FILE;
+  process.env.EGO_RECLAIM_STATE_FILE = file;
+  try {
+    return await fn(file);
+  } finally {
+    if (prev === undefined) delete process.env.EGO_RECLAIM_STATE_FILE;
+    else process.env.EGO_RECLAIM_STATE_FILE = prev;
+    rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+  }
+}
+
+test("save/load activity round-trips space timestamps", async () => {
+  await withStateFile(async () => {
+    await saveActivity({ 1: 1000, 2: 2000 });
+    assert.deepEqual(loadActivity(), { 1: 1000, 2: 2000 });
+  });
+});
+
+test("touchTaskSpace records a fresh timestamp", async () => {
+  await withStateFile(async () => {
+    await touchTaskSpace(7);
+    const map = loadActivity();
+    assert.ok(typeof map[7] === "number");
+    assert.ok(Math.abs(map[7] - Date.now()) < 5000);
+  });
+});
+
+test("loadActivity is tolerant of missing and corrupt files", async () => {
+  await withStateFile(async (file) => {
+    assert.deepEqual(loadActivity(), {});
+    writeFileSync(file, "{not json", "utf8");
+    assert.deepEqual(loadActivity(), {});
+  });
+});
+
+test("reclaimConfig defaults and env overrides", () => {
+  const prev = {
+    idle: process.env.EGO_RECLAIM_IDLE_S,
+    max: process.env.EGO_RECLAIM_MAX_SPACES,
+    dis: process.env.EGO_RECLAIM_DISABLE,
+  };
+  try {
+    delete process.env.EGO_RECLAIM_IDLE_S;
+    delete process.env.EGO_RECLAIM_MAX_SPACES;
+    delete process.env.EGO_RECLAIM_DISABLE;
+    assert.deepEqual(reclaimConfig(), {
+      idleSec: 7200,
+      maxSpaces: 8,
+      disabled: false,
+    });
+    process.env.EGO_RECLAIM_IDLE_S = "1800";
+    process.env.EGO_RECLAIM_MAX_SPACES = "4";
+    process.env.EGO_RECLAIM_DISABLE = "1";
+    assert.deepEqual(reclaimConfig(), {
+      idleSec: 1800,
+      maxSpaces: 4,
+      disabled: true,
+    });
+  } finally {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+});
+
+test("reclaimStateFile respects env override", () => {
+  const prev = process.env.EGO_RECLAIM_STATE_FILE;
+  try {
+    process.env.EGO_RECLAIM_STATE_FILE = "/tmp/custom-state.json";
+    assert.equal(reclaimStateFile(), "/tmp/custom-state.json");
+  } finally {
+    if (prev === undefined) delete process.env.EGO_RECLAIM_STATE_FILE;
+    else process.env.EGO_RECLAIM_STATE_FILE = prev;
+  }
+});

--- a/package/ego-browser/src/taskspace-activity.ts
+++ b/package/ego-browser/src/taskspace-activity.ts
@@ -1,0 +1,121 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import { resolvePath } from "./env.js";
+import { state } from "./state.js";
+
+/**
+ * Idle task-space reclamation state.
+ *
+ * The ego-browser harness is a short-lived process (one Node invocation per
+ * heredoc round), so it cannot keep task-space activity timestamps in memory.
+ * Instead it persists `{ spaceId -> lastTouchedAtMs }` to a JSON file on disk.
+ * `reclaimIdleTaskSpaces()` (see taskspace-reclaim.ts) reads this map on every
+ * harness startup and closes agent-owned task spaces that have been idle longer
+ * than the configured threshold, which lets the browser reclaim their renderer
+ * processes. Only agent-owned spaces are touched; user tabs are never closed.
+ *
+ * Env overrides:
+ *   EGO_RECLAIM_STATE_FILE  — absolute path to the state file (default
+ *                             ~/.local/share/ego/reclaim-state.json)
+ *   EGO_RECLAIM_IDLE_S      — idle threshold in seconds (default 7200 = 2h)
+ *   EGO_RECLAIM_MAX_SPACES  — hard cap on live agent spaces (default 8)
+ *   EGO_RECLAIM_DISABLE     — "1"/"true" disables reclamation entirely
+ */
+export type ActivityMap = Record<number, number>;
+
+const DEFAULT_STATE_FILE = resolve(
+  process.env.HOME || process.env.USERPROFILE || ".",
+  ".local/share/ego/reclaim-state.json",
+);
+
+export function reclaimStateFile(): string {
+  const override = process.env.EGO_RECLAIM_STATE_FILE;
+  return override ? resolvePath(override) : DEFAULT_STATE_FILE;
+}
+
+export function reclaimConfig() {
+  return {
+    idleSec: envInt("EGO_RECLAIM_IDLE_S", 7200),
+    maxSpaces: envInt("EGO_RECLAIM_MAX_SPACES", 8),
+    disabled: envFlag("EGO_RECLAIM_DISABLE", false),
+  };
+}
+
+function envInt(key: string, fallback: number): number {
+  const v = process.env[key];
+  if (!v) return fallback;
+  const n = Number(v);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+function envFlag(key: string, fallback: boolean): boolean {
+  const v = process.env[key];
+  if (v === undefined) return fallback;
+  return /^(1|true|yes|on)$/i.test(v);
+}
+
+export function loadActivity(): ActivityMap {
+  try {
+    const file = reclaimStateFile();
+    if (!existsSync(file)) return {};
+    const raw: unknown = JSON.parse(readFileSync(file, "utf8"));
+    if (raw && typeof raw === "object" && "spaces" in raw) {
+      return normalizeActivity(raw.spaces);
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function normalizeActivity(raw: unknown): ActivityMap {
+  const out: ActivityMap = {};
+  if (!raw || typeof raw !== "object") return out;
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    const id = Number(k);
+    const ts = Number(v);
+    if (Number.isFinite(id) && Number.isFinite(ts)) out[id] = ts;
+  }
+  return out;
+}
+
+export async function saveActivity(map: ActivityMap): Promise<void> {
+  let tmp: string | undefined;
+  try {
+    const file = reclaimStateFile();
+    mkdirSync(dirname(file), { recursive: true });
+    const payload = JSON.stringify({ spaces: map, v: 1 }, null, 2);
+    // Atomic write: write a temp file then rename, so a concurrent harness
+    // process never reads a half-written JSON (which would make loadActivity
+    // return {} and bypass idle protection).
+    tmp = `${file}.tmp.${process.pid}`;
+    const write = state.writeFile;
+    if (typeof write === "function") {
+      await write(tmp, payload, "utf8");
+      renameSync(tmp, file);
+    }
+  } catch {
+    // Best-effort: a failing state file must never block agent work. Clean up
+    // the temp file so it can't accumulate across runs.
+    if (tmp) {
+      try {
+        unlinkSync(tmp);
+      } catch {
+        // already gone
+      }
+    }
+  }
+}
+
+/**
+ * Record that an agent-owned task space was just selected/used, so the idle
+ * reaper keeps it alive. Safe to call for any numeric space id; callers should
+ * only call this for agent-owned spaces.
+ */
+export async function touchTaskSpace(spaceId: number): Promise<void> {
+  if (!Number.isFinite(spaceId)) return;
+  const map = loadActivity();
+  map[spaceId] = typeof state.now === "function" ? state.now() : Date.now();
+  await saveActivity(map);
+}

--- a/package/ego-browser/src/taskspace-e2e.test.mjs
+++ b/package/ego-browser/src/taskspace-e2e.test.mjs
@@ -81,6 +81,12 @@ class FakeEgo {
 async function runTaskspaceScript(ego, code) {
   const previous = globalThis.ego;
   globalThis.ego = ego;
+  // Idle reclamation runs once per harness startup and would prepend a stray
+  // listTaskSpaces call before the script; disable it here so these e2e tests
+  // stay focused on task-space helper call sequences. Reclamation has its own
+  // dedicated suite (taskspace-reclaim.test.mjs).
+  const prevReclaimDisable = process.env.EGO_RECLAIM_DISABLE;
+  process.env.EGO_RECLAIM_DISABLE = "1";
   const stdout = captureStream();
   const stderr = captureStream();
   try {
@@ -93,6 +99,11 @@ async function runTaskspaceScript(ego, code) {
     });
     return { exitCode, stdout: stdout.text(), stderr: stderr.text() };
   } finally {
+    if (prevReclaimDisable === undefined) {
+      delete process.env.EGO_RECLAIM_DISABLE;
+    } else {
+      process.env.EGO_RECLAIM_DISABLE = prevReclaimDisable;
+    }
     if (previous === undefined) {
       delete globalThis.ego;
     } else {

--- a/package/ego-browser/src/taskspace-reclaim.test.mjs
+++ b/package/ego-browser/src/taskspace-reclaim.test.mjs
@@ -1,0 +1,239 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { reclaimIdleTaskSpaces } from "../dist/src/taskspace-reclaim.js";
+import { loadActivity, saveActivity } from "../dist/src/taskspace-activity.js";
+import { state } from "../dist/src/state.js";
+
+class FakeEgo {
+  constructor(taskSpaces = []) {
+    this.taskSpaces = taskSpaces.map((s) => ({ ...s }));
+    this.calls = [];
+    this.selectedId = null;
+  }
+  async listTaskSpaces() {
+    this.calls.push(["listTaskSpaces"]);
+    return { taskSpaces: this.taskSpaces.map((s) => ({ ...s })) };
+  }
+  useTaskSpace(id) {
+    if (typeof id !== "number") throw new TypeError("numeric id");
+    this.calls.push(["useTaskSpace", id]);
+    this.selectedId = id;
+    return id;
+  }
+  async closeTaskSpace() {
+    this.calls.push(["closeTaskSpace"]);
+    const id = this.selectedId;
+    this.taskSpaces = this.taskSpaces.filter((s) => s.id !== id);
+    this.selectedId = null;
+    return { closed: id };
+  }
+}
+
+const HOUR = 3600 * 1000;
+const MIN = 60 * 1000;
+
+async function setup({ spaces, activity, env = {} }) {
+  state.reclaimDone = false;
+  const dir = mkdtempSync(join(tmpdir(), "ego-reclaim-"));
+  const stateFile = join(dir, "state.json");
+  const prevEnv = {};
+  for (const [k, v] of Object.entries(env)) {
+    prevEnv[k] = process.env[k];
+    process.env[k] = v;
+  }
+  const prevStateFile = process.env.EGO_RECLAIM_STATE_FILE;
+  process.env.EGO_RECLAIM_STATE_FILE = stateFile;
+  if (activity) await saveActivity(activity);
+  const ego = new FakeEgo(spaces);
+  const prevEgo = globalThis.ego;
+  globalThis.ego = ego;
+  return {
+    ego,
+    stateFile,
+    cleanup() {
+      for (const [k, v] of Object.entries(prevEnv)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+      if (prevStateFile === undefined) delete process.env.EGO_RECLAIM_STATE_FILE;
+      else process.env.EGO_RECLAIM_STATE_FILE = prevStateFile;
+      if (prevEgo === undefined) delete globalThis.ego;
+      else globalThis.ego = prevEgo;
+      rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+    },
+  };
+}
+
+test("reclaims agent space idle past threshold, keeps fresh one", async () => {
+  const now = 1700000000000;
+  const ctx = await setup({
+    spaces: [
+      { taskId: "stale", id: 1, name: "stale", ownership: "agent" },
+      { taskId: "fresh", id: 2, name: "fresh", ownership: "agent" },
+    ],
+    activity: { 1: now - 3 * HOUR, 2: now - 10 * MIN },
+  });
+  try {
+    const r = await reclaimIdleTaskSpaces({ now: () => now, log() {} });
+    assert.equal(r.scanned, 2);
+    assert.equal(r.reclaimed, 1);
+    assert.equal(ctx.ego.taskSpaces.length, 1);
+    assert.equal(ctx.ego.taskSpaces[0].id, 2);
+    assert.equal(
+      ctx.ego.calls.filter((c) => c[0] === "closeTaskSpace").length,
+      1,
+    );
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test("never touches user-owned spaces", async () => {
+  const now = 1700000000000;
+  const ctx = await setup({
+    spaces: [
+      { taskId: "agent-old", id: 1, name: "agent-old", ownership: "agent" },
+      { taskId: "user-tab", id: 2, name: "user-tab", ownership: "user" },
+    ],
+    activity: { 1: now - 5 * HOUR },
+  });
+  try {
+    const r = await reclaimIdleTaskSpaces({ now: () => now, log() {} });
+    assert.equal(r.scanned, 1);
+    assert.equal(r.reclaimed, 1);
+    const ids = ctx.ego.taskSpaces.map((s) => s.id).sort((a, b) => a - b);
+    assert.deepEqual(ids, [2]);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test("hard cap reclaims oldest even when all fresh", async () => {
+  const now = 1700000000000;
+  const spaces = [];
+  for (let i = 1; i <= 5; i++) {
+    spaces.push({ taskId: `s${i}`, id: i, name: `s${i}`, ownership: "agent" });
+  }
+  // larger i -> older (smaller timestamp); ranked ascending reclaims oldest first
+  const activity = {};
+  for (let i = 1; i <= 5; i++) activity[i] = now - i * MIN;
+  const ctx = await setup({
+    spaces,
+    activity,
+    env: { EGO_RECLAIM_MAX_SPACES: "3" },
+  });
+  try {
+    const r = await reclaimIdleTaskSpaces({ now: () => now, log() {} });
+    assert.equal(r.reclaimed, 2);
+    const ids = ctx.ego.taskSpaces.map((s) => s.id).sort((a, b) => a - b);
+    assert.deepEqual(ids, [1, 2, 3]);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test("disabled env reclaims nothing", async () => {
+  const now = 1700000000000;
+  const ctx = await setup({
+    spaces: [{ taskId: "x", id: 1, name: "x", ownership: "agent" }],
+    activity: { 1: now - 10 * HOUR },
+    env: { EGO_RECLAIM_DISABLE: "1" },
+  });
+  try {
+    const r = await reclaimIdleTaskSpaces({ now: () => now, log() {} });
+    assert.equal(r.reclaimed, 0);
+    assert.equal(ctx.ego.taskSpaces.length, 1);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test("no ego runtime returns empty without throwing", async () => {
+  state.reclaimDone = false;
+  const prev = globalThis.ego;
+  delete globalThis.ego;
+  const dir = mkdtempSync(join(tmpdir(), "ego-reclaim-"));
+  const prevFile = process.env.EGO_RECLAIM_STATE_FILE;
+  process.env.EGO_RECLAIM_STATE_FILE = join(dir, "s.json");
+  try {
+    const r = await reclaimIdleTaskSpaces({ log() {} });
+    assert.equal(r.reclaimed, 0);
+    assert.equal(r.scanned, 0);
+  } finally {
+    if (prevFile === undefined) delete process.env.EGO_RECLAIM_STATE_FILE;
+    else process.env.EGO_RECLAIM_STATE_FILE = prevFile;
+    rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+    if (prev !== undefined) globalThis.ego = prev;
+  }
+});
+
+test("first sight seeds instead of reclaiming (deploy safety)", async () => {
+  const now = 1700000000000;
+  // No activity file at all — every space is unknown on first deploy.
+  const ctx = await setup({
+    spaces: [
+      { taskId: "unknown-a", id: 1, name: "unknown-a", ownership: "agent" },
+      { taskId: "unknown-b", id: 2, name: "unknown-b", ownership: "agent" },
+    ],
+  });
+  try {
+    const r = await reclaimIdleTaskSpaces({ now: () => now, log() {} });
+    assert.equal(r.reclaimed, 0);
+    assert.equal(ctx.ego.taskSpaces.length, 2);
+    assert.equal(
+      ctx.ego.calls.filter((c) => c[0] === "closeTaskSpace").length,
+      0,
+    );
+    // Seeded timestamps persisted for next round.
+    const seeded = loadActivity();
+    assert.equal(typeof seeded[1], "number");
+    assert.equal(typeof seeded[2], "number");
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test("seeded space reclaims only after idle window elapses", async () => {
+  const t0 = 1700000000000;
+  const ctx = await setup({
+    spaces: [{ taskId: "x", id: 1, name: "x", ownership: "agent" }],
+  });
+  try {
+    await reclaimIdleTaskSpaces({ now: () => t0, log() {} });
+    assert.equal(ctx.ego.taskSpaces.length, 1);
+    // No touch in between; 3h later the seeded space is now reclaimable.
+    state.reclaimDone = false;
+    const r = await reclaimIdleTaskSpaces({
+      now: () => t0 + 3 * HOUR,
+      log() {},
+    });
+    assert.equal(r.reclaimed, 1);
+    assert.equal(ctx.ego.taskSpaces.length, 0);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test("first-sight spaces are also exempt from the hard cap", async () => {
+  const now = 1700000000000;
+  const spaces = [];
+  for (let i = 1; i <= 5; i++) {
+    spaces.push({ taskId: `s${i}`, id: i, name: `s${i}`, ownership: "agent" });
+  }
+  // No activity records — all first-sight; cap must NOT reclaim any.
+  const ctx = await setup({
+    spaces,
+    env: { EGO_RECLAIM_MAX_SPACES: "3" },
+  });
+  try {
+    const r = await reclaimIdleTaskSpaces({ now: () => now, log() {} });
+    assert.equal(r.reclaimed, 0);
+    assert.equal(ctx.ego.taskSpaces.length, 5);
+  } finally {
+    ctx.cleanup();
+  }
+});

--- a/package/ego-browser/src/taskspace-reclaim.ts
+++ b/package/ego-browser/src/taskspace-reclaim.ts
@@ -1,0 +1,211 @@
+import { assertNoEgoError } from "./ego-errors.js";
+import { loadActivity, reclaimConfig, saveActivity } from "./taskspace-activity.js";
+import { state } from "./state.js";
+
+export type ReclaimSpace = {
+  id: number;
+  name?: string;
+  taskId?: string;
+  ownership?: string;
+};
+
+export type ReclaimResult = {
+  scanned: number;
+  reclaimed: number;
+  details: string[];
+};
+
+type ReclaimDeps = {
+  /** Override enumeration (tests). Defaults to ego.listTaskSpaces. */
+  list?: () => Promise<ReclaimSpace[]>;
+  /** Override closure (tests). Defaults to ego.useTaskSpace + ego.closeTaskSpace. */
+  complete?: (id: number) => Promise<unknown>;
+  /** Sink for human-readable reclaim notices. */
+  log?: (msg: string) => void;
+  /** Clock override (ms). */
+  now?: () => number;
+};
+
+/**
+ * Local mirror of helpers.normalizeTaskSpace. Kept here so this module does not
+ * import helpers (helpers imports reclaimIdleTaskSpaces); that would be a cycle.
+ */
+function normalizeTaskSpace(space: unknown): ReclaimSpace | null {
+  if (!space || typeof space !== "object") return null;
+  const entries = Object.entries(space as object);
+  const get = (key: string): unknown =>
+    entries.find(([k]) => k === key)?.[1];
+  const taskId = get("taskId") ?? get("name") ?? get("id");
+  if (taskId === undefined || taskId === null || taskId === "") return null;
+  const rawId = get("id") ?? taskId;
+  const id = Number(rawId);
+  if (!Number.isFinite(id)) return null;
+  const rawName = get("name") ?? taskId;
+  const rawOwnership = get("ownership");
+  return {
+    id,
+    taskId: String(taskId),
+    name: String(rawName),
+    ownership: typeof rawOwnership === "string" ? rawOwnership : undefined,
+  };
+}
+
+async function listAllTaskSpaces(): Promise<ReclaimSpace[]> {
+  const ego = globalThis.ego as
+    | { listTaskSpaces?: () => Promise<unknown> }
+    | undefined;
+  if (!ego || typeof ego.listTaskSpaces !== "function") {
+    throw new Error("listTaskSpaces requires ego.listTaskSpaces");
+  }
+  const raw = assertNoEgoError(await ego.listTaskSpaces(), "listTaskSpaces");
+  if (!raw || typeof raw !== "object" || !("taskSpaces" in raw)) {
+    throw new Error("listTaskSpaces expected { taskSpaces: [...] }");
+  }
+  const arr = (raw as { taskSpaces: unknown }).taskSpaces;
+  if (!Array.isArray(arr)) {
+    throw new Error("listTaskSpaces expected { taskSpaces: [...] }");
+  }
+  return arr
+    .map(normalizeTaskSpace)
+    .filter((s): s is ReclaimSpace => s !== null);
+}
+
+async function closeAgentTaskSpace(id: number): Promise<void> {
+  const ego = globalThis.ego as
+    | {
+        useTaskSpace?: (id: number) => unknown;
+        closeTaskSpace?: () => Promise<unknown>;
+      }
+    | undefined;
+  if (!ego) throw new Error("close requires ego runtime");
+  if (typeof ego.useTaskSpace === "function") {
+    assertNoEgoError(await ego.useTaskSpace(id), "useTaskSpace");
+  }
+  if (typeof ego.closeTaskSpace !== "function") {
+    throw new Error("requires ego.closeTaskSpace");
+  }
+  assertNoEgoError(await ego.closeTaskSpace(), "closeTaskSpace");
+}
+
+/**
+ * Close agent-owned task spaces that have been idle past the configured
+ * threshold or that exceed the live-space cap, so their renderer processes
+ * don't pile up across sessions.
+ *
+ * Reached once per harness process: app-mode agents hit it via
+ * useOrCreateTaskSpace (helpers.ts); CLI mode hits it via run.ts execute().
+ * `state.reclaimDone` makes the two entry points collapse to a single reap.
+ *
+ * Only `ownership === "agent"` spaces are reclaimed. User-owned and
+ * agentDelegatedToUser spaces are never touched. Failures are logged but never
+ * throw; the agent script still runs.
+ */
+export async function reclaimIdleTaskSpaces(
+  deps: ReclaimDeps = {},
+): Promise<ReclaimResult> {
+  const log = deps.log ?? ((m: string) => console.log(m));
+  const now = deps.now ?? Date.now;
+  const listFn = deps.list ?? listAllTaskSpaces;
+  const completeFn = deps.complete ?? closeAgentTaskSpace;
+
+  const cfg = reclaimConfig();
+  if (cfg.disabled) return { scanned: 0, reclaimed: 0, details: [] };
+  if (state.reclaimDone) return { scanned: 0, reclaimed: 0, details: [] };
+  state.reclaimDone = true;
+
+  let spaces: ReclaimSpace[];
+  try {
+    spaces = await listFn();
+  } catch {
+    // No ego runtime / cannot enumerate — nothing to reclaim.
+    return { scanned: 0, reclaimed: 0, details: [] };
+  }
+
+  const agentSpaces = spaces.filter((s) => s && s.ownership === "agent");
+  if (agentSpaces.length === 0) {
+    return { scanned: 0, reclaimed: 0, details: [] };
+  }
+
+  const activity = loadActivity();
+  const idleMs = cfg.idleSec * 1000;
+  const idleMin = Math.round(idleMs / 60000);
+
+  // First-sight seeding: a space with no activity record (state file missing,
+  // fresh machine, or created before this feature shipped — including a space
+  // a concurrent omp session is actively using) must never be reclaimed on
+  // sight. Seed it with now so it only becomes reclaimable once the idle
+  // threshold elapses without further use; the seeded timestamp persists via
+  // the prune below.
+  const seededIds = new Set<number>();
+  for (const s of agentSpaces) {
+    if (activity[s.id] === undefined) {
+      activity[s.id] = now();
+      seededIds.add(s.id);
+    }
+  }
+
+  // Oldest first (smallest lastTouchedAt). Every agent space now has a record.
+  const ranked = agentSpaces
+    .map((s) => ({ space: s, lastTs: activity[s.id] ?? 0 }))
+    .sort((a, b) => a.lastTs - b.lastTs);
+
+  const reclaimIds = new Set<number>();
+  const targets: { space: ReclaimSpace; reason: string }[] = [];
+
+  for (const { space, lastTs } of ranked) {
+    if (seededIds.has(space.id)) continue; // just seeded — give it the idle window
+    if (now() - lastTs >= idleMs) {
+      const mins = Math.round((now() - lastTs) / 60000);
+      targets.push({ space, reason: `idle ${mins}min >= ${idleMin}min` });
+      reclaimIds.add(space.id);
+    }
+  }
+
+  // Hard cap: reclaim oldest non-seeded, non-idle spaces when over the cap.
+  // Seeded spaces are skipped so a fresh deploy never mass-closes spaces that
+  // predate the activity log.
+  let over = agentSpaces.length - cfg.maxSpaces;
+  if (over > 0) {
+    for (const { space } of ranked) {
+      if (over <= 0) break;
+      if (reclaimIds.has(space.id)) continue;
+      if (seededIds.has(space.id)) continue;
+      targets.push({
+        space,
+        reason: `over cap ${agentSpaces.length}/${cfg.maxSpaces}`,
+      });
+      reclaimIds.add(space.id);
+      over--;
+    }
+  }
+
+  const details: string[] = [];
+  let reclaimed = 0;
+  for (const { space, reason } of targets) {
+    try {
+      await completeFn(space.id);
+      reclaimed++;
+      const label = space.name ?? space.taskId ?? String(space.id);
+      details.push(`reclaimed #${space.id} "${label}" — ${reason}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const label = space.name ?? space.taskId ?? String(space.id);
+      details.push(`skip #${space.id} "${label}" — ${reason} — ${msg}`);
+    }
+  }
+
+  // Prune state entries for spaces that no longer exist.
+  const aliveIds = new Set(spaces.map((s) => s.id));
+  const next: Record<number, number> = {};
+  for (const [id, ts] of Object.entries(activity)) {
+    if (aliveIds.has(Number(id))) next[Number(id)] = ts;
+  }
+  await saveActivity(next);
+
+  if (reclaimed > 0) {
+    log(`[ego-reclaim] reclaimed ${reclaimed} idle task space(s):`);
+    for (const d of details) log(`  ${d}`);
+  }
+
+  return { scanned: agentSpaces.length, reclaimed, details };
+}


### PR DESCRIPTION
## What
Add lazy idle task-space reclamation so agent task spaces left by earlier sessions — and their renderer processes — get released automatically instead of piling up.

Closes #270.

## Why
Today `completeTaskSpace` is the only release path and it is 100% agent-driven; abandoned sessions leak renderer processes and swap climbs monotonically (see #270 for 26h measurements: 20→58 helper processes, 10→35 GB swap). The harness kept no cross-process activity state and `listTaskSpaces` carries no timestamp, so there was nothing to time out against.

## How to verify

```bash
cd package/ego-browser
npm ci
npm test    # 312 pass / 0 fail
```

Behavior covered by the new `taskspace-reclaim.test.mjs`:
- a space idle past `EGO_RECLAIM_IDLE_S` (default 7200s) is closed; a fresh one is kept
- `ownership === "user"` is never touched
- hard cap (`EGO_RECLAIM_MAX_SPACES`) reclaims oldest-first when over the cap
- `EGO_RECLAIM_DISABLE=1` is a no-op
- **first-sight seeding**: spaces with no activity record are seeded with `now` and skipped (deploy safety — never mass-closes pre-existing / in-use spaces); they only become reclaimable after the idle window
- a seeded space is reclaimed on a later run once idle
- no `ego` runtime → empty result, no throw

Manual (against a live browser):
```bash
ego-browser nodejs <<'EOF'
const t = await taskSpaces.useOrCreate('reclaim-verify');   // triggers the once-per-process reap
console.log(JSON.stringify({ id: t.id, spaces: (await listTaskSpaces()).length }));
await taskSpaces.complete('reclaim-verify', { keep: false });
EOF
```

## Impact
- **Helper surface**: no new public helper. Reclamation is an internal mechanism triggered from `run.ts execute()` (CLI mode) and `helpers.useOrCreateTaskSpace()` (embedded app-SDK mode), collapsed to once-per-process via `state.reclaimDone`.
- **Agent side**: no change required. Agents that already call `completeTaskSpace` behave identically; agents that forget it now have a safety net.
- **Existing tests**: `taskspace-e2e.test.mjs` and `helpers.test.mjs` set `EGO_RECLAIM_DISABLE=1` in their harness so call-sequence assertions stay deterministic. New suites: `taskspace-activity.test.mjs`, `taskspace-reclaim.test.mjs`.
- **Config**: env-gated, default on (idle 2h, cap 8). `EGO_RECLAIM_DISABLE=1` opts out.

### Files
- `src/taskspace-activity.ts` (new) — activity map + atomic persistence + config
- `src/taskspace-reclaim.ts` (new) — reclaim logic; talks to `globalThis.ego` directly (no helpers import → no cycle); once-per-process guard
- `src/helpers.ts` — `selectTaskSpace` touches activity (gated by disabled); `useOrCreateTaskSpace` triggers reclaim (CLI+app-SDK coverage)
- `src/run.ts` — `execute()` triggers reclaim (CLI coverage)
- `src/state.ts` — `reclaimDone` once-guard
- `AGENTS.md` — Task Spaces section documents the mechanism + env

### Open questions for reviewers
1. Are the default thresholds (2h idle / 8 cap) right for the project, or should reclamation be opt-in by default?
2. `useOrCreateTaskSpace` as the app-SDK trigger point — acceptable, or prefer a different hook?