### PR TITLE
feat(ego-browser): move the native agent cursor with Playwright pointer actions

### DIFF
--- a/package/ego-browser/src/playwright/mouse-highlight.test.mjs
+++ b/package/ego-browser/src/playwright/mouse-highlight.test.mjs
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { highlightAgentMouse } =
+  await import("../../dist/src/playwright/mouse-highlight.js");
+
+function mouseCommand(type, x, y) {
+  return {
+    id: 1,
+    method: "Input.dispatchMouseEvent",
+    params: { type, x, y, button: "left" },
+    sessionId: "session-1",
+  };
+}
+
+function recordingRuntime(result) {
+  const highlighted = [];
+  return {
+    highlighted,
+    animationHighlightMouseToPosition(x, y) {
+      highlighted.push([x, y]);
+      return result;
+    },
+  };
+}
+
+test("a pointer move takes the native agent cursor to the same point", () => {
+  const runtime = recordingRuntime();
+  highlightAgentMouse(runtime, mouseCommand("mouseMoved", 128.5, 42));
+  assert.deepEqual(runtime.highlighted, [[128.5, 42]]);
+});
+
+test("only pointer moves take the cursor along", () => {
+  const runtime = recordingRuntime();
+  highlightAgentMouse(runtime, mouseCommand("mousePressed", 10, 20));
+  highlightAgentMouse(runtime, mouseCommand("mouseReleased", 10, 20));
+  highlightAgentMouse(runtime, mouseCommand("mouseWheel", 10, 20));
+  highlightAgentMouse(runtime, {
+    id: 2,
+    method: "Input.dispatchKeyEvent",
+    params: { type: "keyDown", x: 10, y: 20 },
+  });
+  highlightAgentMouse(runtime, {
+    id: 3,
+    method: "Page.navigate",
+    params: { url: "https://example.com" },
+  });
+  assert.deepEqual(runtime.highlighted, []);
+});
+
+test("a move without usable coordinates leaves the cursor alone", () => {
+  const runtime = recordingRuntime();
+  highlightAgentMouse(runtime, mouseCommand("mouseMoved", "12", 20));
+  highlightAgentMouse(runtime, mouseCommand("mouseMoved", 12, undefined));
+  highlightAgentMouse(runtime, { id: 4, method: "Input.dispatchMouseEvent" });
+  assert.deepEqual(runtime.highlighted, []);
+});
+
+test("a runtime without the native overlay call still dispatches pointer moves", () => {
+  assert.doesNotThrow(() => {
+    highlightAgentMouse({}, mouseCommand("mouseMoved", 10, 20));
+    highlightAgentMouse(undefined, mouseCommand("mouseMoved", 10, 20));
+    highlightAgentMouse(
+      { animationHighlightMouseToPosition: "not a function" },
+      mouseCommand("mouseMoved", 10, 20),
+    );
+  });
+});
+
+test("a refused overlay move is dropped instead of crashing the agent", async () => {
+  const runtime = recordingRuntime(
+    Promise.reject(new Error("user is controlling the task space")),
+  );
+  highlightAgentMouse(runtime, mouseCommand("mouseMoved", 10, 20));
+  assert.deepEqual(runtime.highlighted, [[10, 20]]);
+  // An unhandled rejection reaching the process here fails this test, which is
+  // what the pointer path must never do when the user takes control.
+  await new Promise((resolve) => setTimeout(resolve, 10));
+});

