### PR TITLE
feat(ego-browser): expose listProfiles and thread profileId through task-space creation

### DIFF
--- a/package/ego-browser/src/helpers.test.mjs
+++ b/package/ego-browser/src/helpers.test.mjs
@@ -9,6 +9,7 @@ import {
   handOffTaskSpace,
   newTaskSpace,
   helperContext,
+  listProfiles,
   listTaskSpaces,
   useOrCreateTaskSpace,
   switchTaskSpace,
@@ -340,6 +341,80 @@ test("switchTaskSpace awaits useTaskSpace binding errors", async () => {
   );
 });
 
+test("listProfiles normalizes the profiles binding shape", async () => {
+  await withEgo(
+    {
+      async listProfiles() {
+        return {
+          profiles: [
+            { id: "Default", name: "Projects", isDefault: false },
+            { id: "Profile 7", name: "Deepanshu (Toptal)", isDefault: false },
+          ],
+        };
+      },
+    },
+    async () => {
+      assert.deepEqual(await listProfiles(), [
+        { id: "Default", name: "Projects", isDefault: false },
+        { id: "Profile 7", name: "Deepanshu (Toptal)", isDefault: false },
+      ]);
+    },
+  );
+});
+
+test("listProfiles drops entries without an id and rejects a missing profiles array", async () => {
+  await withEgo(
+    {
+      async listProfiles() {
+        return {
+          profiles: [{ name: "orphaned" }, { id: "Profile 2", name: "Thapar" }],
+        };
+      },
+    },
+    async () => {
+      assert.deepEqual(await listProfiles(), [
+        { id: "Profile 2", name: "Thapar" },
+      ]);
+    },
+  );
+  await withEgo(
+    {
+      async listProfiles() {
+        return {};
+      },
+    },
+    async () => {
+      await assert.rejects(
+        () => listProfiles(),
+        /listProfiles expected \{ profiles: \[\.\.\.\] \}/,
+      );
+    },
+  );
+});
+
+test("newTaskSpace passes the requested profileId through to ego.createTaskSpace", async () => {
+  const calls = [];
+  await withEgo(
+    {
+      async createTaskSpace(name, profileId) {
+        calls.push(["createTaskSpace", name, profileId]);
+        return { taskId: name, id: 7, name, ownership: "agent" };
+      },
+      useTaskSpace(taskId) {
+        calls.push(["useTaskSpace", taskId]);
+        return taskId;
+      },
+    },
+    async () => {
+      await newTaskSpace("toptal-work", "Profile 7");
+    },
+  );
+  assert.deepEqual(calls, [
+    ["createTaskSpace", "toptal-work", "Profile 7"],
+    ["useTaskSpace", 7],
+  ]);
+});
+
 test("newTaskSpace creates and selects an agent task space", async () => {
   const calls = [];
   await withEgo(
@@ -597,6 +672,34 @@ test("useOrCreateTaskSpace creates missing spaces", async () => {
   assert.deepEqual(calls, [
     ["listTaskSpaces"],
     ["createTaskSpace", "checkout-flow"],
+    ["useTaskSpace", 7],
+  ]);
+});
+
+test("useOrCreateTaskSpace passes profileId through when creating a missing space", async () => {
+  const calls = [];
+  await withEgo(
+    {
+      async listTaskSpaces() {
+        calls.push(["listTaskSpaces"]);
+        return { taskSpaces: [] };
+      },
+      async createTaskSpace(name, profileId) {
+        calls.push(["createTaskSpace", name, profileId]);
+        return { taskId: name, id: 7, name, ownership: "agent" };
+      },
+      useTaskSpace(taskId) {
+        calls.push(["useTaskSpace", taskId]);
+        return taskId;
+      },
+    },
+    async () => {
+      await useOrCreateTaskSpace("toptal-work", "Profile 7");
+    },
+  );
+  assert.deepEqual(calls, [
+    ["listTaskSpaces"],
+    ["createTaskSpace", "toptal-work", "Profile 7"],
     ["useTaskSpace", 7],
   ]);
 });

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -114,6 +114,22 @@ export async function listTaskSpaces() {
   );
 }
 
+/**
+ * List the ego lite browser profiles available on this machine (e.g. separate
+ * logins for personal vs. work accounts). Pass a profile's `id` to
+ * newTaskSpace(name, profileId) / useOrCreateTaskSpace to bind a task space to it.
+ * @returns {Promise<Array<{id:string,name:string,isDefault?:boolean}>>}
+ */
+export async function listProfiles() {
+  const ego = globalThis.ego;
+  if (!ego || typeof ego.listProfiles !== "function") {
+    throw new Error("listProfiles requires ego.listProfiles");
+  }
+  return normalizeProfiles(
+    assertNoEgoError(await ego.listProfiles(), "listProfiles"),
+  );
+}
+
 /*
  * Task space ownership policy (`ownership`: "agent" | "agentDelegatedToUser" | "user").
  * "agent" and "agentDelegatedToUser" are both agent-owned (see isAgentOwned) — the
@@ -166,15 +182,23 @@ export async function switchTaskSpace(nameOrId) {
 /**
  * Create an agent-owned task space and select it for the current Node invocation.
  * @param {string} name Task space name.
+ * @param {string} [profileId] Profile id from listProfiles(); omit to use the default profile.
  * @returns {Promise<{taskId:string,id:number,name:string,createdBy?:string,ownership?:string,recentTabTitles?:string[]}>}
  */
-export async function newTaskSpace(name) {
+export async function newTaskSpace(name, profileId) {
   const ego = globalThis.ego;
   if (!ego || typeof ego.createTaskSpace !== "function") {
     throw new Error("newTaskSpace requires ego.createTaskSpace");
   }
   const created = normalizeTaskSpace(
-    assertNoEgoError(await ego.createTaskSpace(name), "newTaskSpace"),
+    assertNoEgoError(
+      // ego.createTaskSpace's validator rejects an explicit `undefined` second
+      // argument, so only pass profileId when the caller actually provided one.
+      profileId === undefined
+        ? await ego.createTaskSpace(name)
+        : await ego.createTaskSpace(name, profileId),
+      "newTaskSpace",
+    ),
   );
   if (!created) {
     throw new Error("newTaskSpace returned an invalid task space");
@@ -188,16 +212,19 @@ export async function newTaskSpace(name) {
  * spaces are selected but not claimed (the EGO_TASK_SPACE_USER_IN_CONTROL error
  * surfaces) — call claimTaskSpace(nameOrId) to take ownership.
  * @param {string|number} nameOrId Task space name or numeric id.
+ * @param {string} [profileId] Profile id from listProfiles(), used only when a new
+ *   space is created (an existing space keeps its own profile). Must be a plain
+ *   string id, not an options object — this helper does not accept `{ profileId }`.
  * @returns {Promise<{taskId:string,id:number,name:string,createdBy?:string,ownership?:string,recentTabTitles?:string[]}>}
  */
-export async function useOrCreateTaskSpace(nameOrId) {
+export async function useOrCreateTaskSpace(nameOrId, profileId) {
   const spaces = await listTaskSpaces();
   const existing = findMatchingTaskSpace(spaces, nameOrId);
   if (!existing) {
     if (typeof nameOrId === "number") {
       throw new Error(`task space not found: ${nameOrId}`);
     }
-    return newTaskSpace(nameOrId);
+    return newTaskSpace(nameOrId, profileId);
   }
   if (isAgentOwned(existing.ownership)) {
     return selectTaskSpace(globalThis.ego, existing, "useOrCreateTaskSpace");
@@ -413,6 +440,13 @@ function normalizeTaskSpaces(raw) {
     return raw.taskSpaces.map(normalizeTaskSpace).filter(Boolean);
   }
   throw new Error("listTaskSpaces expected { taskSpaces: [...] }");
+}
+
+function normalizeProfiles(raw) {
+  if (Array.isArray(raw?.profiles)) {
+    return raw.profiles.filter((profile) => profile?.id);
+  }
+  throw new Error("listProfiles expected { profiles: [...] }");
 }
 
 function normalizeTaskSpace(space) {
@@ -785,6 +819,7 @@ function createBrowserFacade() {
 function createTaskSpacesFacade() {
   return {
     list: listTaskSpaces,
+    listProfiles,
     switch: switchTaskSpace,
     new: newTaskSpace,
     useOrCreate: useOrCreateTaskSpace,
@@ -813,7 +848,7 @@ const FACADE_HELP: Record<string, string> = {
   browser:
     "browser: tab facade. Use browser.listTabs(), browser.currentTab(), browser.switchTab(target), browser.openOrReuseTab(url, options), and browser.closeTab(target). Treat targetId as short-lived: obtain and validate it in the current script; switchTab/closeTab refresh the tab list before acting.",
   taskSpaces:
-    "taskSpaces: task-space facade. Use taskSpaces.useOrCreate(nameOrId), taskSpaces.claim(nameOrId), taskSpaces.switch(nameOrId), taskSpaces.complete(nameOrId, options), taskSpaces.handOff(nameOrId), taskSpaces.takeOver(nameOrId), and taskSpaces.waitForAgentControl(nameOrId, options).",
+    "taskSpaces: task-space facade. Use taskSpaces.useOrCreate(nameOrId, profileId?), taskSpaces.listProfiles(), taskSpaces.claim(nameOrId), taskSpaces.switch(nameOrId), taskSpaces.complete(nameOrId, options), taskSpaces.handOff(nameOrId), taskSpaces.takeOver(nameOrId), and taskSpaces.waitForAgentControl(nameOrId, options). listProfiles() returns the ego lite browser profiles ({id, name, isDefault}) available on this machine; pass a profile's id as the second argument to useOrCreate/newTaskSpace to bind a new space to it — the space keeps that profile's login state.",
   site: "site: learned site-skill facade. Use site.skills(url), site.skillsForUrl(url), site.runTool(siteId, toolName, args), site.runBrowserTool(siteId, toolName, args), and site.learnContext(url).",
   fetch:
     "fetch: network facade. Use fetch.server(url, options) for Node-side fetch and fetch.browser(url, options) for browser-origin fetch.",


### PR DESCRIPTION
## Summary
- Add a documented `listProfiles()` helper (mirrors `listTaskSpaces()`), reachable via `ego.listProfiles()` under the hood — previously only reachable through the undocumented raw `ego.listProfiles()` call.
- Thread an optional `profileId` through `newTaskSpace(name, profileId)` / `useOrCreateTaskSpace(nameOrId, profileId)` so they actually bind a new task space to a requested browser profile instead of silently ignoring the argument and always using the default profile.

## Why
Hit this directly: asked an agent to open a task space on a specific ego lite browser profile (e.g. "Deepanshu (Toptal)"), and it silently opened the default profile instead — `useOrCreateTaskSpace(name, { profileId })` swallows the option. The only reliable path was the low-level `ego.createTaskSpace(name, profileId)` (positional args). This wraps that properly at the helper layer.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 315/315 passing, including new coverage for `listProfiles()` normalization and `profileId` threading through `newTaskSpace`/`useOrCreateTaskSpace`
- [x] `npm run build` clean
- [x] Manually verified against a running ego lite instance: `ego.listProfiles()` / `ego.createTaskSpace(name, profileId)` work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)