### PR TITLE
fix(ego-browser): refresh session after opening tab

### DIFF
--- a/package/ego-browser/src/driver/nav.test.mjs
+++ b/package/ego-browser/src/driver/nav.test.mjs
@@ -141,6 +141,71 @@ test("newTab throws when the binding returns no targetId", async () => {
   );
 });
 
+test("newTab attaches subsequent page commands to the created target", async () => {
+  const calls = [];
+  let tabs = [
+    {
+      targetId: "target-old",
+      active: true,
+      title: "Old",
+      url: "https://example.com/old",
+    },
+  ];
+  const runtime = {
+    async listTabs() {
+      return { tabs };
+    },
+    async createTab(url) {
+      tabs = [
+        { ...tabs[0], active: false },
+        { targetId: "target-new", active: true, title: "New", url },
+      ];
+      return { targetId: "target-new" };
+    },
+    sendCDPMessage(payload) {
+      const request = JSON.parse(payload);
+      calls.push(request);
+      const result =
+        request.method === "Target.attachToTarget"
+          ? { sessionId: `session-${request.params.targetId}` }
+          : {};
+      queueMicrotask(() =>
+        runtime.onCDPMessage(JSON.stringify({ id: request.id, result })),
+      );
+    },
+  };
+
+  await withEgo(runtime, async () => {
+    invalidateSession();
+    state.preferredTargetId = null;
+    try {
+      await browserCdp("Runtime.evaluate", { expression: "1" });
+      assert.equal(state.sessionTargetId, "target-old");
+
+      assert.equal(await newTab("https://example.com/new"), "target-new");
+      assert.equal(state.sessionId, null);
+      assert.equal(state.preferredTargetId, "target-new");
+
+      await browserCdp("Runtime.evaluate", { expression: "2" });
+      assert.equal(state.sessionTargetId, "target-new");
+    } finally {
+      invalidateSession();
+      state.preferredTargetId = null;
+    }
+  });
+
+  assert.deepEqual(
+    calls
+      .filter((call) => call.method === "Target.attachToTarget")
+      .map((call) => call.params.targetId),
+    ["target-old", "target-new"],
+  );
+  assert.equal(
+    calls.filter((call) => call.method === "Runtime.evaluate").at(-1).sessionId,
+    "session-target-new",
+  );
+});
+
 test("openOrReuseTab settles a newly opened tab in milliseconds, not seconds", async () => {
   // Regression: the new-tab branch used to sleep(settle * 1000), so settle:500
   // (documented as 500ms) blocked for 500 seconds while the reuse branch

--- a/package/ego-browser/src/driver/nav.ts
+++ b/package/ego-browser/src/driver/nav.ts
@@ -170,6 +170,8 @@ export async function newTab(url = "about:blank") {
   if (!result.targetId) {
     throw new Error("newTab returned no targetId");
   }
+  invalidateSession();
+  setPreferredTarget(result.targetId);
   return result.targetId;
 }
 


### PR DESCRIPTION
## Summary

- invalidate the cached CDP session after `newTab()` creates a target
- prefer the created target for the next page-scoped CDP command
- add a regression test that starts on an old session and verifies the next command attaches to the new target

## Why

`newTab()` returned the new target ID without updating session selection. Because `ensureSession()` caches the current session for two seconds, an immediate wait or page command could continue operating on the previously active tab. `switchTab()` already invalidates the session and sets a preferred target; this applies the same transition after native tab creation.

## Impact

Commands issued immediately after `newTab()` or the new-tab branch of `openOrReuseTab()` now attach to the created tab instead of briefly reusing the prior tab's session.

## Validation

- `npm test` — 312 tests passed
- Prettier check passed
- TypeScript typecheck passed
- Site-skill validation passed
- Vulnerability audit found 0 issues
- Real-browser navigation helper case passed; the full local E2E run finished 42/45, with unrelated existing/environmental failures in ffmpeg discovery, the concert inventory fixture, and canvas zigzag stroke counting