--- a/package/ego-browser/src/playwright/mouse-highlight.ts
+++ b/package/ego-browser/src/playwright/mouse-highlight.ts
@@ -1,0 +1,39 @@
+export type AgentMouseHighlightRuntime = {
+  animationHighlightMouseToPosition?: (x: number, y: number) => unknown;
+};
+
+type CdpCommand = {
+  method?: unknown;
+  params?: unknown;
+};
+
+/**
+ * Moves the native agent-mouse overlay — the cursor the user watches travel
+ * across the TaskSpace — to wherever the agent is about to act.
+ *
+ * The native side animates from the cursor's current position to the point it
+ * is given, so one target point per move is all it needs; ego-browser only has
+ * to say where. Playwright exposes no helper layer to say it from (page.click,
+ * locator.click, hover, dragTo and page.mouse are Playwright's own), but every
+ * one of them emits Input.dispatchMouseEvent/mouseMoved before pressing, so
+ * mirroring that single command covers them all.
+ */
+export function highlightAgentMouse(
+  runtime: AgentMouseHighlightRuntime | undefined,
+  message: CdpCommand,
+): void {
+  if (message?.method !== "Input.dispatchMouseEvent") return;
+  const params = message.params as
+    { type?: unknown; x?: unknown; y?: unknown } | undefined;
+  if (params?.type !== "mouseMoved") return;
+  if (typeof params.x !== "number" || typeof params.y !== "number") return;
+  const highlight = runtime?.animationHighlightMouseToPosition;
+  if (typeof highlight !== "function") return;
+  const shown = highlight.call(runtime, params.x, params.y) as
+    Promise<unknown> | undefined;
+  // Never awaited: the overlay is decorative and must not pace the pointer
+  // action. Its rejections are routine — the native call refuses once the user
+  // takes control, and the space can close mid-move — so they are dropped here
+  // rather than left to crash the agent's process as unhandled rejections.
+  if (typeof shown?.then === "function") shown.then(undefined, () => {});
+}

--- a/package/ego-browser/src/playwright/routing.test.mjs
+++ b/package/ego-browser/src/playwright/routing.test.mjs
@@ -147,6 +147,43 @@ test("the Ego Playwright transport forwards events and ignores another CDP clien
   transport.close();
 });
 
