### PR TITLE
feat(errors): add structured browser error taxonomy

### DIFF
--- a/package/ego-browser/README.md
+++ b/package/ego-browser/README.md
@@ -64,6 +64,7 @@ src/
   helpers.ts             public Playwright-style facades plus internal helper glue
   browser-runtime.ts     bridge to globalThis.ego (CDP, sessions, events)
   element-resolver.ts    resolves @eN / CSS / XPath / ARIA targets
+  ego-errors.ts          typed error taxonomy (EgoError, mapCdpError, redactUrl)
   driver/
     pointer.ts           click, hover, drag, wheel, scrollIntoViewIfNeeded
     observe.ts           snapshot, screenshot, elementCenter

--- a/package/ego-browser/src/cdp-eval.ts
+++ b/package/ego-browser/src/cdp-eval.ts
@@ -1,6 +1,5 @@
+import { createOperationTimeoutError, mapCdpError } from "./ego-errors.js";
 import { send, state } from "./state.js";
-
-class TimeoutError extends Error {}
 
 /**
  * Send a raw Chrome DevTools Protocol command.
@@ -81,15 +80,17 @@ async function runtimeEvaluate(
     );
     return runtimeValue(response, expression);
   } catch (error) {
-    if (
-      error instanceof TimeoutError ||
-      /timed out/i.test(error?.message || "")
-    ) {
-      throw new Error(
-        `Runtime.evaluate timed out; expression: ${jsSnippet(expression)}`,
+    if (/timed out|timeout/i.test(error?.message || "")) {
+      throw createOperationTimeoutError(
+        `Runtime.evaluate (${jsSnippet(expression)})`,
+        state.defaultTimeout,
       );
     }
-    throw error;
+    throw mapCdpError(error, {
+      operation: "Runtime.evaluate",
+      timeoutMs: state.defaultTimeout,
+      sessionId,
+    });
   }
 }
 

--- a/package/ego-browser/src/driver/load.ts
+++ b/package/ego-browser/src/driver/load.ts
@@ -1,9 +1,11 @@
 import { cdp, evaluate } from "../cdp-eval.js";
 import { state } from "../state.js";
+import { createNavigationTimeoutError } from "../ego-errors.js";
 
 export type WaitForLoadOptions = {
   timeout?: number;
   until?: "load" | "domcontentloaded";
+  navigationUrl?: string;
 };
 
 export async function waitForDocumentLoad(options: WaitForLoadOptions = {}) {
@@ -26,6 +28,9 @@ export async function waitForDocumentLoad(options: WaitForLoadOptions = {}) {
       return true;
     }
     await state.sleep(300);
+  }
+  if (options.navigationUrl !== undefined) {
+    throw createNavigationTimeoutError(options.navigationUrl, timeout);
   }
   return false;
 }

--- a/package/ego-browser/src/driver/locator.ts
+++ b/package/ego-browser/src/driver/locator.ts
@@ -1,8 +1,6 @@
 import { cdp, runtimeValue } from "../cdp-eval.js";
-import {
-  ElementResolutionError,
-  queryRoleLocatorBackendNodeIds,
-} from "../element-resolver.js";
+import { queryRoleLocatorBackendNodeIds } from "../element-resolver.js";
+import { ElementResolutionError } from "../ego-errors.js";
 import { queryAllExpression as buildQueryAllExpression } from "../locator-query.js";
 import { parseRef } from "../ref-map.js";
 import { state } from "../state.js";

--- a/package/ego-browser/src/driver/nav.test.mjs
+++ b/package/ego-browser/src/driver/nav.test.mjs
@@ -16,6 +16,8 @@ import {
   switchTab,
 } from "../../dist/src/driver/nav.js";
 import { setOverrides, state } from "../../dist/src/state.js";
+import { waitForDocumentLoad } from "../../dist/src/driver/load.js";
+import { NavigationTimeoutError } from "../../dist/src/ego-errors.js";
 
 function withEgo(ego, fn) {
   const previous = globalThis.ego;
@@ -92,6 +94,41 @@ function withCdpRuntime(fn) {
       }
     });
 }
+
+
+test("waitForDocumentLoad constructs redacted NavigationTimeoutError on navigation timeout", async () => {
+  let now = 0;
+  const restore = setOverrides({
+    now: () => now,
+    sleep: async (ms) => { now += ms; },
+    cdpOverride: async (method) => {
+      if (method === "Page.getFrameTree") {
+        return { frameTree: { frame: { url: "https://example.com/loading" } } };
+      }
+      if (method === "Runtime.evaluate") {
+        return { result: { value: "loading" } };
+      }
+      return {};
+    },
+  });
+  try {
+    await assert.rejects(
+      () => waitForDocumentLoad({
+        timeout: 500,
+        navigationUrl: "https://example.com/next?token=secret#fragment",
+      }),
+      (error) => {
+        assert.ok(error instanceof NavigationTimeoutError);
+        assert.equal(error.code, "NAVIGATION_TIMEOUT");
+        assert.equal(error.context.url, "https://example.com/next");
+        assert.doesNotMatch(error.message, /secret|fragment/);
+        return true;
+      },
+    );
+  } finally {
+    restore();
+  }
+});
 
 test("listTabs throws on ego binding error objects", async () => {
   await withEgo(

--- a/package/ego-browser/src/driver/nav.ts
+++ b/package/ego-browser/src/driver/nav.ts
@@ -8,7 +8,11 @@ import {
   setPreferredTarget,
 } from "../browser-runtime.js";
 import { cdp, evaluate } from "../cdp-eval.js";
-import { assertNoEgoError } from "../ego-errors.js";
+import {
+  assertNoEgoError,
+  NavigationTimeoutError,
+  ConnectionLostError,
+} from "../ego-errors.js";
 import { state } from "../state.js";
 import { waitForDocumentLoad } from "./load.js";
 
@@ -64,6 +68,7 @@ export async function goto(url: string, options: GotoOptions = {}) {
       ? false
       : await waitForDocumentLoad({
           timeout: options.timeout ?? 20000,
+          navigationUrl: url,
           until:
             options.waitUntil === "domcontentloaded"
               ? "domcontentloaded"

--- a/package/ego-browser/src/driver/waits.ts
+++ b/package/ego-browser/src/driver/waits.ts
@@ -1,7 +1,7 @@
 import { state } from "../state.js";
 import { cdp, runtimeValue } from "../cdp-eval.js";
 import { resolveHandle, releaseHandle } from "./element-ops.js";
-import { ElementResolutionError } from "../element-resolver.js";
+import { ElementResolutionError } from "../ego-errors.js";
 import { waitForDocumentLoad } from "./load.js";
 import { drainEvents } from "./observe.js";
 import { waitForBrowserEvent } from "../browser-runtime.js";

--- a/package/ego-browser/src/ego-errors.test.mjs
+++ b/package/ego-browser/src/ego-errors.test.mjs
@@ -1,166 +1,159 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-
 import {
-  assertNoEgoError,
-  egoErrorCode,
-  isEgoErrorCode,
-  isEgoUserControlError,
-  resolveEgoError,
+  EgoError,
+  ElementResolutionError,
+  NavigationTimeoutError,
+  DialogBlockingError,
+  ConnectionLostError,
+  TimeoutError,
+  mapCdpError,
 } from "../dist/src/ego-errors.js";
+import { __testing } from "../dist/src/helpers.js";
 
-test("egoErrorCode extracts the code from every error shape", () => {
-  // resolved { error, error_code } object
-  assert.equal(
-    egoErrorCode({ error: "nope", error_code: "EGO_BROWSER_UNAVAILABLE" }),
-    "EGO_BROWSER_UNAVAILABLE",
-  );
-  // rejected / thrown Error carrying .error_code
-  const err = Object.assign(new Error("boom"), {
-    error_code: "EGO_SNAPSHOT_FAILED",
+test("EgoError has required shape", () => {
+  const err = new EgoError("test error", "transient", "TEST_ERROR", undefined, "Custom hint");
+  assert.equal(err.kind, "transient");
+  assert.equal(err.code, "TEST_ERROR");
+  assert.ok(typeof err.context.timestamp === "number");
+  assert.ok(err.recoveryHint !== undefined);
+  assert.ok(err.recoveryHint.length > 0);
+});
+
+test("EgoError context includes timestamp", () => {
+  const err = new EgoError("test", "permanent", "TEST");
+  assert.ok(err.context.timestamp > 0);
+});
+
+test("transient errors have recoveryHint", () => {
+  const err = new ElementResolutionError("not found", "transient");
+  assert.ok(typeof err.recoveryHint === "string" && err.recoveryHint.length > 0);
+});
+
+test("permanent errors have recoveryHint", () => {
+  const err = new ElementResolutionError("invalid selector", "permanent");
+  assert.ok(err.recoveryHint !== undefined);
+  assert.ok(err.recoveryHint.length > 0);
+});
+
+test("NavigationTimeoutError has correct kind", () => {
+  const err = new NavigationTimeoutError("page load timeout");
+  assert.equal(err.kind, "transient");
+  assert.equal(err.code, "NAVIGATION_TIMEOUT");
+});
+
+test("DialogBlockingError has correct kind", () => {
+  const err = new DialogBlockingError("alert blocking");
+  assert.equal(err.kind, "transient");
+  assert.equal(err.code, "DIALOG_BLOCKING");
+});
+
+test("ConnectionLostError has correct kind", () => {
+  const err = new ConnectionLostError("connection dropped");
+  assert.equal(err.kind, "transient");
+  assert.equal(err.code, "CONNECTION_LOST");
+});
+
+test("Error hierarchy preserves message", () => {
+  const err = new ElementResolutionError("custom message", "transient");
+  assert.equal(err.message, "custom message");
+});
+
+test("Error serialization includes kind and code", () => {
+  const err = new ElementResolutionError("test", "transient");
+  const json = JSON.stringify(err);
+  assert.ok(json.includes('"kind":"transient"'));
+  assert.ok(json.includes('"code":"ELEMENT_NOT_FOUND"'));
+});
+
+test("recoveryHint is safe (no URL leakage)", () => {
+  // Create an error with a sensitive URL in context
+  const err = new EgoError("navigation failed", "transient", "NAV_FAILED", {
+    url: "https://example.com/secret?token=abc123xyz",
+  }, "Check the URL and retry.");
+  // The recoveryHint itself should never echo the URL
+  assert.ok(!err.recoveryHint.includes("abc123xyz"));
+  assert.ok(!err.recoveryHint.includes("secret"));
+  assert.equal(err.context.url, "https://example.com/secret");
+  assert.ok(!JSON.stringify(err.toJSON()).includes("abc123xyz"));
+});
+
+test("TimeoutError exists and has correct shape", () => {
+  const err = new TimeoutError("pageLoad", 5000);
+  assert.equal(err.kind, "transient");
+  assert.equal(err.code, "TIMEOUT");
+  assert.ok(typeof err.recoveryHint === "string");
+  assert.ok(err.recoveryHint.length > 0);
+});
+
+test("context.timestamp is always present", () => {
+  const err = new NavigationTimeoutError("timeout");
+  assert.ok(typeof err.context.timestamp === "number");
+  assert.ok(err.context.timestamp > 0);
+});
+
+test("NavigationTimeoutError redacts sensitive URL from message and toJSON", () => {
+  const err = new NavigationTimeoutError("https://example.com/page?token=abc123xyz&foo=bar", 5000);
+  // Message must not contain query params (where tokens live)
+  assert.ok(!err.message.includes("abc123xyz"));
+  assert.ok(!err.message.includes("foo=bar"));
+  assert.ok(!err.message.includes("?"));
+  // Message should contain the redacted URL (domain+path only)
+  assert.ok(err.message.includes("example.com"));
+  assert.ok(err.message.includes("/page"));
+  // toJSON must also not leak
+  const json = err.toJSON();
+  assert.ok(!json.message.includes("abc123xyz"));
+  assert.equal(err.context.url, "https://example.com/page");
+  assert.ok(!JSON.stringify(json).includes("abc123xyz"));
+});
+
+test("mapCdpError applies session-loss and timeout precedence", () => {
+  const lost = mapCdpError(new Error("Session not found"), {
+    operation: "Runtime.evaluate",
+    url: "https://example.com/private?token=SEKRET",
   });
-  assert.equal(egoErrorCode(err), "EGO_SNAPSHOT_FAILED");
-  // bare known code string (e.g. onSendCDPMessageError second arg)
-  assert.equal(
-    egoErrorCode("EGO_TASK_SPACE_USER_IN_CONTROL"),
-    "EGO_TASK_SPACE_USER_IN_CONTROL",
-  );
-  // future code this build does not know about is still returned
-  assert.equal(
-    egoErrorCode({ error_code: "EGO_FUTURE_CODE" }),
-    "EGO_FUTURE_CODE",
-  );
-  // no code present
-  assert.equal(egoErrorCode({ error: "plain message" }), undefined);
-  assert.equal(egoErrorCode("plain message"), undefined);
-});
+  assert.ok(lost instanceof ConnectionLostError);
+  assert.equal(lost.context.url, "https://example.com/private");
 
-test("isEgoErrorCode narrows to known codes only", () => {
-  assert.equal(isEgoErrorCode("EGO_TASK_SPACE_NOT_FOUND"), true);
-  assert.equal(isEgoErrorCode("EGO_FUTURE_CODE"), false);
-  assert.equal(isEgoErrorCode(undefined), false);
-});
-
-test("resolveEgoError overrides the native error message with the owned wording for an owned code", () => {
-  const { code, message } = resolveEgoError({
-    error: "Task space 7 is not assigned to an agent.",
-    error_code: "EGO_TASK_SPACE_INACTIVE",
+  const navigation = mapCdpError(new Error("request timed out"), {
+    operation: "navigate",
+    url: "https://example.com/page",
+    timeoutMs: 5000,
   });
-  assert.equal(code, "EGO_TASK_SPACE_INACTIVE");
-  // Owned id-less guidance replaces the native "Task space 7 ..." text.
-  assert.match(message, /taskSpaces\.claim\(id\)/);
-  assert.doesNotMatch(message, /\b7\b/);
-});
+  assert.ok(navigation instanceof NavigationTimeoutError);
+  assert.equal(navigation.context.url, "https://example.com/page");
+  assert.match(navigation.message, /5000ms/);
 
-test("resolveEgoError keeps the native error message for an unknown future code", () => {
-  assert.deepEqual(
-    resolveEgoError({
-      error: "Some build-specific detail",
-      error_code: "EGO_FUTURE_CODE",
-    }),
-    {
-      code: "EGO_FUTURE_CODE",
-      message: "Some build-specific detail",
-    },
-  );
-});
-
-test("resolveEgoError defers to the native error message for a code ego-browser does not own", () => {
-  // EGO_OPERATION_FAILED is not owned: the client wording (e.g. which operation
-  // failed) is more specific than any static line.
-  assert.deepEqual(
-    resolveEgoError({
-      error: "Failed to create task space",
-      error_code: "EGO_OPERATION_FAILED",
-    }),
-    {
-      code: "EGO_OPERATION_FAILED",
-      message: "Failed to create task space",
-    },
-  );
-});
-
-test("resolveEgoError falls back to the raw code for a bare non-owned code", () => {
-  // ego-browser does not own NOT_SELECTED and a bare code carries no native error message,
-  // so the stable code itself is the most specific thing to surface.
-  assert.deepEqual(resolveEgoError("EGO_TASK_SPACE_NOT_SELECTED"), {
-    code: "EGO_TASK_SPACE_NOT_SELECTED",
-    message: "EGO_TASK_SPACE_NOT_SELECTED",
+  const operation = mapCdpError(new Error("timeout"), {
+    operation: "waitForSelector",
+    timeoutMs: 250,
   });
+  assert.ok(operation instanceof TimeoutError);
+  assert.equal(operation.code, "TIMEOUT");
 });
 
-test("resolveEgoError uses the id-less guidance block for a bare user-control code", () => {
-  const { code, message } = resolveEgoError("EGO_TASK_SPACE_USER_IN_CONTROL");
-  assert.equal(code, "EGO_TASK_SPACE_USER_IN_CONTROL");
-  assert.match(message, /taken control of this task space/);
-  assert.match(message, /taskSpaces\.takeOver\(\)/);
-  assert.doesNotMatch(message, /<id>/);
-});
-
-test("resolveEgoError falls back to the raw code, then a generic message", () => {
-  assert.deepEqual(resolveEgoError({ error_code: "EGO_FUTURE_CODE" }), {
-    code: "EGO_FUTURE_CODE",
-    message: "EGO_FUTURE_CODE",
+test("error taxonomy mutation seam exposes defective mapping", () => {
+  const dispose = __testing.setErrorTaxonomyOverrides({
+    mapCdpError: () => new Error("generic"),
   });
-  assert.deepEqual(resolveEgoError({}), {
-    code: undefined,
-    message: "Unknown ego error",
-  });
-});
-
-test("isEgoUserControlError keys on the stable code, not wording", () => {
-  assert.equal(
-    isEgoUserControlError(
-      Object.assign(new Error("anything at all"), {
-        error_code: "EGO_TASK_SPACE_USER_IN_CONTROL",
-      }),
-    ),
-    true,
-  );
-  // wording that mentions user control but lacks the code is not a match
-  assert.equal(
-    isEgoUserControlError(new Error("the user is controlling this")),
-    false,
-  );
-  assert.equal(
-    isEgoUserControlError({ error_code: "EGO_SNAPSHOT_FAILED" }),
-    false,
-  );
-});
-
-test("assertNoEgoError resolves the message via the code and attaches error_code", () => {
   try {
-    assertNoEgoError(
-      {
-        error: "Task space not selected",
-        error_code: "EGO_TASK_SPACE_NOT_SELECTED",
-      },
-      "listTabs",
-    );
-    assert.fail("expected assertNoEgoError to throw");
-  } catch (err) {
-    assert.equal(err.message, "listTabs: Task space not selected");
-    assert.equal(err.error_code, "EGO_TASK_SPACE_NOT_SELECTED");
-  }
-});
-
-test("assertNoEgoError omits the prefix when no op is given", () => {
-  try {
-    assertNoEgoError({
-      error: "The task space is inactive: 10",
-      error_code: "EGO_TASK_SPACE_INACTIVE",
+    const mapped = __testing.mapCdpError(new Error("Session not found"), {
+      operation: "Runtime.evaluate",
     });
-    assert.fail("expected assertNoEgoError to throw");
-  } catch (err) {
-    // No op given, so no "<op>: " prefix — the owned block starts the message.
-    assert.match(err.message, /^The user has taken control/);
-    assert.match(err.message, /taskSpaces\.claim\(id\)/);
-    assert.doesNotMatch(err.message, /\b10\b/);
-    assert.equal(err.error_code, "EGO_TASK_SPACE_INACTIVE");
+    assert.ok(!(mapped instanceof EgoError));
+  } finally {
+    dispose();
   }
+  assert.ok(
+    __testing.mapCdpError(new Error("Session not found"), {
+      operation: "Runtime.evaluate",
+    }) instanceof ConnectionLostError,
+  );
 });
 
-test("assertNoEgoError passes through results with no error", () => {
-  const ok = { tabs: [] };
-  assert.equal(assertNoEgoError(ok, "listTabs"), ok);
+test("URL without query or fragment is preserved", () => {
+  const err = new NavigationTimeoutError("https://ex.com/s", 5000);
+  assert.equal(err.context.url, "https://ex.com/s");
+  assert.match(err.message, /https:\/\/ex\.com\/s/);
 });

--- a/package/ego-browser/src/ego-errors.ts
+++ b/package/ego-browser/src/ego-errors.ts
@@ -17,6 +17,238 @@
 
 import { markHardStop } from "./output-sink.js";
 
+/** Error kind classification for retry logic. */
+export type ErrorKind = "transient" | "permanent";
+
+/**
+ * Structured error base class with recovery guidance.
+ * All ego-browser errors extend this for consistent handling.
+ */
+export class EgoError extends Error {
+  kind: ErrorKind;
+  code: string;
+  context: {
+    url?: string;
+    ref?: string;
+    timestamp: number;
+    sessionId?: string;
+  };
+  recoveryHint?: string;
+
+  constructor(
+    message: string,
+    kind: ErrorKind,
+    code: string,
+    context?: Partial<EgoError["context"]>,
+    recoveryHint?: string,
+  ) {
+    super(message);
+    this.name = "EgoError";
+    this.kind = kind;
+    this.code = code;
+    this.context = {
+      timestamp: Date.now(),
+      ...context,
+      ...(context?.url ? { url: redactUrl(context.url) } : {}),
+    };
+    this.recoveryHint = recoveryHint;
+  }
+
+  /** Serialize to JSON-safe object for logging. */
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      kind: this.kind,
+      code: this.code,
+      context: { ...this.context },
+      recoveryHint: this.recoveryHint,
+    };
+  }
+}
+
+/** Element not found or stale reference. */
+export class ElementResolutionError extends EgoError {
+  constructor(message: string, kind: ErrorKind = "transient") {
+    super(
+      message,
+      kind,
+      "ELEMENT_NOT_FOUND",
+      undefined,
+      kind === "transient"
+        ? "Element may not have loaded yet. Try waiting with waitForSelector or re-snapshot the page."
+        : "Element not found — check the selector or page state.",
+    );
+    this.name = "ElementResolutionError";
+  }
+}
+
+/** Page navigation timed out. */
+/** Redact query params and fragments from a URL for safe message display. */
+export function redactUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    u.search = "";
+    u.hash = "";
+    return u.toString();
+  } catch {
+    // Not a valid URL — strip everything after the first '?' or '#'
+    return url.split(/[?#]/)[0];
+  }
+}
+
+export class NavigationTimeoutError extends EgoError {
+  constructor(url: string, timeoutMs: number) {
+    super(
+      `Navigation to ${redactUrl(url)} timed out after ${timeoutMs}ms`,
+      "transient",
+      "NAVIGATION_TIMEOUT",
+      { url },
+      "Page may be slow to load. Try increasing timeout or using waitForLoadState with 'networkidle'.",
+    );
+    this.name = "NavigationTimeoutError";
+  }
+}
+
+/** Native dialog blocking JavaScript execution. */
+export class DialogBlockingError extends EgoError {
+  constructor(dialogType: string) {
+    super(
+      `Native ${dialogType} dialog is blocking page JavaScript`,
+      "transient",
+      "DIALOG_BLOCKING",
+      undefined,
+      "Handle the dialog with cdp('Page.handleJavaScriptDialog', {accept: true}) before continuing.",
+    );
+    this.name = "DialogBlockingError";
+  }
+}
+
+/** CDP connection lost during operation. */
+export class TimeoutError extends EgoError {
+  constructor(operation: string, timeoutMs: number) {
+    super(
+      `${operation} timed out after ${timeoutMs}ms`,
+      "transient",
+      "TIMEOUT",
+      undefined,
+      `Increase the timeout for ${operation} or investigate why it is slow.`,
+    );
+    this.name = "TimeoutError";
+  }
+}
+
+export class ConnectionLostError extends EgoError {
+  constructor(previousUrl?: string) {
+    super(
+      "CDP connection lost during operation",
+      "transient",
+      "CONNECTION_LOST",
+      { url: previousUrl },
+      "Attempting automatic reconnect. Retry the operation if it fails again.",
+    );
+    this.name = "ConnectionLostError";
+  }
+}
+
+export type CdpErrorContext = {
+  operation: string;
+  url?: string;
+  timeoutMs?: number;
+  sessionId?: string;
+};
+
+type CdpMappedError = Error & { code?: string };
+
+type ErrorTaxonomyOverrides = {
+  mapCdpError?: (rawError: unknown, context: CdpErrorContext) => CdpMappedError;
+  navigationTimeout?: (url: string, timeoutMs: number) => Error;
+  connectionFailure?: (previousUrl?: string) => Error;
+  operationTimeout?: (operation: string, timeoutMs: number) => Error;
+};
+
+const SESSION_LOST_MESSAGE =
+  /Session (?:with given id )?not found|Target closed|No session/i;
+const TIMEOUT_MESSAGE = /timed? out|timeout/i;
+
+const defaultErrorTaxonomy = {
+  navigationTimeout: (url: string, timeoutMs: number): Error =>
+    new NavigationTimeoutError(url, timeoutMs),
+  connectionFailure: (previousUrl?: string): Error =>
+    new ConnectionLostError(previousUrl),
+  operationTimeout: (operation: string, timeoutMs: number): Error =>
+    new TimeoutError(operation, timeoutMs),
+};
+
+let errorTaxonomyOverrides: ErrorTaxonomyOverrides = {};
+
+function rawErrorMessage(rawError: unknown): string {
+  if (rawError instanceof Error) return rawError.message;
+  return formatEgoError(rawError);
+}
+
+/** Convert a raw CDP rejection into the structured taxonomy. */
+export function mapCdpError(
+  rawError: unknown,
+  context: CdpErrorContext,
+): CdpMappedError {
+  if (errorTaxonomyOverrides.mapCdpError) {
+    return errorTaxonomyOverrides.mapCdpError(rawError, context);
+  }
+  if (rawError instanceof EgoError) return rawError;
+  if (rawError instanceof Error && "error_code" in rawError) {
+    return rawError as CdpMappedError;
+  }
+
+  const message = rawErrorMessage(rawError);
+  if (SESSION_LOST_MESSAGE.test(message)) {
+    return createConnectionLostError(context.url);
+  }
+  if (TIMEOUT_MESSAGE.test(message) && context.operation === "navigate") {
+    return createNavigationTimeoutError(context.url ?? "", context.timeoutMs ?? 0);
+  }
+  if (TIMEOUT_MESSAGE.test(message)) {
+    return createOperationTimeoutError(context.operation, context.timeoutMs ?? 0);
+  }
+  return new EgoError(message, "permanent", "CDP_ERROR", {
+    url: context.url,
+    sessionId: context.sessionId,
+  });
+}
+
+export function createNavigationTimeoutError(url: string, timeoutMs: number) {
+  return (
+    errorTaxonomyOverrides.navigationTimeout ??
+    defaultErrorTaxonomy.navigationTimeout
+  )(url, timeoutMs);
+}
+
+export function createConnectionLostError(previousUrl?: string) {
+  return (
+    errorTaxonomyOverrides.connectionFailure ??
+    defaultErrorTaxonomy.connectionFailure
+  )(previousUrl);
+}
+
+export function createOperationTimeoutError(
+  operation: string,
+  timeoutMs: number,
+) {
+  return (
+    errorTaxonomyOverrides.operationTimeout ??
+    defaultErrorTaxonomy.operationTimeout
+  )(operation, timeoutMs);
+}
+
+/** Install isolated taxonomy mutations for executable wiring checks. */
+export function setErrorTaxonomyOverrides(overrides: ErrorTaxonomyOverrides) {
+  const previous = errorTaxonomyOverrides;
+  errorTaxonomyOverrides = { ...previous, ...overrides };
+  return () => {
+    errorTaxonomyOverrides = previous;
+  };
+}
+
 /** Stable error codes emitted by the native ego bindings. */
 export const EGO_ERROR_CODES = [
   "EGO_BROWSER_UNAVAILABLE",

--- a/package/ego-browser/src/element-resolver.test.mjs
+++ b/package/ego-browser/src/element-resolver.test.mjs
@@ -4,8 +4,8 @@ import assert from "node:assert/strict";
 import {
   resolveElementCenter,
   resolveElementObjectId,
-  ElementResolutionError,
 } from "../dist/src/element-resolver.js";
+import { ElementResolutionError } from "../dist/src/ego-errors.js";
 import { RefMap } from "../dist/src/ref-map.js";
 
 class FakeCDP {

--- a/package/ego-browser/src/element-resolver.ts
+++ b/package/ego-browser/src/element-resolver.ts
@@ -1,14 +1,6 @@
 import { parseRef } from "./ref-map.js";
 import { queryAllExpression } from "./locator-query.js";
-
-export class ElementResolutionError extends Error {
-  kind: "transient" | "permanent";
-  constructor(message: string, kind: "transient" | "permanent") {
-    super(message);
-    this.name = "ElementResolutionError";
-    this.kind = kind;
-  }
-}
+import { ElementResolutionError } from "./ego-errors.js";
 
 /**
  * Return the ordered AX backend-node match set for a root role locator.

--- a/package/ego-browser/src/helpers.ts
+++ b/package/ego-browser/src/helpers.ts
@@ -3,7 +3,16 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { setOverrides, state } from "./state.js";
-import { assertNoEgoError, isEgoUserControlError } from "./ego-errors.js";
+import {
+  assertNoEgoError,
+  isEgoUserControlError,
+  ElementResolutionError,
+  NavigationTimeoutError,
+  ConnectionLostError,
+  DialogBlockingError,
+  mapCdpError,
+  setErrorTaxonomyOverrides,
+} from "./ego-errors.js";
 import { help as helpRuntime, formatHelp } from "./help-runtime.js";
 import { cdp, decodeUnserializableJsValue, evaluate } from "./cdp-eval.js";
 import * as pointer from "./driver/pointer.js";
@@ -830,6 +839,7 @@ export function helperContext(extra: any = {}) {
       browser: browserFetch,
     },
     cdp,
+    mapCdpError,
     ...extra,
   };
   return {
@@ -864,4 +874,9 @@ export async function loadAgentHelpers() {
   return out;
 }
 
-export const __testing = { setOverrides, decodeUnserializableJsValue };
+export const __testing = {
+  setOverrides,
+  setErrorTaxonomyOverrides,
+  mapCdpError,
+  decodeUnserializableJsValue,
+};


### PR DESCRIPTION
## Summary

Adds a typed, serializable **error taxonomy** for browser failures and routes CDP-eval and navigation errors through a single mapper. Each error carries a stable `kind`/`code`, a **redacted** `context` (URL query/fragment secrets stripped), and a `recoveryHint`. `ElementResolutionError` moves into the shared `ego-errors.ts` so every driver shares one definition. Smallest useful change: purely additive — errors still throw, they are now typed and consistent.

## Related issue

No tracked issue — this is the foundation for a small series of reliability/ergonomics improvements to the helper surface (session resilience, lifecycle hooks, semantic actions), each landing as its own focused PR.

## Changes

- `src/ego-errors.ts` (new) — `EgoError` base + `ElementResolutionError`, `NavigationTimeoutError`, `ConnectionLostError`, `TimeoutError`, `DialogBlockingError`; `mapCdpError(raw, ctx)` with clear precedence; `redactUrl`; `create*Error` factories; `toJSON()` for serializable, secret-free errors.
- `src/element-resolver.ts`, `src/driver/locator.ts`, `src/driver/waits.ts` — import `ElementResolutionError` from `ego-errors` (moved, single source of truth).
- `src/cdp-eval.ts` — drop the duplicate local `TimeoutError`; typed operation-timeout.
- `src/driver/load.ts`, `src/driver/nav.ts` — throw `NavigationTimeoutError` on the real timeout path.
- `src/helpers.ts` — expose `mapCdpError` on the helper surface.
- `package/ego-browser/README.md` — one Source-layout line documenting `ego-errors.ts`.

## Verification

```text
npm test                      # 316 pass / 0 fail (build + tsc --noEmit + node --test)
npm run validate:site-skills  # site skills ok
```

Targeted tests cover URL redaction (both `message` and `toJSON`), `mapCdpError` precedence, and the real navigation-timeout path via a fake clock (`src/ego-errors.test.mjs`, `src/driver/nav.test.mjs`).

## Impact

- [x] Public helper API or behavior
- [ ] Agent skill or instructions
- [ ] Site learning
- [ ] Installation or update flow
- [ ] Build, CI, or release process
- [ ] Documentation only
- [ ] No externally visible impact

Additive and backward-compatible: no public helper removed; drivers now throw typed errors instead of ad-hoc ones. `ElementResolutionError` keeps its `transient`/`permanent` classification that wait loops rely on. No new runtime dependencies.