+test("the Ego Playwright transport moves the native agent cursor with each pointer move", () => {
+  const sent = [];
+  const highlighted = [];
+  const runtime = {
+    sendCDPMessage(payload) {
+      sent.push(JSON.parse(payload));
+    },
+    animationHighlightMouseToPosition(x, y) {
+      highlighted.push([x, y]);
+    },
+  };
+  const transport = egoTransport.createEgoCdpTransport(runtime, {
+    allocateMessageId: () => 1_000_000_003,
+  });
+
+  transport.send({
+    id: 1,
+    method: "Input.dispatchMouseEvent",
+    params: { type: "mouseMoved", x: 240, y: 130, button: "none" },
+    sessionId: "session-1",
+  });
+  transport.send({
+    id: 2,
+    method: "Input.dispatchMouseEvent",
+    params: { type: "mousePressed", x: 240, y: 130, button: "left" },
+    sessionId: "session-1",
+  });
+
+  assert.deepEqual(highlighted, [[240, 130]]);
+  assert.deepEqual(
+    sent.map((message) => message.params.type),
+    ["mouseMoved", "mousePressed"],
+    "the overlay observes the pointer stream without consuming it",
+  );
+  transport.close();
+});
+
 test("the direct Playwright transport exposes only targets from the selected TaskSpace", async () => {
   class FakeWebSocketTransport {
     static async connect() {

--- a/package/ego-browser/src/playwright/routing.ts
+++ b/package/ego-browser/src/playwright/routing.ts
@@ -3,9 +3,11 @@ import {
   subscribeEgoCdpTransport,
 } from "../browser-runtime.js";
 import { resolveEgoError } from "../ego-errors.js";
+import { highlightAgentMouse } from "./mouse-highlight.js";
 
 export type EgoCdpRuntime = {
   sendCDPMessage: (payload: string) => unknown;
+  animationHighlightMouseToPosition?: (x: number, y: number) => unknown;
   createTab?: (url?: string) => Promise<unknown> | unknown;
   listTabs?: () => Promise<{
     tabs?: Array<{ targetId?: string; active?: boolean; url?: string }>;
@@ -197,6 +199,7 @@ export class EgoCdpTransport {
 
   send(message: any) {
     if (this.closed) throw new Error("Ego CDP transport is closed");
+    highlightAgentMouse(this.#runtime, message);
     const compatibilityResult = playwrightCompatibilityResult(message.method);
     if (compatibilityResult !== undefined) {
       this.#emit({

--- a/package/ego-browser/test/real-browser-e2e/suites/index.mjs
+++ b/package/ego-browser/test/real-browser-e2e/suites/index.mjs
@@ -1,3 +1,4 @@
+import { agentMouseOverlayCase } from "./platform/agent-mouse-overlay.mjs";
 import { ariaSnapshotCase } from "./platform/aria-snapshot.mjs";
 import { nativeCloseRegressionCase } from "./platform/close-regression.mjs";
 import { contextLifecycleCase } from "./platform/context-lifecycle.mjs";
@@ -50,6 +51,7 @@ export const e2eCases = [
     body: nativePlaywrightCase,
   },
   ariaSnapshotCase,
+  agentMouseOverlayCase,
   playwrightCdpSessionCase,
   networkRoutingCase,
   nativeCloseRegressionCase,

--- a/package/ego-browser/test/real-browser-e2e/suites/platform/agent-mouse-overlay.mjs
+++ b/package/ego-browser/test/real-browser-e2e/suites/platform/agent-mouse-overlay.mjs
@@ -1,0 +1,109 @@
+// The native agent cursor is painted by the browser UI layer, outside anything
+// a page screenshot or the DOM can observe. What this case can establish end to
+// end is the half that lives in ego-browser: a real Playwright pointer action
+// reaches the native overlay call, carries the coordinates of the element it is
+// about to act on, and the native side accepts them and reports the cursor
+// shown.
+export const agentMouseOverlayCase = {
+  name: "agent mouse overlay",
+  kind: "platform",
+  body() {
+    return `
+      const task = await openE2eTaskSpace(taskName);
+      const page = task.page;
+      await page.goto(baseUrl + "/tests/clicks?platform=agent-mouse-overlay", {
+        waitUntil: "load",
+        timeout: 20_000,
+      });
+
+      const ego = globalThis.ego;
+      assertEqual(
+        typeof ego.animationHighlightMouseToPosition,
+        "function",
+        "the native runtime exposes the agent mouse overlay call",
+      );
+      const nativeHighlight = ego.animationHighlightMouseToPosition;
+      const moves = [];
+      const observeHighlight = (x, y) => {
+        const shown = nativeHighlight.call(ego, x, y);
+        moves.push({ x, y, shown });
+        return shown;
+      };
+      ego.animationHighlightMouseToPosition = observeHighlight;
+      assertEqual(
+        ego.animationHighlightMouseToPosition,
+        observeHighlight,
+        "the native overlay call is observable for this case",
+      );
+
+      function assertMoveWithin(move, box, label) {
+        assert(
+          move.x >= box.x &&
+            move.x <= box.x + box.width &&
+            move.y >= box.y &&
+            move.y <= box.y + box.height,
+          label +
+            ": cursor went to (" + move.x + ", " + move.y + "), element covers (" +
+            box.x + ", " + box.y + ") to (" + (box.x + box.width) + ", " +
+            (box.y + box.height) + ")",
+        );
+      }
+
+      try {
+        const probe = page.getByRole("button", { name: "Test click events" });
+        await probe.scrollIntoViewIfNeeded();
+        const probeBox = await probe.boundingBox();
+        await probe.click();
+
+        assert(moves.length > 0, "a Playwright click moves the native agent cursor");
+        const clickMove = moves.at(-1);
+        assertMoveWithin(
+          clickMove,
+          probeBox,
+          "the click takes the cursor onto the element it acts on, in css pixels",
+        );
+        assertIncludes(
+          JSON.stringify(await clickMove.shown),
+          "mouse highlight shown",
+          "the native side accepts the position and shows the cursor",
+        );
+        assertEqual(
+          await page.getByTestId("click-count").textContent(),
+          "1",
+          "the observed click still reaches the page",
+        );
+
+        const movesAfterClick = moves.length;
+        const menu = page.getByRole("button", { name: "More actions" });
+        await menu.scrollIntoViewIfNeeded();
+        const menuBox = await menu.boundingBox();
+        await menu.hover();
+
+        assert(
+          moves.length > movesAfterClick,
+          "a Playwright hover moves the native agent cursor",
+        );
+        assertMoveWithin(
+          moves.at(-1),
+          menuBox,
+          "the hover takes the cursor onto the hovered element",
+        );
+
+        const movesBeforeKeyboard = moves.length;
+        await page.keyboard.press("Escape");
+        assertEqual(
+          await page.getByTestId("click-count").textContent(),
+          "1",
+          "keyboard work runs without a pointer action",
+        );
+        assertEqual(
+          moves.length,
+          movesBeforeKeyboard,
+          "work that presses no pointer leaves the cursor where it is",
+        );
+      } finally {
+        ego.animationHighlightMouseToPosition = nativeHighlight;
+      }
+    `;
+  },
+};

--- a/package/ego-browser/test/real-browser-e2e/suites/scenarios/pixel-tools.mjs
+++ b/package/ego-browser/test/real-browser-e2e/suites/scenarios/pixel-tools.mjs
@@ -147,8 +147,10 @@ export function locateSwatch(image, rgb, region) {
   };
 }
 
-// Screenshots are device pixels; page.mouse takes CSS pixels. This is the whole
-// conversion the visual path depends on.
+// A screenshot taken at the default scale is device pixels; page.mouse takes
+// CSS pixels. The visual path reads its coordinates from a scale:'css'
+// screenshot instead, so this conversion is what that reading is checked
+// against rather than how it is produced.
 export function toCssPoint(box, ratio) {
   return { x: box.centerX / ratio, y: box.centerY / ratio };
 }

--- a/package/ego-browser/test/real-browser-e2e/suites/scenarios/visual-path.mjs
+++ b/package/ego-browser/test/real-browser-e2e/suites/scenarios/visual-path.mjs
@@ -50,6 +50,25 @@ export const visualPathScenarioCase = scenarioCase(
         return decodePng(await observedScreenshot(page, label));
       }
 
+      // Every coordinate this case aims with is read out of a scale:'css'
+      // screenshot and handed to page.mouse unconverted, because page.mouse
+      // speaks CSS pixels. That binds the clicks below to CSS pixel
+      // screenshots: should they ever stop being honoured, the image comes
+      // back in device pixels, every coordinate read out of it is one device
+      // pixel ratio too large, and the aiming fails instead of passing on a
+      // conversion this case did itself. A 1x display cannot tell the two
+      // units apart; the ratio the fixture reports is asserted on below.
+      async function shootCss(label, options) {
+        const image = await page.screenshot({
+          animations: "disabled",
+          scale: "css",
+          timeout: 60_000,
+          ...options,
+        });
+        assert(image.length > 0, label + " screenshot contains image bytes");
+        return decodePng(image);
+      }
+
       async function shootWholePage() {
         const image = await page.screenshot({
           animations: "disabled",
@@ -65,26 +84,43 @@ export const visualPathScenarioCase = scenarioCase(
         return page.evaluate(() => window.scrollY);
       }
 
-      // Reads a target straight out of the image. Nothing here asks the DOM
-      // where anything is: that is the whole point of the visual path.
+      // Reads a target straight out of a CSS pixel image. Nothing here asks the
+      // DOM where anything is: that is the whole point of the visual path. The
+      // measured size is compared against the CSS box rather than the device
+      // pixel one, so an image that came back in device pixels is caught here
+      // before its centre is ever aimed at. A swatch edge that lands on a
+      // fractional CSS pixel is antialiased away from its own colour, which
+      // costs at most one row or column of the match.
       function sight(image, target) {
         const box = locateSwatch(image, target.pendingRgb);
         assert(box, target.id + " is visible in the screenshot");
-        assertEqual(
-          box.width,
-          Math.round(target.width * ratio),
-          target.id + " keeps its rendered width in the image",
+        assert(
+          Math.abs(box.width - target.width) <= 1,
+          target.id +
+            " keeps its CSS width in the image: measured " +
+            box.width +
+            " against a CSS width of " +
+            target.width +
+            " and a device pixel width of " +
+            Math.round(target.width * ratio),
         );
-        assertEqual(
-          box.height,
-          Math.round(target.height * ratio),
-          target.id + " keeps its rendered height in the image",
+        assert(
+          Math.abs(box.height - target.height) <= 1,
+          target.id +
+            " keeps its CSS height in the image: measured " +
+            box.height +
+            " against a CSS height of " +
+            target.height +
+            " and a device pixel height of " +
+            Math.round(target.height * ratio),
         );
         assert(
           box.fill > 0.98,
           target.id + " reads back as one solid block of its own colour",
         );
-        return toCssPoint(box, ratio);
+        // No division by the device pixel ratio: a centre read out of a CSS
+        // pixel image is already the coordinate page.mouse takes.
+        return { x: box.centerX, y: box.centerY };
       }
 
       async function aim(target, point) {
@@ -125,33 +161,56 @@ export const visualPathScenarioCase = scenarioCase(
       );
 
       // scale:'css' hands back the picture in CSS pixels, which is the unit
-      // page.mouse takes: a coordinate read out of this image is aimed with, so
-      // the visual path needs no device pixel ratio conversion at all.
-      const cssScaled = decodePng(
-        await page.screenshot({
-          animations: "disabled",
-          scale: "css",
-          timeout: 60_000,
-        }),
-      );
+      // page.mouse takes: this is the image every coordinate below is read out
+      // of, so the visual path needs no device pixel ratio conversion at all.
+      const cssBoard = await shootCss("alignment board at rest in css pixels");
       assertEqual(
-        cssScaled.width,
+        cssBoard.width,
         environment.innerWidth,
         "a scale:'css' screenshot spans the CSS viewport, so an x read from it is already a page.mouse x",
       );
       assertEqual(
-        cssScaled.height,
+        cssBoard.height,
         environment.innerHeight,
         "a scale:'css' screenshot is as tall as the CSS viewport, so a y read from it is already a page.mouse y",
       );
       assertEqual(
-        Math.round(cssScaled.width * ratio),
+        Math.round(cssBoard.width * ratio),
         board.width,
         "the css screenshot is the device pixel screenshot divided by the device pixel ratio",
       );
       assert(
-        ratio === 1 || cssScaled.width < board.width,
+        ratio === 1 || cssBoard.width < board.width,
         "a screenshot taken with no scale still returns device pixels: Playwright defaults to scale:'device' and honouring scale:'css' must not flip that default",
+      );
+
+      // The same swatch located in both images: aiming straight off the css
+      // image is the same aim as the device pixel reading converted by hand,
+      // which is what this case used to do for every click.
+      const deviceAlpha = locateSwatch(board, PRIMARY[0].pendingRgb);
+      const cssAlpha = locateSwatch(cssBoard, PRIMARY[0].pendingRgb);
+      assert(
+        deviceAlpha && cssAlpha,
+        PRIMARY[0].id + " is visible in both the device pixel and css images",
+      );
+      const convertedAlpha = toCssPoint(deviceAlpha, ratio);
+      assert(
+        Math.abs(convertedAlpha.x - cssAlpha.centerX) <= 1 &&
+          Math.abs(convertedAlpha.y - cssAlpha.centerY) <= 1,
+        "a centre read off the css image needs no conversion: css reads " +
+          cssAlpha.centerX +
+          "," +
+          cssAlpha.centerY +
+          " against a device pixel reading of " +
+          deviceAlpha.centerX +
+          "," +
+          deviceAlpha.centerY +
+          " converted to " +
+          convertedAlpha.x +
+          "," +
+          convertedAlpha.y +
+          " at ratio " +
+          ratio,
       );
 
       // The css scale reaches every screenshot surface, not just the viewport
@@ -207,7 +266,7 @@ export const visualPathScenarioCase = scenarioCase(
       // One clean image supplies every primary coordinate: click markers land on
       // the targets already hit, and re-reading between clicks would let a
       // marker eat into the neighbour that is measured next.
-      const primaryPoints = PRIMARY.map((target) => sight(board, target));
+      const primaryPoints = PRIMARY.map((target) => sight(cssBoard, target));
       for (const [index, target] of PRIMARY.entries()) {
         await aim(target, primaryPoints[index]);
       }
@@ -258,14 +317,9 @@ export const visualPathScenarioCase = scenarioCase(
           "px",
       );
 
-      const cssWholePage = decodePng(
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          scale: "css",
-          timeout: 60_000,
-        }),
-      );
+      const cssWholePage = await shootCss("the whole page in css pixels", {
+        fullPage: true,
+      });
       assert(
         Math.abs(cssWholePage.width * ratio - wholePage.width) <= 1 &&
           Math.abs(cssWholePage.height * ratio - wholePage.height) <= 1,
@@ -281,24 +335,30 @@ export const visualPathScenarioCase = scenarioCase(
           ratio,
       );
       assert(
-        cssWholePage.height > cssScaled.height,
+        cssWholePage.height > cssBoard.height,
         "a full-page scale:'css' screenshot still spans the whole document rather than one viewport",
       );
-      const chipOnPage = locateSwatch(wholePage, CHIPS[0].pendingRgb);
+      // The scroll target is a page coordinate, and window.scrollTo takes CSS
+      // pixels too, so it is read off the css full-page image directly.
+      const chipOnPage = locateSwatch(cssWholePage, CHIPS[0].pendingRgb);
       assert(chipOnPage, "the first chip is visible in the full-page screenshot");
-      const chipPageY = chipOnPage.centerY / ratio;
+      const chipPageY = chipOnPage.centerY;
       const scrolled = await scrollPageTo(
         Math.max(0, Math.round(chipPageY - environment.innerHeight / 2)),
       );
       assert(scrolled > 0, "the page scrolled towards the precision chips");
 
-      const chipBoard = await shoot("precision chips in view");
+      const chipBoard = await shootCss("precision chips in view");
       const chipInView = locateSwatch(chipBoard, CHIPS[0].pendingRgb);
       assert(chipInView, "the first chip is visible after scrolling");
-      assertEqual(
-        Math.round(chipInView.centerY / ratio + scrolled),
-        Math.round(chipPageY),
-        "full-page screenshot coordinates are page coordinates, viewport screenshot coordinates are not",
+      assert(
+        Math.abs(chipInView.centerY + scrolled - chipPageY) <= 1,
+        "full-page screenshot coordinates are page coordinates, viewport screenshot coordinates are not: the chip sits at " +
+          chipInView.centerY +
+          " in a viewport scrolled to " +
+          scrolled +
+          " against a page position of " +
+          chipPageY,
       );
 
       const chipPoints = CHIPS.map((chip) => sight(chipBoard, chip));
@@ -323,18 +383,24 @@ export const visualPathScenarioCase = scenarioCase(
           staleReadback,
       );
 
-      const stageBoard = await shoot("canvas stage in view");
+      const stageBoard = await shootCss("canvas stage in view");
       const paper = locateSwatch(stageBoard, STAGE.paperRgb);
       assert(paper, "the canvas surface is visible in the screenshot");
-      assertEqual(
-        paper.width,
-        Math.round(STAGE.width * ratio),
-        "the canvas surface reads back at its rendered width",
+      assert(
+        Math.abs(paper.width - STAGE.width) <= 1,
+        "the canvas surface reads back at its CSS width: measured " +
+          paper.width +
+          " against a CSS width of " +
+          STAGE.width +
+          " and a device pixel width of " +
+          Math.round(STAGE.width * ratio),
       );
-      const stageLeft = paper.minX / ratio;
-      const stageTop = paper.minY / ratio;
-      const stageWidth = paper.width / ratio;
-      const stageHeight = paper.height / ratio;
+      // Every point of the gesture below is a CSS pixel taken straight from the
+      // image, the same unit page.mouse moves in.
+      const stageLeft = paper.minX;
+      const stageTop = paper.minY;
+      const stageWidth = paper.width;
+      const stageHeight = paper.height;
       const from = {
         x: stageLeft + stageWidth * 0.15,
         y: stageTop + stageHeight * 0.25,
@@ -360,19 +426,25 @@ export const visualPathScenarioCase = scenarioCase(
         "a pressed pointer path draws one stroke on a surface with no structure to read",
       );
 
-      const inked = await shoot("canvas after the stroke");
+      const inked = await shootCss("canvas after the stroke");
       const ink = locateSwatch(inked, STAGE.inkRgb);
       assert(ink, "the stroke is visible in the screenshot");
       assert(
-        Math.abs(ink.minX / ratio - from.x) <= 4,
-        "the stroke starts at the pixel the pointer pressed on",
+        Math.abs(ink.minX - from.x) <= 4,
+        "the stroke starts at the pixel the pointer pressed on: the ink begins at " +
+          ink.minX +
+          " against a press at " +
+          from.x,
       );
       assert(
-        Math.abs(ink.maxX / ratio - to.x) <= 4,
-        "the stroke ends at the pixel the pointer released on",
+        Math.abs(ink.maxX - to.x) <= 4,
+        "the stroke ends at the pixel the pointer released on: the ink ends at " +
+          ink.maxX +
+          " against a release at " +
+          to.x,
       );
       assert(
-        ink.height / ratio > stageHeight * 0.3,
+        ink.height > stageHeight * 0.3,
         "the stroke follows the whole dragged path instead of joining two points",
       );
     `,


### PR DESCRIPTION
## Summary

Two changes to the Playwright pointer surface and the real-browser coverage around it.

**Move the native agent cursor with Playwright pointer actions.** The pre-Playwright driver moved the native agent cursor from its own click, hover and drag helpers. Those helpers went away with the migration, so the cursor the user watches has been standing still ever since. Playwright exposes no helper layer to call the native overlay from, but every pointer action it offers — `page.click`, `locator.click`, `hover`, `dragTo` and `page.mouse` alike — emits an `Input.dispatchMouseEvent`/`mouseMoved` before it presses. Mirroring that one command from the CDP transport covers them all, and the native side animates from the cursor's current position to the point it is given. The call is deliberately fire-and-forget: the overlay is decorative and must neither pace nor fail the pointer action, and its rejections are routine once the user takes control or the space closes.

**Aim the visual path from CSS pixel screenshots.** The `visual-path` case read every coordinate out of a default screenshot and divided it by the device pixel ratio itself, so its clicks landed correctly whether or not screenshots came back in CSS pixels — losing that support would have been reported only by a few size assertions, never by the aiming the case exists to exercise. It now reads every aimed coordinate from a `scale: 'css'` screenshot and hands it to `page.mouse` unconverted. The device pixel screenshot stays for the assertions that describe it (the unscaled default, the clip, the full-page scrollbar) plus one cross-check that a centre read off the css image equals the device pixel reading converted by hand.

## Test plan

- Unit tests over the mirroring rule (`mouse-highlight.test.mjs`) and the transport wiring (`routing.test.mjs`).
- New real-browser case `platform/agent-mouse-overlay`: a Playwright click and hover carry the coordinates of the element they act on to the native overlay.
- `scenarios/visual-path` verified against a real browser at ratio 2 in a 1275x752 viewport — passes with 143 assertions. With `syncCssPixelScreenshots` removed from the connector it fails at the css viewport assertion; stripping the assertions ahead of the aiming carries that failure through to the click itself, which then reports a miss instead of the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
