### PR TITLE
feat(linux): fully functional optimized Linux port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,14 @@ jobs:
       - name: Install deps
         run: npm ci
 
+      - name: Run install.sh (Linux path)
+        working-directory: ${{ github.workspace }}
+        env:
+          EGO_BROWSER_ASSUME_YES: "1"
+        run: |
+          sh skills/ego-browser/scripts/install.sh
+          "$HOME/.local/bin/ego-browser" --help
+
       - name: npm test
         run: npm test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,47 @@ jobs:
       - run: npm test
       - run: npm run validate:site-skills
 
+  linux-headless:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: package/ego-browser
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package/ego-browser/package-lock.json
+
+      - name: Install Chrome
+        run: |
+          wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq google-chrome-stable
+
+      - name: Verify Chrome
+        run: |
+          google-chrome-stable --version
+          which google-chrome-stable
+
+      - name: Run doctor-linux
+        run: node scripts/doctor-linux.mjs
+
+      - name: Install deps
+        run: npm ci
+
+      - name: npm test
+        run: npm test
+
+      - name: Validate site skills
+        run: npm run validate:site-skills
+
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: test
+    needs: [test, linux-headless]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 ego (lite) is a browser where you and your AI agents work in parallel. Your agents run multiple browser tasks in their own Spaces while your tabs stay yours, and tasks complete faster on fewer tokens.
 
+> **Linux support is here.** macOS remains primary; Linux is fully automated via Chrome/Chromium + CDP (`EGO_LINUX=1` or auto-detect). See `skills/ego-browser/references/install.md` → *Linux* section. Windows is on the [roadmap](https://lite.ego.app/roadmap).
+
 Existing tools like browser-use and agent-browser are browser automation frameworks: they need a separate browser to drive, logins never carry cleanly, and you and the agent end up fighting for the same tabs. ego lite is one browser designed from the start for the two of you to share. No extra setup, and the agent can always reach your real logins and tabs through `ego-browser`.
 
 ## Demo
@@ -27,7 +29,11 @@ https://github.com/user-attachments/assets/ffe7954b-58ee-411e-b35d-ec30c58a08bc
 
 ## Quick Start
 
-ego lite runs on macOS today. Windows and Linux are on the [roadmap](https://lite.ego.app/roadmap).
+| Platform | Status | Install |
+|---|:---:|---|
+| macOS (Apple Silicon / Intel) | ✅ Stable | DMG from below or `npx skills add citrolabs/ego-lite` |
+| Linux (Chrome/Chromium) | ✅ Stable | `sh skills/ego-browser/scripts/install.sh` (auto-detects apt/dnf/pacman; `EGO_LINUX=1`) |
+| Windows | 🗓️ Roadmap | — |
 
 ### 1. Install
 
@@ -49,6 +55,15 @@ npx skills add citrolabs/ego-lite
 ```
 
 The first time your agent runs a browser task, it walks you through installing the ego lite app.
+
+**Linux:** run `sh skills/ego-browser/scripts/install.sh` — it auto-detects `apt`/`dnf`/`pacman`/`zypper`, installs or finds Chrome/Chromium, builds the CLI, and creates `~/.local/bin/ego-browser`. Then:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+EGO_LINUX=1 ego-browser nodejs <<'EOF'
+console.log(await pageInfo())
+EOF
+```
 
 **1.3 Let your agent set it up**
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npx skills add citrolabs/ego-lite
 
 The first time your agent runs a browser task, it walks you through installing the ego lite app.
 
-**Linux:** run `sh skills/ego-browser/scripts/install.sh` — it auto-detects `apt`/`dnf`/`pacman`/`zypper`, installs or finds Chrome/Chromium, builds the CLI, and creates `~/.local/bin/ego-browser`. Then:
+**Linux:** the CLI is built from source, so this needs a full clone of the repo (not just the skill added via `npx`): `git clone https://github.com/citrolabs/ego-lite && cd ego-lite`. Then run `sh skills/ego-browser/scripts/install.sh` — it auto-detects `apt`/`dnf`/`pacman`/`zypper`, installs or finds Chrome/Chromium, builds the CLI, and creates `~/.local/bin/ego-browser`. Then:
 
 ```bash
 export PATH="$HOME/.local/bin:$PATH"

--- a/package/ego-browser/package-lock.json
+++ b/package/ego-browser/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.16.0"
+        "acorn": "^8.16.0",
+        "ws": "^8.21.3"
       },
       "bin": {
         "ego-browser": "dist/out/index.js"
@@ -1368,6 +1369,27 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package/ego-browser/package.json
+++ b/package/ego-browser/package.json
@@ -35,6 +35,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "acorn": "^8.16.0"
+    "acorn": "^8.16.0",
+    "ws": "^8.21.3"
   }
 }

--- a/package/ego-browser/scripts/build.mjs
+++ b/package/ego-browser/scripts/build.mjs
@@ -67,7 +67,11 @@ try {
 
   const rollupConfig = {
     input: join(root, "src/index.ts"),
-    external: [...builtinModules, ...builtinModules.map((m) => `node:${m}`)],
+    external: [
+      ...builtinModules,
+      ...builtinModules.map((m) => `node:${m}`),
+      "ws",
+    ],
     plugins: [
       resolve(),
       typescript({

--- a/package/ego-browser/scripts/doctor-linux.mjs
+++ b/package/ego-browser/scripts/doctor-linux.mjs
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+/**
+ * doctor-linux — diagnostic script for Linux ego-browser environments.
+ *
+ * Reports:
+ *   - Chrome/Chromium version and install path
+ *   - DevTools debugging port availability (default 9222)
+ *   - Browser cache / user-data directory size
+ *   - Wayland vs X11 display server
+ *   - ws package (WebSocket) availability
+ *   - Node.js version
+ *
+ * Usage:
+ *   node scripts/doctor-linux.mjs
+ *   node scripts/doctor-linux.mjs --json    (machine-readable output)
+ *
+ * Can also be consumed as a module from run.ts via the --doctor flag
+ * when the platform is Linux.
+ */
+
+import { execSync } from "node:child_process";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { statSync, existsSync } from "node:fs";
+
+const outputJson =
+  process.argv.includes("--json") || process.argv.includes("-j");
+
+/**
+ * @param {string} cmd
+ * @param {{ env?: Record<string,string> }} [opts]
+ * @returns {string}
+ */
+function run(cmd, opts = {}) {
+  try {
+    return execSync(cmd, {
+      encoding: "utf-8",
+      timeout: 10_000,
+      stdio: ["pipe", "pipe", "pipe"],
+      ...opts,
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Try to find the Chrome/Chromium binary and its version.
+ */
+function chromeInfo() {
+  const candidates = [
+    "google-chrome-stable",
+    "google-chrome",
+    "google-chrome-beta",
+    "google-chrome-unstable",
+    "chromium",
+    "chromium-browser",
+    "chrome",
+  ];
+
+  let binary = "";
+  let version = "";
+
+  for (const name of candidates) {
+    const path = run(`which ${name} 2>/dev/null`);
+    if (path) {
+      binary = path;
+      version = run(`${path} --version 2>/dev/null`);
+      if (version) break;
+    }
+  }
+
+  // Fallback: check common install locations
+  if (!binary) {
+    for (const dir of [
+      "/opt/google/chrome",
+      "/opt/google/chrome-beta",
+      "/usr/bin",
+      "/snap/bin",
+    ]) {
+      for (const name of [
+        "google-chrome-stable",
+        "google-chrome",
+        "chromium",
+        "chromium-browser",
+      ]) {
+        const p = join(dir, name);
+        if (existsSync(p)) {
+          binary = p;
+          version = run(`${p} --version 2>/dev/null`);
+          if (version) break;
+        }
+      }
+      if (binary) break;
+    }
+  }
+
+  return { binary, version };
+}
+
+/**
+ * Check if a process is listening on the given port.
+ */
+function portStatus(port = 9222) {
+  const methods = [
+    // ss (iproute2, most common)
+    () => {
+      const out = run(`ss -tlnp 2>/dev/null | grep ":${port} "`);
+      return out
+        ? `listening: ${out.split(/\s+/).slice(0, 5).join(" ")}`
+        : "not listening";
+    },
+    // netstat fallback
+    () => {
+      const out = run(`netstat -tlnp 2>/dev/null | grep ":${port} "`);
+      return out
+        ? `listening: ${out.split(/\s+/).slice(0, 5).join(" ")}`
+        : "not listening";
+    },
+    // Direct HTTP check
+    () => {
+      const out = run(
+        `curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:${port}/json/version 2>/dev/null`,
+      );
+      return out === "200"
+        ? "responding (HTTP 200)"
+        : `HTTP ${out || "unreachable"}`;
+    },
+  ];
+
+  for (const method of methods) {
+    const result = method();
+    if (result && result !== "not listening" && !result.startsWith("HTTP ")) {
+      return { status: "ready", detail: result, port };
+    }
+    if (result === "responding (HTTP 200)") {
+      return { status: "ready", detail: result, port };
+    }
+  }
+
+  return {
+    status: "unavailable",
+    detail: methods[2]?.() || "unreachable",
+    port,
+  };
+}
+
+/**
+ * Report Chrome cache directory size.
+ */
+function cacheInfo() {
+  const candidates = [
+    join(homedir(), ".cache/google-chrome"),
+    join(homedir(), ".cache/chromium"),
+    join(homedir(), ".config/google-chrome"),
+    join(homedir(), ".config/chromium"),
+    join(homedir(), "snap/chromium/common/.cache/chromium"),
+    join(homedir(), "snap/chromium/current/.config/chromium"),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      const size = dirSize(candidate);
+      return {
+        path: candidate,
+        sizeMB: size > 0 ? (size / (1024 * 1024)).toFixed(1) : "0",
+      };
+    }
+  }
+  return { path: "", sizeMB: "0" };
+}
+
+function dirSize(dir) {
+  try {
+    const out = run(`du -sm "${dir}" 2>/dev/null | cut -f1`);
+    return parseInt(out, 10) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Detect display server type.
+ */
+function displayServer() {
+  const wayland = process.env.WAYLAND_DISPLAY || run("echo $XDG_SESSION_TYPE");
+  const x11 = process.env.DISPLAY;
+
+  if (wayland && wayland !== "x11" && wayland !== "tty") {
+    return {
+      type: "wayland",
+      display: wayland,
+      x11Fallback: x11 || "",
+    };
+  }
+  if (x11) {
+    return { type: "x11", display: x11 };
+  }
+  return { type: "unknown", display: "" };
+}
+
+/**
+ * Check ws package availability.
+ */
+function wsPackageInfo() {
+  try {
+    // Use dynamic require to check without statically importing
+    const pkg = JSON.parse(
+      run(
+        "node -e \"console.log(JSON.stringify(require('ws/package.json')))\" 2>/dev/null",
+      ) || "{}",
+    );
+    if (pkg.version) {
+      return { available: true, version: pkg.version };
+    }
+  } catch {
+    // not found
+  }
+
+  // Check if it's resolvable from the project
+  try {
+    const p = join(
+      import.meta.dirname,
+      "..",
+      "node_modules",
+      "ws",
+      "package.json",
+    );
+    if (existsSync(p)) {
+      const pkg = JSON.parse(run(`cat "${p}"`));
+      return { available: true, version: pkg.version };
+    }
+  } catch {
+    // not found
+  }
+
+  return { available: false, version: "" };
+}
+
+/**
+ * Node.js info.
+ */
+function nodeInfo() {
+  return {
+    version: process.version,
+    platform: platform(),
+    arch: process.arch,
+  };
+}
+
+function main() {
+  const chrome = chromeInfo();
+  const port = portStatus();
+  const cache = cacheInfo();
+  const display = displayServer();
+  const wsPkg = wsPackageInfo();
+  const node = nodeInfo();
+
+  const report = {
+    platform: "linux",
+    timestamp: new Date().toISOString(),
+    node,
+    chrome: {
+      binary: chrome.binary,
+      version: chrome.version || "not found",
+      detected: Boolean(chrome.binary && chrome.version),
+    },
+    devtools: {
+      port: port.port,
+      status: port.status,
+      detail: port.detail,
+    },
+    browserCache: cache,
+    displayServer: display,
+    dependencies: {
+      ws: wsPkg,
+    },
+  };
+
+  if (outputJson) {
+    console.log(JSON.stringify(report, null, 2));
+    return 0;
+  }
+
+  console.log("🩺 ego-browser Linux Diagnostic Report");
+  console.log("======================================\n");
+  console.log(`  Node.js:     ${node.version} (${node.platform} ${node.arch})`);
+
+  console.log(`  Chrome:      ${chrome.version || "❌ not found"}`);
+  if (chrome.binary) console.log(`  Chrome bin:  ${chrome.binary}`);
+
+  console.log(`\n  DevTools:    port ${port.port} — ${port.status}`);
+  console.log(`               ${port.detail}`);
+
+  console.log(`\n  Cache:       ${cache.path || "❌ not found"}`);
+  if (cache.path) console.log(`               ${cache.sizeMB} MB`);
+
+  console.log(`\n  Display:     ${display.type}`);
+  if (display.display)
+    console.log(
+      `               ${display.display}${display.x11Fallback ? ` (X11: ${display.x11Fallback})` : ""}`,
+    );
+
+  console.log(
+    `\n  ws package:  ${wsPkg.available ? `✅ v${wsPkg.version}` : "❌ not installed"}`,
+  );
+
+  // Summary
+  const issues = [];
+  if (!report.chrome.detected) issues.push("Chrome/Chromium not found");
+  if (port.status !== "ready" && process.env.EGO_LINUX !== "1")
+    issues.push(
+      `DevTools port ${port.port} not responding (launch with EGO_LINUX=1)`,
+    );
+  if (!wsPkg.available) issues.push("ws package not installed");
+  if (display.type === "unknown")
+    issues.push("Display server unknown (headless CI is normal)");
+
+  console.log("\n--------------------------------------");
+  if (issues.length === 0) {
+    console.log("✅ All checks passed.");
+  } else {
+    console.log(`⚠️  ${issues.length} issue(s) found:`);
+    for (const issue of issues) {
+      console.log(`   - ${issue}`);
+    }
+  }
+
+  return issues.length > 0 ? 1 : 0;
+}
+
+// Run if called directly
+const isMain =
+  process.argv[1] &&
+  import.meta.url.endsWith(process.argv[1].replace(/^\.?\/?/, ""));
+if (isMain || process.argv[1]?.includes("doctor-linux")) {
+  process.exitCode = main();
+}
+
+export {
+  chromeInfo,
+  portStatus,
+  cacheInfo,
+  displayServer,
+  wsPackageInfo,
+  nodeInfo,
+  main,
+};

--- a/package/ego-browser/src/linux/bridge.test.mjs
+++ b/package/ego-browser/src/linux/bridge.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, afterEach } from "node:test";
+import { describe, it, afterEach, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import { WebSocketServer } from "ws";
@@ -8,17 +8,24 @@ describe("linux bridge", () => {
   let httpServer = null;
   let wss = null;
   let connections = [];
-  const PORT = 19223;
+  let PORT = 19223 + Math.floor(Math.random() * 8000);
 
   afterEach(async () => {
     for (const c of connections) c.close();
     connections.length = 0;
-    wss?.close();
-    wss = null;
+    if (wss) {
+      await new Promise((resolve) => wss.close(() => resolve()));
+      wss = null;
+    }
     if (httpServer) {
       await new Promise((resolve) => httpServer.close(() => resolve()));
       httpServer = null;
     }
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  beforeEach(() => {
+    PORT = 19223 + Math.floor(Math.random() * 8000);
   });
 
   it("connects to a DevTools-like WebSocket target", async () => {
@@ -47,7 +54,6 @@ describe("linux bridge", () => {
     const bridge = await connectLinuxBridge({ port: PORT });
     bridge.send("hello");
 
-    // Give the message time to arrive
     await new Promise((r) => setTimeout(r, 100));
 
     assert.ok(received.includes("hello"));

--- a/package/ego-browser/src/linux/bridge.test.mjs
+++ b/package/ego-browser/src/linux/bridge.test.mjs
@@ -1,0 +1,90 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { WebSocketServer } from "ws";
+import { connectLinuxBridge } from "../../dist/src/linux/bridge.js";
+
+describe("linux bridge", () => {
+  let httpServer = null;
+  let wss = null;
+  let connections = [];
+  const PORT = 19223;
+
+  afterEach(async () => {
+    for (const c of connections) c.close();
+    connections.length = 0;
+    wss?.close();
+    wss = null;
+    if (httpServer) {
+      await new Promise((resolve) => httpServer.close(() => resolve()));
+      httpServer = null;
+    }
+  });
+
+  it("connects to a DevTools-like WebSocket target", async () => {
+    httpServer = createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify([
+          {
+            webSocketDebuggerUrl: `ws://127.0.0.1:${PORT + 1}/devtools/page/1`,
+          },
+        ]),
+      );
+    });
+
+    await new Promise((resolve) => httpServer.listen(PORT, resolve));
+
+    let received = "";
+    wss = new WebSocketServer({ port: PORT + 1, host: "127.0.0.1" });
+    wss.on("connection", (ws) => {
+      connections.push(ws);
+      ws.on("message", (data) => {
+        received += data.toString();
+      });
+    });
+
+    const bridge = await connectLinuxBridge({ port: PORT });
+    bridge.send("hello");
+
+    // Give the message time to arrive
+    await new Promise((r) => setTimeout(r, 100));
+
+    assert.ok(received.includes("hello"));
+    bridge.close();
+  });
+
+  it("throws when no page target is available", async () => {
+    httpServer = createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end("[]");
+    });
+
+    await new Promise((resolve) => httpServer.listen(PORT, resolve));
+
+    await assert.rejects(
+      () => connectLinuxBridge({ port: PORT, timeoutMs: 500 }),
+      /No page target found/,
+    );
+  });
+
+  it("throws when ws connection times out", async () => {
+    httpServer = createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify([
+          {
+            webSocketDebuggerUrl: `ws://127.0.0.1:${PORT + 99}/devtools/page/1`,
+          },
+        ]),
+      );
+    });
+
+    await new Promise((resolve) => httpServer.listen(PORT, resolve));
+
+    await assert.rejects(
+      () => connectLinuxBridge({ port: PORT, timeoutMs: 100 }),
+      /timed out|ECONNREFUSED/,
+    );
+  });
+});

--- a/package/ego-browser/src/linux/bridge.ts
+++ b/package/ego-browser/src/linux/bridge.ts
@@ -63,7 +63,7 @@ export async function connectLinuxBridge(
   ws.on("error", () => options.onClose?.());
 
   const send = (message: string): void => {
-    if (ws.readyState !== ws.OPEN) {
+    if (ws.readyState !== 1) {
       throw new Error("WebSocket is not open");
     }
     ws.send(message);

--- a/package/ego-browser/src/linux/bridge.ts
+++ b/package/ego-browser/src/linux/bridge.ts
@@ -13,6 +13,10 @@ export interface LinuxBridgeTarget {
 export interface LinuxBridgeOptions {
   port?: number;
   timeoutMs?: number;
+  /** Called with each raw CDP message received on the WebSocket. */
+  onMessage?: (data: string) => void;
+  /** Called once when the WebSocket closes or errors after connecting. */
+  onClose?: () => void;
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
@@ -51,6 +55,12 @@ export async function connectLinuxBridge(
   }
 
   const ws = await connectWithTimeout(page.webSocketDebuggerUrl, timeoutMs);
+
+  ws.on("message", (data) => {
+    options.onMessage?.(data.toString());
+  });
+  ws.on("close", () => options.onClose?.());
+  ws.on("error", () => options.onClose?.());
 
   const send = (message: string): void => {
     if (ws.readyState !== ws.OPEN) {

--- a/package/ego-browser/src/linux/bridge.ts
+++ b/package/ego-browser/src/linux/bridge.ts
@@ -1,0 +1,96 @@
+/**
+ * Linux bridge — connects to Chrome via DevTools HTTP + WebSocket.
+ * Uses raw node:http for /json so it never collides with the agent
+ * helper facade that overwrites globalThis.fetch.
+ */
+import { request as httpRequest } from "node:http";
+
+export interface LinuxBridgeTarget {
+  send(message: string): void;
+  close(): void;
+}
+
+export interface LinuxBridgeOptions {
+  port?: number;
+  timeoutMs?: number;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const req = httpRequest(url, (res) => {
+      let data = "";
+      res.on("data", (c: Buffer) => (data += c.toString()));
+      res.on("end", () => {
+        try {
+          resolve(JSON.parse(data) as T);
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+export async function connectLinuxBridge(
+  options: LinuxBridgeOptions = {},
+): Promise<LinuxBridgeTarget> {
+  const port = options.port ?? 9222;
+  const timeoutMs = options.timeoutMs ?? 5000;
+
+  const targets = await fetchJson<Array<{ webSocketDebuggerUrl: string }>>(
+    `http://127.0.0.1:${port}/json`,
+  );
+
+  const page = targets.find((t) => t.webSocketDebuggerUrl);
+  if (!page) {
+    throw new Error(
+      `No page target found on port ${port}. Is Chrome running with --remote-debugging-port=${port}?`,
+    );
+  }
+
+  const ws = await connectWithTimeout(page.webSocketDebuggerUrl, timeoutMs);
+
+  const send = (message: string): void => {
+    if (ws.readyState !== ws.OPEN) {
+      throw new Error("WebSocket is not open");
+    }
+    ws.send(message);
+  };
+
+  const close = (): void => {
+    ws.close();
+  };
+
+  return { send, close };
+}
+
+async function connectWithTimeout(
+  url: string,
+  timeoutMs: number,
+): Promise<import("ws").WebSocket> {
+  const { WebSocket } = await import("ws");
+
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const timer = setTimeout(() => {
+      ws.close();
+      reject(
+        new Error(
+          `WebSocket connection to ${url} timed out after ${timeoutMs}ms`,
+        ),
+      );
+    }, timeoutMs);
+
+    ws.on("open", () => {
+      clearTimeout(timer);
+      resolve(ws);
+    });
+
+    ws.on("error", (err: Error) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}

--- a/package/ego-browser/src/linux/index.ts
+++ b/package/ego-browser/src/linux/index.ts
@@ -1,0 +1,162 @@
+/**
+ * Linux polyfill entrypoint — `src/linux/index.ts`
+ *
+ * Installs a `globalThis.ego` polyfill on Linux that routes all browser
+ * work through a local Chrome instance via CDP. Zero cost on macOS.
+ *
+ * Activation:
+ *   - `EGO_LINUX=1` forces activation (explicit opt-in).
+ *   - Otherwise on Linux: requires `google-chrome` binary to auto-activate.
+ *   - Unit tests: set `EGO_LINUX=0` or `CI=1` to suppress (helpers.test.mjs
+ *     mocks cdpOverride so chrome must NOT be spawned during tests).
+ *   - macOS: never auto-activates.
+ *
+ * Wiring: imported by `src/state.ts` (side-effect) so activation happens
+ * before any helper is evaluated. To avoid breaking tests, activation is
+ * deferred to the first `globalThis.ego` access when not already present.
+ */
+
+import { existsSync } from "node:fs";
+
+import { connectLinuxBridge } from "./bridge.js";
+import { launchChrome, type ChromeInstance } from "./launcher.js";
+import { LinuxSnapshot } from "./snapshot-ax.js";
+import { LinuxTaskSpaces } from "./task-spaces.js";
+
+const WS_PORT = Number(process.env.EGO_LINUX_PORT ?? 9222);
+
+let instance: ChromeInstance | null = null;
+let bridge: { send: (m: string) => void; close: () => void } | null = null;
+let installed = false;
+
+function hasChrome(): boolean {
+  const bin = process.env.EGO_CHROME_BIN ?? "/usr/bin/google-chrome";
+  if (existsSync(bin)) return true;
+  for (const p of [
+    "/usr/bin/chromium-browser",
+    "/usr/bin/chromium",
+    "/snap/bin/chromium",
+  ]) {
+    if (existsSync(p)) return true;
+  }
+  return false;
+}
+
+function shouldActivate(): boolean {
+  if (process.env.EGO_LINUX === "0") return false;
+  if (process.env.EGO_LINUX === "1") return true;
+  // Suppress during unit tests — helpers.test.mjs uses cdpOverride
+  if (process.env.CI === "1" && process.env.EGO_LINUX !== "1") return false;
+  if (process.platform !== "linux") return false;
+  return hasChrome();
+}
+
+async function ensureBridge(): Promise<{ send: (m: string) => void }> {
+  if (bridge) return bridge;
+  try {
+    bridge = await connectLinuxBridge({ port: WS_PORT, timeoutMs: 1500 });
+    return bridge;
+  } catch {
+    // No daemon — launch one
+  }
+  instance = await launchChrome({ headless: true });
+  await new Promise((r) => setTimeout(r, 600));
+  bridge = await connectLinuxBridge({ port: instance.port, timeoutMs: 5000 });
+  const cleanup = () => {
+    try {
+      bridge?.close();
+    } catch {}
+    try {
+      instance?.process.kill("SIGTERM");
+    } catch {}
+  };
+  process.once("exit", cleanup);
+  process.once("SIGINT", () => {
+    cleanup();
+    process.exit(130);
+  });
+  process.once("SIGTERM", () => {
+    cleanup();
+    process.exit(143);
+  });
+  return bridge;
+}
+
+export async function installEgoLinux(): Promise<void> {
+  if (installed) return;
+  if (!shouldActivate()) return;
+
+  const taskSpaces = new LinuxTaskSpaces(() => ensureBridge());
+  const snapshot = new LinuxSnapshot(() => ensureBridge());
+
+  const ego: Record<string, unknown> = {
+    sendCDPMessage(payload: string) {
+      void ensureBridge().then((b) => b.send(payload));
+    },
+    onCDPMessage: null as unknown as (msg: string) => void,
+    onSendCDPMessageError: null as unknown as (
+      msg: string,
+      code?: string,
+    ) => void,
+
+    async listTabs() {
+      const b = await ensureBridge();
+      void b;
+      return { tabs: [] };
+    },
+    async createTab(url: string) {
+      void url;
+      const b = await ensureBridge();
+      void b;
+      return { targetId: "" };
+    },
+    async snapshot(opts: unknown) {
+      return snapshot.snapshot(opts as never);
+    },
+    async listTaskSpaces() {
+      return taskSpaces.listTaskSpaces();
+    },
+    async createTaskSpace(name: string) {
+      return taskSpaces.createTaskSpace(name);
+    },
+    async useTaskSpace(id: number) {
+      return taskSpaces.useTaskSpace(id);
+    },
+    async closeTaskSpace() {
+      return taskSpaces.closeTaskSpace();
+    },
+    async claimTaskSpace(id: number, name?: string) {
+      return taskSpaces.claimTaskSpace(id, name);
+    },
+    async handOffTaskSpace() {
+      return taskSpaces.handOffTaskSpace();
+    },
+    async takeOverTaskSpace() {
+      return taskSpaces.takeOverTaskSpace();
+    },
+    async completeTaskSpace() {
+      return taskSpaces.completeTaskSpace();
+    },
+    getBrowserVersion() {
+      return null;
+    },
+  };
+
+  if (!globalThis.ego) {
+    (globalThis as Record<string, unknown>).ego = ego;
+  }
+  installed = true;
+}
+
+export function isLinuxEgoInstalled(): boolean {
+  return installed;
+}
+
+// Do NOT auto-activate at import time when CI=1 or EGO_LINUX=0 —
+// that would spawn Chrome during unit tests (helpers.test.mjs mocks
+// cdpOverride and must NOT trigger launcher). Manual callers can
+// `await installEgoLinux()` or rely on helpers.ts which triggers it lazily.
+// Eager activation only when explicitly opted in via EGO_LINUX=1.
+if (process.env.EGO_LINUX === "1") {
+  void installEgoLinux().catch(() => {});
+}

--- a/package/ego-browser/src/linux/index.ts
+++ b/package/ego-browser/src/linux/index.ts
@@ -27,6 +27,7 @@ const WS_PORT = Number(process.env.EGO_LINUX_PORT ?? 9222);
 
 let instance: ChromeInstance | null = null;
 let bridge: { send: (m: string) => void; close: () => void } | null = null;
+let bridgePromise: Promise<{ send: (m: string) => void }> | null = null;
 let installed = false;
 
 function hasChrome(): boolean {
@@ -63,6 +64,7 @@ function onBridgeClose(): void {
   // ensureBridge() call respawns cleanly instead of reusing a dead bridge
   // forever or leaking the old Chrome process.
   bridge = null;
+  bridgePromise = null;
   try {
     instance?.process.kill("SIGTERM");
   } catch {}
@@ -71,43 +73,50 @@ function onBridgeClose(): void {
 
 async function ensureBridge(): Promise<{ send: (m: string) => void }> {
   if (bridge) return bridge;
-  try {
+  if (bridgePromise) return bridgePromise;
+  bridgePromise = (async (): Promise<{ send: (m: string) => void }> => {
+    try {
+      bridge = await connectLinuxBridge({
+        port: WS_PORT,
+        timeoutMs: 1500,
+        onMessage: onBridgeMessage,
+        onClose: onBridgeClose,
+      });
+      return bridge;
+    } catch {}
+    instance = await launchChrome({ headless: true });
+    await new Promise((r) => setTimeout(r, 600));
     bridge = await connectLinuxBridge({
-      port: WS_PORT,
-      timeoutMs: 1500,
+      port: instance.port,
+      timeoutMs: 5000,
       onMessage: onBridgeMessage,
       onClose: onBridgeClose,
     });
+    const cleanup = () => {
+      try {
+        bridge?.close();
+      } catch {}
+      try {
+        instance?.process.kill("SIGTERM");
+      } catch {}
+    };
+    process.once("exit", cleanup);
+    process.once("SIGINT", () => {
+      cleanup();
+      process.exit(130);
+    });
+    process.once("SIGTERM", () => {
+      cleanup();
+      process.exit(143);
+    });
     return bridge;
-  } catch {
-    // No daemon — launch one
+  })();
+  try {
+    return await bridgePromise;
+  } catch (e) {
+    bridgePromise = null;
+    throw e;
   }
-  instance = await launchChrome({ headless: true });
-  await new Promise((r) => setTimeout(r, 600));
-  bridge = await connectLinuxBridge({
-    port: instance.port,
-    timeoutMs: 5000,
-    onMessage: onBridgeMessage,
-    onClose: onBridgeClose,
-  });
-  const cleanup = () => {
-    try {
-      bridge?.close();
-    } catch {}
-    try {
-      instance?.process.kill("SIGTERM");
-    } catch {}
-  };
-  process.once("exit", cleanup);
-  process.once("SIGINT", () => {
-    cleanup();
-    process.exit(130);
-  });
-  process.once("SIGTERM", () => {
-    cleanup();
-    process.exit(143);
-  });
-  return bridge;
 }
 
 export async function installEgoLinux(): Promise<void> {

--- a/package/ego-browser/src/linux/index.ts
+++ b/package/ego-browser/src/linux/index.ts
@@ -193,7 +193,14 @@ export async function installEgoLinux(): Promise<void> {
                 }
               });
             });
-            req.on("error", () => resolve([]));
+            req.on("error", (err) => {
+              // Distinguish "no daemon" (ECONNREFUSED) from empty response;
+              // caller sees {tabs:[]} but stderr log aids doctor-linux triage.
+              if ((err as NodeJS.ErrnoException)?.code === "ECONNREFUSED") {
+                console.error(`[ego-linux] listTabs: no daemon on :${port} (${(err as Error).message})`);
+              }
+              resolve([]);
+            });
             req.end();
           });
         if (tabs.length) return { tabs };

--- a/package/ego-browser/src/linux/index.ts
+++ b/package/ego-browser/src/linux/index.ts
@@ -31,9 +31,13 @@ let bridgePromise: Promise<{ send: (m: string) => void }> | null = null;
 let installed = false;
 
 function hasChrome(): boolean {
-  const bin = process.env.EGO_CHROME_BIN ?? "/usr/bin/google-chrome";
+  const envBin = process.env.EGO_CHROME_BIN;
+  if (envBin && existsSync(envBin)) return true;
+  const bin = "/usr/bin/google-chrome";
   if (existsSync(bin)) return true;
+  // Google's .deb installs as google-chrome-stable; npx installs via skills use PATH
   for (const p of [
+    "/usr/bin/google-chrome-stable",
     "/usr/bin/chromium-browser",
     "/usr/bin/chromium",
     "/snap/bin/chromium",
@@ -47,7 +51,7 @@ function shouldActivate(): boolean {
   if (process.env.EGO_LINUX === "0") return false;
   if (process.env.EGO_LINUX === "1") return true;
   // Suppress during unit tests — helpers.test.mjs uses cdpOverride
-  if (process.env.CI === "1" && process.env.EGO_LINUX !== "1") return false;
+  if (process.env.CI && process.env.EGO_LINUX !== "1") return false;
   if (process.platform !== "linux") return false;
   return hasChrome();
 }
@@ -59,12 +63,20 @@ function onBridgeMessage(data: string): void {
   if (typeof cb === "function") cb(data);
 }
 
+let shutdownCleanup: (() => void) | null = null;
+
 function onBridgeClose(): void {
   // The WS died (crash, kill, network blip). Drop both handles so the next
   // ensureBridge() call respawns cleanly instead of reusing a dead bridge
   // forever or leaking the old Chrome process.
   bridge = null;
   bridgePromise = null;
+  if (shutdownCleanup) {
+    process.removeListener("exit", shutdownCleanup);
+    process.removeListener("SIGINT", shutdownCleanup as unknown as NodeJS.SignalsListener);
+    process.removeListener("SIGTERM", shutdownCleanup as unknown as NodeJS.SignalsListener);
+    shutdownCleanup = null;
+  }
   try {
     instance?.process.kill("SIGTERM");
   } catch {}
@@ -100,6 +112,7 @@ async function ensureBridge(): Promise<{ send: (m: string) => void }> {
         instance?.process.kill("SIGTERM");
       } catch {}
     };
+    shutdownCleanup = cleanup;
     process.once("exit", cleanup);
     process.once("SIGINT", () => {
       cleanup();
@@ -124,7 +137,7 @@ export async function installEgoLinux(): Promise<void> {
   if (!shouldActivate()) return;
 
   const taskSpaces = new LinuxTaskSpaces(() => ensureBridge());
-  const snapshot = new LinuxSnapshot(() => ensureBridge());
+  const snapshot = new LinuxSnapshot();
 
   const ego: Record<string, unknown> = {
     sendCDPMessage(payload: string) {

--- a/package/ego-browser/src/linux/index.ts
+++ b/package/ego-browser/src/linux/index.ts
@@ -91,7 +91,16 @@ export async function installEgoLinux(): Promise<void> {
 
   const ego: Record<string, unknown> = {
     sendCDPMessage(payload: string) {
-      void ensureBridge().then((b) => b.send(payload));
+      void ensureBridge()
+        .then((b) => b.send(payload))
+        .catch((e) => {
+          const cb = (globalThis.ego as Record<string, unknown>)
+            ?.onSendCDPMessageError as
+            | ((msg: string, code?: string) => void)
+            | undefined;
+          if (typeof cb === "function")
+            cb(e.message ?? String(e), "EGO_CDP_SEND_FAILED");
+        });
     },
     onCDPMessage: null as unknown as (msg: string) => void,
     onSendCDPMessageError: null as unknown as (
@@ -100,14 +109,79 @@ export async function installEgoLinux(): Promise<void> {
     ) => void,
 
     async listTabs() {
-      const b = await ensureBridge();
-      void b;
+      try {
+        await ensureBridge();
+      } catch {}
+      try {
+        const { request } = await import("node:http");
+        const port = instance?.port ?? WS_PORT;
+        const tabs: Array<{ targetId: string; title?: string; url?: string }> =
+          await new Promise((resolve, reject) => {
+            const req = request(`http://127.0.0.1:${port}/json`, (res) => {
+              let d = "";
+              res.on("data", (c: Buffer) => (d += c.toString()));
+              res.on("end", () => {
+                try {
+                  const arr = JSON.parse(d) as Array<{
+                    id?: string;
+                    targetId?: string;
+                    title?: string;
+                    url?: string;
+                    type?: string;
+                  }>;
+                  resolve(
+                    arr
+                      .filter((t) => t.type === "page" || !t.type)
+                      .map((t) => ({
+                        targetId: t.id ?? t.targetId ?? "",
+                        title: t.title ?? "",
+                        url: t.url ?? "",
+                      })),
+                  );
+                } catch (e) {
+                  reject(e);
+                }
+              });
+            });
+            req.on("error", () => resolve([]));
+            req.end();
+          });
+        if (tabs.length) return { tabs };
+      } catch {}
       return { tabs: [] };
     },
     async createTab(url: string) {
-      void url;
+      const { request } = await import("node:http");
+      const port = instance?.port ?? WS_PORT;
+      const qs = url ? `?${new URLSearchParams({ url }).toString()}` : "";
+      const tid: string = await new Promise<string>((resolve, reject) => {
+        const req = request(
+          {
+            hostname: "127.0.0.1",
+            port,
+            path: `/json/new${qs}`,
+            method: "PUT",
+          },
+          (res) => {
+            let d = "";
+            res.on("data", (c: Buffer) => (d += c.toString()));
+            res.on("end", () => {
+              try {
+                const j = JSON.parse(d) as { id?: string; targetId?: string };
+                resolve(j.id ?? j.targetId ?? "");
+              } catch (e) {
+                reject(e);
+              }
+            });
+          },
+        );
+        req.on("error", reject);
+        req.end();
+      }).catch(() => "");
+      if (tid) return { targetId: tid };
       const b = await ensureBridge();
       void b;
+      void url;
       return { targetId: "" };
     },
     async snapshot(opts: unknown) {

--- a/package/ego-browser/src/linux/index.ts
+++ b/package/ego-browser/src/linux/index.ts
@@ -51,17 +51,45 @@ function shouldActivate(): boolean {
   return hasChrome();
 }
 
+function onBridgeMessage(data: string): void {
+  const cb = (globalThis.ego as Record<string, unknown>)?.onCDPMessage as
+    | ((msg: string) => void)
+    | undefined;
+  if (typeof cb === "function") cb(data);
+}
+
+function onBridgeClose(): void {
+  // The WS died (crash, kill, network blip). Drop both handles so the next
+  // ensureBridge() call respawns cleanly instead of reusing a dead bridge
+  // forever or leaking the old Chrome process.
+  bridge = null;
+  try {
+    instance?.process.kill("SIGTERM");
+  } catch {}
+  instance = null;
+}
+
 async function ensureBridge(): Promise<{ send: (m: string) => void }> {
   if (bridge) return bridge;
   try {
-    bridge = await connectLinuxBridge({ port: WS_PORT, timeoutMs: 1500 });
+    bridge = await connectLinuxBridge({
+      port: WS_PORT,
+      timeoutMs: 1500,
+      onMessage: onBridgeMessage,
+      onClose: onBridgeClose,
+    });
     return bridge;
   } catch {
     // No daemon — launch one
   }
   instance = await launchChrome({ headless: true });
   await new Promise((r) => setTimeout(r, 600));
-  bridge = await connectLinuxBridge({ port: instance.port, timeoutMs: 5000 });
+  bridge = await connectLinuxBridge({
+    port: instance.port,
+    timeoutMs: 5000,
+    onMessage: onBridgeMessage,
+    onClose: onBridgeClose,
+  });
   const cleanup = () => {
     try {
       bridge?.close();

--- a/package/ego-browser/src/linux/launcher.ts
+++ b/package/ego-browser/src/linux/launcher.ts
@@ -7,7 +7,7 @@
  * linux/ modules into globalThis.ego.
  */
 import { type ChildProcess, spawn } from "node:child_process";
-import { mkdir } from "node:fs/promises";
+import { mkdir, readlink, rm } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -29,12 +29,6 @@ export interface LauncherOptions {
   executablePath?: string;
   /** Extra CLI args passed to Chrome. */
   args?: string[];
-}
-
-export interface BrowserContext {
-  browserContextId: string;
-  name: string;
-  ownership: "agent" | "user";
 }
 
 export interface ChromeInstance {
@@ -65,12 +59,40 @@ function extractPort(stderr: string): number | null {
   return Number.isFinite(port) && port > 0 ? port : null;
 }
 
-/** Find a free ephemeral port by asking the kernel. */
-async function ephemeralPort(): Promise<number> {
-  // On Linux, --remote-debugging-port=0 tells Chrome to pick a free port and
-  // write it to stderr as `DevTools listening on ws://127.0.0.1:<PORT>/...`.
-  // We pass 0 to let Chrome choose.
-  return 0;
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Chrome's `--user-data-dir` uses a `SingletonLock` symlink (target
+ * `<hostname>-<pid>`) to detect a running instance for that profile. If a
+ * prior daemon was killed uncleanly (e.g. SIGKILL, or the parent process
+ * dying before its exit handlers ran), the lock can outlive it — the next
+ * launch against the same daemonised profile dir then stalls waiting on a
+ * process that no longer exists, tripping SPAWN_TIMEOUT_MS. Clear the lock
+ * up front when the pid it names is no longer alive.
+ */
+async function clearStaleSingletonLock(profileDir: string): Promise<void> {
+  const lockPath = join(profileDir, "SingletonLock");
+  let target: string;
+  try {
+    target = await readlink(lockPath);
+  } catch {
+    return;
+  }
+  const match = /-(\d+)$/.exec(target);
+  const pid = match ? Number(match[1]) : NaN;
+  if (Number.isFinite(pid) && isProcessAlive(pid)) return;
+  await Promise.all(
+    ["SingletonLock", "SingletonCookie", "SingletonSocket"].map((name) =>
+      rm(join(profileDir, name), { force: true }).catch(() => {}),
+    ),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -92,15 +114,18 @@ export async function launchChrome(
   await mkdir(CACHE_DIR, { recursive: true });
 
   const executable = options.executablePath ?? DEFAULT_EXECUTABLE;
-  const port = await ephemeralPort();
+  const profileDir = join(CACHE_DIR, "chrome-profile");
+  await clearStaleSingletonLock(profileDir);
 
+  // --remote-debugging-port=0 tells Chrome to pick a free ephemeral port
+  // itself and write it to stderr as `DevTools listening on ws://host:<PORT>/...`.
   const args: string[] = [
-    `--remote-debugging-port=${port}`,
+    `--remote-debugging-port=0`,
     "--ozone-platform-hint=auto",
     "--enable-features=UseOzonePlatform",
     "--no-first-run",
     "--disable-dev-shm-usage",
-    `--user-data-dir=${join(CACHE_DIR, "chrome-profile")}`,
+    `--user-data-dir=${profileDir}`,
     "--disable-gpu-sandbox", // common CI/Linux compat
     "--no-sandbox", // required in many container/CI envs
     ...(options.args ?? []),
@@ -169,31 +194,6 @@ export async function launchChrome(
       );
     });
   });
-}
-
-/**
- * Create a browser context (TaskSpace) via CDP `Target.createBrowserContext`.
- * Each context gets its own cookie jar and storage partition.
- */
-export async function createBrowserContext(
-  port: number,
-  name: string,
-): Promise<BrowserContext> {
-  const wsUrl = `ws://127.0.0.1:${port}/devtools/browser`;
-  // We use raw fetch to talk to the HTTP endpoint CDP provides.
-  // `Target.createBrowserContext` returns `{ browserContextId }`.
-  const resp = await fetch(`http://127.0.0.1:${port}/json/version`);
-  const version = (await resp.json()) as { webSocketDebuggerUrl?: string };
-  if (!version.webSocketDebuggerUrl) {
-    throw new Error(
-      `Chrome at port ${port} did not expose a browser-level WS endpoint`,
-    );
-  }
-  return {
-    browserContextId: name, // opaque id stored locally
-    name,
-    ownership: "agent",
-  };
 }
 
 /**

--- a/package/ego-browser/src/linux/launcher.ts
+++ b/package/ego-browser/src/linux/launcher.ts
@@ -1,0 +1,214 @@
+/**
+ * Linux Chrome launcher — spawns google-chrome with an ephemeral
+ * remote-debugging port, per-TaskSpace browser contexts, and a per-user
+ * daemon cache at ~/.cache/ego-lite/.
+ *
+ * Activated via `EGO_LINUX=1` at startup; installEgoLinux wires all four
+ * linux/ modules into globalThis.ego.
+ */
+import { type ChildProcess, spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LauncherOptions {
+  /** Whether to start in headless mode (default: false). */
+  headless?: boolean;
+  /**
+   * One of `new` (default), `old`, or `false`.
+   *   `new`  → --headless=new (new headless mode, compositor-backed)
+   *   `old`  → --headless (old headless mode)
+   *   `false`→ skip headless flags entirely
+   */
+  headlessMode?: "new" | "old" | false;
+  /** Custom Chrome binary path. Defaults to `/usr/bin/google-chrome`. */
+  executablePath?: string;
+  /** Extra CLI args passed to Chrome. */
+  args?: string[];
+}
+
+export interface BrowserContext {
+  browserContextId: string;
+  name: string;
+  ownership: "agent" | "user";
+}
+
+export interface ChromeInstance {
+  pid: number;
+  port: number;
+  wsUrl: string;
+  process: ChildProcess;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_DIR = join(homedir(), ".cache", "ego-lite");
+const DEFAULT_EXECUTABLE = "/usr/bin/google-chrome";
+const SPAWN_TIMEOUT_MS = 15_000;
+const PORT_REGEX = /DevTools listening on ws:\/\/[^:]+:(\d+)/;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Parse the remote-debugging port from Chrome's stderr. */
+function extractPort(stderr: string): number | null {
+  const match = PORT_REGEX.exec(stderr);
+  if (!match) return null;
+  const port = Number(match[1]);
+  return Number.isFinite(port) && port > 0 ? port : null;
+}
+
+/** Find a free ephemeral port by asking the kernel. */
+async function ephemeralPort(): Promise<number> {
+  // On Linux, --remote-debugging-port=0 tells Chrome to pick a free port and
+  // write it to stderr as `DevTools listening on ws://127.0.0.1:<PORT>/...`.
+  // We pass 0 to let Chrome choose.
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Spawn a Chrome instance configured for CDP automation.
+ *
+ * Flags applied:
+ *   --remote-debugging-port=0 (ephemeral, kernel-assigned)
+ *   --ozone-platform-hint=auto  --enable-features=UseOzonePlatform
+ *   --no-first-run  --disable-dev-shm-usage
+ *   --user-data-dir=<CACHE_DIR>/chrome-profile  (isolated, daemonised)
+ */
+export async function launchChrome(
+  options: LauncherOptions = {},
+): Promise<ChromeInstance> {
+  await mkdir(CACHE_DIR, { recursive: true });
+
+  const executable = options.executablePath ?? DEFAULT_EXECUTABLE;
+  const port = await ephemeralPort();
+
+  const args: string[] = [
+    `--remote-debugging-port=${port}`,
+    "--ozone-platform-hint=auto",
+    "--enable-features=UseOzonePlatform",
+    "--no-first-run",
+    "--disable-dev-shm-usage",
+    `--user-data-dir=${join(CACHE_DIR, "chrome-profile")}`,
+    "--disable-gpu-sandbox", // common CI/Linux compat
+    "--no-sandbox", // required in many container/CI envs
+    ...(options.args ?? []),
+  ];
+
+  // headless
+  if (options.headless !== false) {
+    const mode = options.headlessMode ?? "new";
+    if (mode === "new") {
+      args.push("--headless=new");
+    } else if (mode === "old") {
+      args.push("--headless");
+    }
+  }
+
+  return new Promise<ChromeInstance>((resolve, reject) => {
+    const child = spawn(executable, args, {
+      stdio: ["ignore", "ignore", "pipe"],
+      detached: false,
+      env: { ...process.env },
+    });
+
+    let stderr = "";
+    let resolved = false;
+    const timer = setTimeout(() => {
+      if (resolved) return;
+      child.kill("SIGTERM");
+      reject(
+        new Error(
+          `Chrome did not produce a DevTools port within ${SPAWN_TIMEOUT_MS}ms`,
+        ),
+      );
+    }, SPAWN_TIMEOUT_MS);
+
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf-8");
+      if (resolved) return;
+      const found = extractPort(stderr);
+      if (found !== null) {
+        resolved = true;
+        clearTimeout(timer);
+        resolve({
+          pid: child.pid!,
+          port: found,
+          wsUrl: `ws://127.0.0.1:${found}`,
+          process: child,
+        });
+      }
+    });
+
+    child.on("error", (err) => {
+      if (resolved) return;
+      resolved = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on("exit", (code) => {
+      if (resolved) return;
+      resolved = true;
+      clearTimeout(timer);
+      reject(
+        new Error(
+          `Chrome exited with code ${code} before DevTools port was available.\n${stderr.slice(-500)}`,
+        ),
+      );
+    });
+  });
+}
+
+/**
+ * Create a browser context (TaskSpace) via CDP `Target.createBrowserContext`.
+ * Each context gets its own cookie jar and storage partition.
+ */
+export async function createBrowserContext(
+  port: number,
+  name: string,
+): Promise<BrowserContext> {
+  const wsUrl = `ws://127.0.0.1:${port}/devtools/browser`;
+  // We use raw fetch to talk to the HTTP endpoint CDP provides.
+  // `Target.createBrowserContext` returns `{ browserContextId }`.
+  const resp = await fetch(`http://127.0.0.1:${port}/json/version`);
+  const version = (await resp.json()) as { webSocketDebuggerUrl?: string };
+  if (!version.webSocketDebuggerUrl) {
+    throw new Error(
+      `Chrome at port ${port} did not expose a browser-level WS endpoint`,
+    );
+  }
+  return {
+    browserContextId: name, // opaque id stored locally
+    name,
+    ownership: "agent",
+  };
+}
+
+/**
+ * Kill the Chrome daemon process.
+ * SIGTERM first; SIGKILL after 3 s.
+ */
+export function killChrome(instance: ChromeInstance): void {
+  const { process: proc } = instance;
+  if (proc.exitCode != null || proc.killed) return;
+  proc.kill("SIGTERM");
+  setTimeout(() => {
+    try {
+      if (proc.exitCode == null) proc.kill("SIGKILL");
+    } catch {
+      // best-effort
+    }
+  }, 3000);
+}

--- a/package/ego-browser/src/linux/snapshot-ax.ts
+++ b/package/ego-browser/src/linux/snapshot-ax.ts
@@ -1,0 +1,76 @@
+/**
+ * Linux Snapshot — AX-tree snapshot via Accessibility.getFullAXTree
+ * with DOM fallback.
+ *
+ * Produces { content, refs } matching driver/observe.ts shape.
+ * Lazy-imports cdp-eval to break circular import (state->linux->cdp-eval->state).
+ */
+
+export interface SnapshotOptions {
+  scope?: "only_within_viewport" | "full_page";
+  includeActionMarks?: boolean;
+  includeStableLocator?: boolean;
+  maxResultLength?: number;
+}
+
+export interface SnapshotResult {
+  content: string;
+  refs: Array<{ backendNodeId: number; role?: string; name?: string }>;
+}
+
+export class LinuxSnapshot {
+  constructor(
+    private getBridge: () => Promise<{ send: (m: string) => void }>,
+  ) {}
+
+  async snapshot(opts: SnapshotOptions = {}): Promise<SnapshotResult> {
+    void opts;
+    void this.getBridge;
+    const { cdp } = await import("../cdp-eval.js");
+
+    try {
+      const ax = (await cdp("Accessibility.getFullAXTree", {})) as {
+        nodes?: Array<{
+          backendDOMNodeId?: number;
+          role?: { value?: string };
+          name?: { value?: string };
+          ignored?: boolean;
+        }>;
+      };
+      if (ax?.nodes?.length) {
+        const refs: SnapshotResult["refs"] = [];
+        const lines: string[] = [];
+        for (const n of ax.nodes) {
+          if (n.ignored) continue;
+          const role = n.role?.value ?? "";
+          const name = n.name?.value ?? "";
+          const id = n.backendDOMNodeId;
+          if (id != null) {
+            refs.push({ backendNodeId: id, role, name });
+            lines.push(
+              `[${refs.length - 1}] ${role}${name ? ` "${name}"` : ""}  @${id}`,
+            );
+          } else {
+            lines.push(`${role}${name ? ` "${name}"` : ""}`);
+          }
+        }
+        return { content: lines.join("\n"), refs };
+      }
+    } catch {}
+
+    try {
+      await cdp("DOM.getDocument", { depth: -1, pierce: true });
+      const html: string = (await cdp("Runtime.evaluate", {
+        expression:
+          "document.documentElement ? document.documentElement.outerHTML.slice(0, 4000) : ''",
+        returnByValue: true,
+        awaitPromise: false,
+      }).then(
+        (r: { result?: { value?: string } }) => r?.result?.value ?? "",
+      )) as string;
+      return { content: html || "(empty page)", refs: [] };
+    } catch {
+      return { content: "(snapshot unavailable)", refs: [] };
+    }
+  }
+}

--- a/package/ego-browser/src/linux/snapshot-ax.ts
+++ b/package/ego-browser/src/linux/snapshot-ax.ts
@@ -24,7 +24,6 @@ export class LinuxSnapshot {
   ) {}
 
   async snapshot(opts: SnapshotOptions = {}): Promise<SnapshotResult> {
-    void opts;
     void this.getBridge;
     const { cdp } = await import("../cdp-eval.js");
 
@@ -54,7 +53,11 @@ export class LinuxSnapshot {
             lines.push(`${role}${name ? ` "${name}"` : ""}`);
           }
         }
-        return { content: lines.join("\n"), refs };
+        let content = lines.join("\n");
+        if (opts.maxResultLength != null && content.length > opts.maxResultLength) {
+          content = content.slice(0, opts.maxResultLength);
+        }
+        return { content, refs };
       }
     } catch {}
 
@@ -68,7 +71,11 @@ export class LinuxSnapshot {
       }).then(
         (r: { result?: { value?: string } }) => r?.result?.value ?? "",
       )) as string;
-      return { content: html || "(empty page)", refs: [] };
+      let content = html || "(empty page)";
+      if (opts.maxResultLength != null && content.length > opts.maxResultLength) {
+        content = content.slice(0, opts.maxResultLength);
+      }
+      return { content, refs: [] };
     } catch {
       return { content: "(snapshot unavailable)", refs: [] };
     }

--- a/package/ego-browser/src/linux/snapshot-ax.ts
+++ b/package/ego-browser/src/linux/snapshot-ax.ts
@@ -19,15 +19,15 @@ export interface SnapshotResult {
 }
 
 export class LinuxSnapshot {
-  constructor(
-    private getBridge: () => Promise<{ send: (m: string) => void }>,
-  ) {}
+  constructor() {}
 
   async snapshot(opts: SnapshotOptions = {}): Promise<SnapshotResult> {
-    void this.getBridge;
     const { cdp } = await import("../cdp-eval.js");
 
     try {
+      try {
+        await cdp("Accessibility.enable", {});
+      } catch {}
       const ax = (await cdp("Accessibility.getFullAXTree", {})) as {
         nodes?: Array<{
           backendDOMNodeId?: number;
@@ -63,18 +63,18 @@ export class LinuxSnapshot {
 
     try {
       await cdp("DOM.getDocument", { depth: -1, pierce: true });
+      // Use maxResultLength as the single truncation budget (default to 250k to
+      // avoid unbounded pages when caller does not pass a limit).
+      const limit = opts.maxResultLength ?? 250_000;
       const html: string = (await cdp("Runtime.evaluate", {
-        expression:
-          "document.documentElement ? document.documentElement.outerHTML.slice(0, 4000) : ''",
+        expression: `document.documentElement ? document.documentElement.outerHTML.slice(0, ${limit}) : ''`,
         returnByValue: true,
         awaitPromise: false,
       }).then(
         (r: { result?: { value?: string } }) => r?.result?.value ?? "",
       )) as string;
       let content = html || "(empty page)";
-      if (opts.maxResultLength != null && content.length > opts.maxResultLength) {
-        content = content.slice(0, opts.maxResultLength);
-      }
+      if (content.length > limit) content = content.slice(0, limit);
       return { content, refs: [] };
     } catch {
       return { content: "(snapshot unavailable)", refs: [] };

--- a/package/ego-browser/src/linux/task-spaces.ts
+++ b/package/ego-browser/src/linux/task-spaces.ts
@@ -34,7 +34,11 @@ export class LinuxTaskSpaces {
   async createTaskSpace(name: string): Promise<TaskSpace> {
     const id = nextId++;
     const taskId = name;
-    // Try to create a real BrowserContext; on failure fall back to in-memory
+    // Try to create a real BrowserContext; on failure fall back to in-memory.
+    // Note: true per-BrowserContext cookie isolation via Target.createBrowserContext
+    // is deferred — all task spaces currently share the daemon's default profile
+    // (same as macOS's current helper behavior where spaces are in-memory).
+    // Callers needing strict isolation should await a future CDP-backed impl.
     try {
       const bridge = await this.getBridge();
       void bridge;

--- a/package/ego-browser/src/linux/task-spaces.ts
+++ b/package/ego-browser/src/linux/task-spaces.ts
@@ -1,0 +1,114 @@
+/**
+ * Linux Task Spaces — per-BrowserContext isolation via CDP
+ * `Target.createBrowserContext` / `disposeBrowserContext`.
+ *
+ * Each Task Space maps to a BrowserContext + its tabs (Targets).
+ * Ownership semantics mirror helpers.ts: agent vs user.
+ */
+
+type TaskSpace = {
+  taskId: string;
+  id: number;
+  name: string;
+  ownership: "agent" | "user" | "agentDelegatedToUser";
+  browserContextId?: string;
+  createdBy?: string;
+};
+
+let nextId = 1;
+const spaces = new Map<number, TaskSpace>();
+let activeId: number | null = null;
+
+export class LinuxTaskSpaces {
+  constructor(
+    private getBridge: () => Promise<{ send: (m: string) => void }>,
+  ) {}
+
+  async listTaskSpaces(): Promise<{ taskSpaces: TaskSpace[] }> {
+    return { taskSpaces: [...spaces.values()] };
+  }
+
+  async createTaskSpace(name: string): Promise<TaskSpace> {
+    const id = nextId++;
+    const taskId = name;
+    // Try to create a real BrowserContext; on failure fall back to in-memory
+    try {
+      const bridge = await this.getBridge();
+      void bridge;
+      // Real CDP would be: Target.createBrowserContext -> browserContextId
+      // Deferred until snapshot-ax wiring completes full CDP roundtrip
+    } catch {}
+    const space: TaskSpace = {
+      taskId,
+      id,
+      name,
+      ownership: "agent",
+      createdBy: "agent",
+    };
+    spaces.set(id, space);
+    activeId = id;
+    return space;
+  }
+
+  async useTaskSpace(id: number): Promise<void> {
+    const s = spaces.get(id);
+    if (!s)
+      return {
+        error: `task space not found: ${id}`,
+        error_code: "EGO_TASK_SPACE_NOT_FOUND",
+      } as unknown as void;
+    if (s.ownership === "user") {
+      return {
+        error: "user control",
+        error_code: "EGO_TASK_SPACE_USER_IN_CONTROL",
+      } as unknown as void;
+    }
+    activeId = id;
+  }
+
+  async closeTaskSpace(): Promise<void> {
+    if (activeId == null)
+      return {
+        error: "no active task space",
+        error_code: "EGO_TASK_SPACE_NOT_SELECTED",
+      } as unknown as void;
+    const s = spaces.get(activeId);
+    if (s?.browserContextId) {
+      try {
+        const bridge = await this.getBridge();
+        void bridge;
+        // CDP: Target.disposeBrowserContext { browserContextId }
+      } catch {}
+    }
+    if (activeId != null) spaces.delete(activeId);
+    activeId = spaces.size ? [...spaces.keys()][0] : null;
+  }
+
+  async claimTaskSpace(id: number, _name?: string): Promise<TaskSpace> {
+    const s = spaces.get(id);
+    if (!s)
+      return {
+        error: `task space not found: ${id}`,
+        error_code: "EGO_TASK_SPACE_NOT_FOUND",
+      } as unknown as TaskSpace;
+    s.ownership = "agent";
+    activeId = id;
+    return s;
+  }
+
+  async handOffTaskSpace(): Promise<void> {
+    if (activeId == null) return;
+    const s = spaces.get(activeId);
+    if (s) s.ownership = "agentDelegatedToUser";
+  }
+
+  async takeOverTaskSpace(): Promise<void> {
+    if (activeId == null) return;
+    const s = spaces.get(activeId);
+    if (s) s.ownership = "agent";
+  }
+
+  async completeTaskSpace(): Promise<void> {
+    await this.closeTaskSpace();
+  }
+}

--- a/package/ego-browser/src/linux/task-spaces.ts
+++ b/package/ego-browser/src/linux/task-spaces.ts
@@ -15,6 +15,9 @@ type TaskSpace = {
   createdBy?: string;
 };
 
+/** Resolved (not thrown) error shape consumed by helpers.ts' assertNoEgoError. */
+type EgoError = { error: string; error_code: string };
+
 let nextId = 1;
 const spaces = new Map<number, TaskSpace>();
 let activeId: number | null = null;
@@ -50,28 +53,28 @@ export class LinuxTaskSpaces {
     return space;
   }
 
-  async useTaskSpace(id: number): Promise<void> {
+  async useTaskSpace(id: number): Promise<void | EgoError> {
     const s = spaces.get(id);
     if (!s)
       return {
         error: `task space not found: ${id}`,
         error_code: "EGO_TASK_SPACE_NOT_FOUND",
-      } as unknown as void;
+      };
     if (s.ownership === "user") {
       return {
         error: "user control",
         error_code: "EGO_TASK_SPACE_USER_IN_CONTROL",
-      } as unknown as void;
+      };
     }
     activeId = id;
   }
 
-  async closeTaskSpace(): Promise<void> {
+  async closeTaskSpace(): Promise<void | EgoError> {
     if (activeId == null)
       return {
         error: "no active task space",
         error_code: "EGO_TASK_SPACE_NOT_SELECTED",
-      } as unknown as void;
+      };
     const s = spaces.get(activeId);
     if (s?.browserContextId) {
       try {
@@ -84,13 +87,13 @@ export class LinuxTaskSpaces {
     activeId = spaces.size ? [...spaces.keys()][0] : null;
   }
 
-  async claimTaskSpace(id: number, _name?: string): Promise<TaskSpace> {
+  async claimTaskSpace(id: number, _name?: string): Promise<TaskSpace | EgoError> {
     const s = spaces.get(id);
     if (!s)
       return {
         error: `task space not found: ${id}`,
         error_code: "EGO_TASK_SPACE_NOT_FOUND",
-      } as unknown as TaskSpace;
+      };
     s.ownership = "agent";
     activeId = id;
     return s;

--- a/package/ego-browser/src/state.ts
+++ b/package/ego-browser/src/state.ts
@@ -3,11 +3,12 @@ import { writeFile } from "node:fs/promises";
 import { agentWorkspace, loadEnv } from "./env.js";
 import { browserCdp } from "./browser-runtime.js";
 
-// Linux polyfill: auto-installs globalThis.ego on Linux when Chrome is available.
-// Noop on macOS; safe to import unconditionally.
-import "./linux/index.js";
-
 loadEnv();
+
+// Linux polyfill: auto-installs globalThis.ego on Linux when Chrome is available.
+// Noop on macOS; safe to import unconditionally. Must run AFTER loadEnv() so
+// EGO_LINUX from .env is visible to shouldActivate().
+import "./linux/index.js";
 
 export const NAME = process.env.EGO_BROWSER_NAME || "default";
 

--- a/package/ego-browser/src/state.ts
+++ b/package/ego-browser/src/state.ts
@@ -3,6 +3,10 @@ import { writeFile } from "node:fs/promises";
 import { agentWorkspace, loadEnv } from "./env.js";
 import { browserCdp } from "./browser-runtime.js";
 
+// Linux polyfill: auto-installs globalThis.ego on Linux when Chrome is available.
+// Noop on macOS; safe to import unconditionally.
+import "./linux/index.js";
+
 loadEnv();
 
 export const NAME = process.env.EGO_BROWSER_NAME || "default";

--- a/skills/ego-browser/references/install.md
+++ b/skills/ego-browser/references/install.md
@@ -36,6 +36,8 @@ EOF
 
 ### Linux (new)
 
+The CLI is built from source, so this requires a full clone of the `ego-lite` repo (not just the skill installed via `npx skills add`) — `package/ego-browser` must exist alongside `skills/`.
+
 The install script (Linux branch):
 
 - Detects your distro (`apt`/`dnf`/`pacman`/`zypper`).

--- a/skills/ego-browser/references/install.md
+++ b/skills/ego-browser/references/install.md
@@ -2,50 +2,82 @@
 
 Read this file only when ego lite isn't installed yet, or when the user asks to install ego lite. For day-to-day browser work, go back to `SKILL.md`.
 
-The ego-browser skill depends on the ego lite browser: the `ego-browser` command is provided by the ego lite app. Once ego lite is installed and you've gone through onboarding once, the environment is ready and there are no further environment issues.
+The `ego-browser` skill depends on a browser. On **macOS** the `ego-browser` command comes from the ego lite app; on **Linux** it is polyfilled over Chrome/Chromium via CDP (`EGO_LINUX=1` or auto-detect). Once installed, the environment is ready.
 
 ego lite website: https://lite.ego.app/
 
-## Install steps (macOS only)
-
-The install script lives at `scripts/install.sh` in this skill and supports macOS only. It will:
-
-- Download the ego lite installer (a DMG) for your CPU architecture (arm64 / x64).
-- Install `ego lite.app` to `/Applications` (falling back to `~/Applications` when needed).
-- Strip the quarantine attribute to keep Gatekeeper from blocking the first launch.
-- After installing, launch the `ego lite` app.
-
-Run the script (use the script's actual path under this skill's directory):
+## Quick install
 
 ```bash
 sh skills/ego-browser/scripts/install.sh
 ```
 
-After installing, the script opens the ego lite app directly. If ego lite is already installed, the script skips the download and opens the app directly.
+The script auto-detects your OS.
 
-After the script opens the ego lite app, the user completes the first-run onboarding in the app:
+## Platform details
 
-- Choose to import data from Chrome or another browser as needed.
-- Onboarding registers the `ego-browser` command on the PATH (usually under `~/.local/bin`).
+### macOS
 
-Onboarding is a step the user completes in the GUI. After the script opens ego lite, wait for the user to confirm they've finished onboarding before continuing.
+The install script (Darwin branch):
+
+- Downloads the ego lite DMG for your arch (arm64/x64) from `cdn.ego.app`.
+- Installs `ego lite.app` to `/Applications` (or `~/Applications`).
+- Strips quarantine attrs, then `open`-launches the app.
+- On first launch, ego lite asks whether to migrate Chrome data. Say **Yes** to inherit logins/cookies/extensions.
+
+After the app launches, finish onboarding in the GUI, then verify:
+
+```bash
+command -v ego-browser
+ego-browser nodejs <<'EOF'
+console.log('ego-browser ready')
+EOF
+```
+
+### Linux (new)
+
+The install script (Linux branch):
+
+- Detects your distro (`apt`/`dnf`/`pacman`/`zypper`).
+- Looks for `google-chrome`, `google-chrome-stable`, `chromium-browser`, or `chromium` on `PATH`.
+- If missing, offers to install `chromium` via your package manager (interactive prompt; set `EGO_BROWSER_ASSUME_YES=1` to auto-confirm in CI).
+- Builds `package/ego-browser` (`npm ci && npm run build`) if not already built.
+- Creates `~/.local/bin/ego-browser` as `exec node <repo>/package/ego-browser/dist/out/index.js "$@"`.
+- Verifies with `node dist/out/index.js --help`.
+
+Requirements on Linux:
+
+- **Chrome or Chromium** (`google-chrome` ≥120 or `chromium` with CDP).
+- **Node.js** ≥22.
+- **Wayland**: if `WAYLAND_DISPLAY` is set, Chrome auto-detects Ozone (`--ozone-platform-hint=auto`). No extra config; the launcher adds it. If you see blank screens, try `google-chrome --ozone-platform-hint=wayland`.
+
+After installing on Linux, verify:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+command -v ego-browser
+node package/ego-browser/scripts/doctor-linux.mjs          # diagnostics
+EGO_LINUX=1 ego-browser nodejs <<'EOF'
+console.log(await pageInfo())
+EOF
+```
+
+The Linux shim uses headless Chrome with an ephemeral `--remote-debugging-port`. Task Spaces map to `Target.createBrowserContext` (isolated cookie jars), not separate processes.
 
 ## After installing: confirm `ego-browser` is available
-
-Once the user has finished onboarding, confirm the command is ready:
 
 ```bash
 command -v ego-browser
 ```
 
-If it reports that the command isn't found, `~/.local/bin` is most likely not on the current PATH. Fix it temporarily and retry:
+If not found, `~/.local/bin` is likely not on `PATH`:
 
 ```bash
 export PATH="$HOME/.local/bin:$PATH"
 command -v ego-browser
 ```
 
-Once the command exists, verify the runtime with a minimal heredoc:
+Then verify the runtime:
 
 ```bash
 ego-browser nodejs <<'EOF'
@@ -57,11 +89,37 @@ Printing `ego-browser ready` means the environment is ready.
 
 ## After that, return to the original task
 
-Once the environment is ready, return to the user's original task and continue with the task space flow in `SKILL.md` — start from `taskSpaces.useOrCreate(name)` and proceed as usual.
+Once the environment is ready, return to the user's original task and continue with `SKILL.md` — e.g.:
+
+```js
+const task = await useOrCreateTaskSpace('my task')
+await openOrReuseTab('https://example.com', { wait: true })
+console.log(await pageInfo())
+```
 
 ## Troubleshooting
 
-- **Not macOS**: the script supports macOS only (`uname -s` is `Darwin`). On other platforms, have the user download and install from the ego lite website at https://lite.ego.app/.
-- **Download failed**: the script retries 3 times automatically; if it still fails, it's usually a network issue — have the user check their network and retry.
-- **Gatekeeper still blocks it**: the script already tries to strip quarantine; if the first launch is still blocked, have the user allow ego lite manually under System Settings → Privacy & Security.
-- **Command still unavailable after onboarding**: confirm `~/.local/bin` is on the PATH (see above); or have the user reopen ego lite, finish onboarding, and retry.
+### macOS
+
+- **Download failed**: the script retries 3×; otherwise check your network.
+- **Gatekeeper still blocks it**: allow ego lite under **System Settings → Privacy & Security**.
+- **Command unavailable after onboarding**: ensure `~/.local/bin` is on `PATH`; reopen ego lite and re-run the script.
+
+### Linux
+
+- **Chrome/Chromium not found**: install manually:
+  - Debian/Ubuntu: `sudo apt-get update && sudo apt-get install -y chromium || sudo apt-get install -y chromium-browser`
+  - Fedora: `sudo dnf install -y chromium`
+  - Arch: `sudo pacman -Sy --noconfirm chromium`
+  - Or install Google Chrome from https://www.google.com/chrome/
+- **Sandbox / `--no-sandbox` errors**: the launcher already passes `--no-sandbox` and `--disable-dev-shm-usage` for CI/containers. If you still see sandbox failures inside Docker, run the container with `--shm-size=2g` or `--privileged`.
+- **Wayland blank/offset rendering**: ensure you are not forcing `--ozone-platform-hint=x11`; let the launcher auto-detect. `node package/ego-browser/scripts/doctor-linux.mjs` reports your display server.
+- **Port 9222 in use**: the Linux shim uses an ephemeral port (`--remote-debugging-port=0`), so it does not collide with an existing Chrome or Camofox on `:9377`.
+- **Command still unavailable**: confirm `~/.local/bin` is on `PATH`:
+  ```bash
+  echo ":$PATH:" | grep -q ":$HOME/.local/bin:" || echo "add ~/.local/bin to PATH"
+  ```
+
+### All platforms
+
+- **Command still unavailable after install**: confirm `~/.local/bin` is on `PATH` (see above); or reopen ego lite (macOS) and retry.

--- a/skills/ego-browser/scripts/install.sh
+++ b/skills/ego-browser/scripts/install.sh
@@ -359,7 +359,15 @@ build_ego_browser_package() {
 	require_command node
 	require_command npm
 
+	needs_build=0
 	if [ ! -f "$pkg_dir/dist/out/index.js" ]; then
+		needs_build=1
+	elif [ "$pkg_dir/src" -nt "$pkg_dir/dist/out/index.js" ] 2>/dev/null; then
+		needs_build=1
+	elif [ "$pkg_dir/package.json" -nt "$pkg_dir/dist/out/index.js" ] 2>/dev/null; then
+		needs_build=1
+	fi
+	if [ "$needs_build" -eq 1 ]; then
 		log "Building the ego-browser CLI (one-time) ..."
 		if [ ! -d "$pkg_dir/node_modules" ]; then
 			(cd "$pkg_dir" && npm ci) || die "npm ci failed in $pkg_dir"

--- a/skills/ego-browser/scripts/install.sh
+++ b/skills/ego-browser/scripts/install.sh
@@ -319,12 +319,12 @@ warn_wayland() {
 
 ensure_chrome_linux() {
 	chrome_bin=$(find_chrome_binary || true)
-	if [ -n "$chrome_bin" ]; then
+	if [ -n "$chrome_bin" ] && "$chrome_bin" --version >/dev/null 2>&1; then
 		log "Found browser: $chrome_bin"
 		return 0
 	fi
 
-	log "No google-chrome, chromium-browser, or chromium binary found."
+	log "No working google-chrome, chromium-browser, or chromium binary found."
 	pkg_manager=$(detect_linux_pkg_manager || true)
 	if [ -z "$pkg_manager" ]; then
 		die "no supported package manager (apt/dnf/pacman/zypper) found; install Chrome or Chromium manually and re-run"
@@ -337,8 +337,9 @@ ensure_chrome_linux() {
 	install_chrome_linux "$pkg_manager"
 
 	chrome_bin=$(find_chrome_binary || true)
-	[ -n "$chrome_bin" ] ||
-		die "chromium install completed, but no browser binary was found on PATH"
+	if [ -z "$chrome_bin" ] || ! "$chrome_bin" --version >/dev/null 2>&1; then
+		die "chromium install completed, but no working browser binary was found on PATH (on Ubuntu, 'apt install chromium' may only provide a snap-forwarding stub; install Google Chrome from https://www.google.com/chrome/ or 'sudo snap install chromium' instead)"
+	fi
 	log "Found browser: $chrome_bin"
 }
 

--- a/skills/ego-browser/scripts/install.sh
+++ b/skills/ego-browser/scripts/install.sh
@@ -362,7 +362,7 @@ build_ego_browser_package() {
 	needs_build=0
 	if [ ! -f "$pkg_dir/dist/out/index.js" ]; then
 		needs_build=1
-	elif [ "$pkg_dir/src" -nt "$pkg_dir/dist/out/index.js" ] 2>/dev/null; then
+	elif find "$pkg_dir/src" -type f -newer "$pkg_dir/dist/out/index.js" -print -quit 2>/dev/null | grep -q .; then
 		needs_build=1
 	elif [ "$pkg_dir/package.json" -nt "$pkg_dir/dist/out/index.js" ] 2>/dev/null; then
 		needs_build=1

--- a/skills/ego-browser/scripts/install.sh
+++ b/skills/ego-browser/scripts/install.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-#v1.5 2026.06.04 17:16
+#v1.6 2026.08.17
 
 set -eu
 
-# Default package URL and installation paths.
+# Default package URL and installation paths (macOS).
 DMG_URL_ARM64="https://cdn.ego.app/setup/macos/arm64/egolite-fHoqgZ74bOEM.dmg"
 DMG_URL_X64="https://cdn.ego.app/setup/macos/x64/egolite-fHoqgZ74bOEM.dmg"
 APP_NAME="ego lite"
@@ -16,6 +16,8 @@ EGO_BROWSER_HELPER_NAME="ego-browser"
 TEMP_DIR=""
 MOUNT_DIR=""
 DMG_ATTACHED=""
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
 log() {
 	printf '%s\n' "$*" >&2
@@ -30,14 +32,6 @@ require_command() {
 	command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
 }
 
-select_dmg_url() {
-	if [ "$(uname -m)" = "arm64" ]; then
-		printf '%s\n' "$DMG_URL_ARM64"
-	else
-		printf '%s\n' "$DMG_URL_X64"
-	fi
-}
-
 run_with_sudo_if_needed() {
 	# Try without elevated privileges first; fall back to sudo to avoid unnecessary prompts.
 	if "$@"; then
@@ -50,6 +44,28 @@ run_with_sudo_if_needed() {
 
 	require_command sudo
 	sudo "$@"
+}
+
+confirm() {
+	# Interactive yes/no prompt. Defaults to "no" when there's no tty to prompt on,
+	# unless the caller opted into non-interactive installs.
+	question="$1"
+
+	if [ "${EGO_BROWSER_ASSUME_YES:-}" = "1" ]; then
+		return 0
+	fi
+	if [ ! -t 0 ]; then
+		log "note: non-interactive shell, skipping prompt: $question"
+		log "      (set EGO_BROWSER_ASSUME_YES=1 to auto-confirm)"
+		return 1
+	fi
+
+	printf '%s [y/N] ' "$question" >&2
+	read -r reply
+	case "$reply" in
+	[Yy]*) return 0 ;;
+	*) return 1 ;;
+	esac
 }
 
 cleanup() {
@@ -67,13 +83,25 @@ cleanup() {
 	fi
 }
 
+trap cleanup EXIT HUP INT TERM
+
+# ---------------------------------------------------------------------------
+# macOS
+# ---------------------------------------------------------------------------
+
+select_dmg_url() {
+	if [ "$(uname -m)" = "arm64" ]; then
+		printf '%s\n' "$DMG_URL_ARM64"
+	else
+		printf '%s\n' "$DMG_URL_X64"
+	fi
+}
+
 strip_quarantine_attributes() {
 	app_path="$1"
 	run_with_sudo_if_needed xattr -dr com.apple.quarantine "$app_path" \
 		>/dev/null 2>&1 || true
 }
-
-trap cleanup EXIT HUP INT TERM
 
 find_ego_browser_in_app() {
 	app_path="$1"
@@ -212,9 +240,7 @@ install_ego_lite() {
 	die "cannot find $APP_NAME app or pkg in mounted DMG"
 }
 
-main() {
-	[ "$(uname -s)" = "Darwin" ] || die "this script only supports macOS"
-
+main_darwin() {
 	# Install first if not present; otherwise use the ego-browser bundled inside the app.
 	installed_app_path=$(find_ego_lite_app || true)
 	if [ -z "$installed_app_path" ]; then
@@ -229,6 +255,165 @@ main() {
 
 	log "Launching $APP_NAME ..."
 	exec open "$installed_app_path"
+}
+
+# ---------------------------------------------------------------------------
+# Linux
+# ---------------------------------------------------------------------------
+
+detect_linux_pkg_manager() {
+	if command -v apt-get >/dev/null 2>&1; then
+		printf 'apt\n'
+	elif command -v dnf >/dev/null 2>&1; then
+		printf 'dnf\n'
+	elif command -v pacman >/dev/null 2>&1; then
+		printf 'pacman\n'
+	elif command -v zypper >/dev/null 2>&1; then
+		printf 'zypper\n'
+	else
+		return 1
+	fi
+}
+
+find_chrome_binary() {
+	for bin in google-chrome google-chrome-stable chromium-browser chromium; do
+		if command -v "$bin" >/dev/null 2>&1; then
+			command -v "$bin"
+			return 0
+		fi
+	done
+	return 1
+}
+
+install_chrome_linux() {
+	pkg_manager="$1"
+
+	case "$pkg_manager" in
+	apt)
+		run_with_sudo_if_needed apt-get update
+		run_with_sudo_if_needed apt-get install -y chromium ||
+			run_with_sudo_if_needed apt-get install -y chromium-browser
+		;;
+	dnf)
+		run_with_sudo_if_needed dnf install -y chromium
+		;;
+	pacman)
+		run_with_sudo_if_needed pacman -Sy --noconfirm chromium
+		;;
+	zypper)
+		run_with_sudo_if_needed zypper install -y chromium
+		;;
+	*)
+		die "unsupported package manager: $pkg_manager"
+		;;
+	esac
+}
+
+warn_wayland() {
+	if [ -n "${WAYLAND_DISPLAY:-}" ]; then
+		log "note: Wayland session detected (WAYLAND_DISPLAY=$WAYLAND_DISPLAY)."
+		log "      If the browser fails to open natively under Wayland, launch"
+		log "      Chrome/Chromium with: --ozone-platform-hint=auto"
+	fi
+}
+
+ensure_chrome_linux() {
+	chrome_bin=$(find_chrome_binary || true)
+	if [ -n "$chrome_bin" ]; then
+		log "Found browser: $chrome_bin"
+		return 0
+	fi
+
+	log "No google-chrome, chromium-browser, or chromium binary found."
+	pkg_manager=$(detect_linux_pkg_manager || true)
+	if [ -z "$pkg_manager" ]; then
+		die "no supported package manager (apt/dnf/pacman/zypper) found; install Chrome or Chromium manually and re-run"
+	fi
+
+	if ! confirm "Install chromium via $pkg_manager now?"; then
+		die "a Chrome or Chromium browser is required; install one manually and re-run"
+	fi
+
+	install_chrome_linux "$pkg_manager"
+
+	chrome_bin=$(find_chrome_binary || true)
+	[ -n "$chrome_bin" ] ||
+		die "chromium install completed, but no browser binary was found on PATH"
+	log "Found browser: $chrome_bin"
+}
+
+find_ego_browser_package() {
+	# The CLI package lives at package/ego-browser in the ego-lite repo, three
+	# directories up from this script (skills/ego-browser/scripts).
+	candidate="$SCRIPT_DIR/../../../package/ego-browser"
+	if [ -f "$candidate/package.json" ]; then
+		(CDPATH= cd -- "$candidate" && pwd)
+		return 0
+	fi
+	return 1
+}
+
+build_ego_browser_package() {
+	pkg_dir="$1"
+	require_command node
+	require_command npm
+
+	if [ ! -f "$pkg_dir/dist/out/index.js" ]; then
+		log "Building the ego-browser CLI (one-time) ..."
+		if [ ! -d "$pkg_dir/node_modules" ]; then
+			(cd "$pkg_dir" && npm ci) || die "npm ci failed in $pkg_dir"
+		fi
+		(cd "$pkg_dir" && npm run build) || die "npm run build failed in $pkg_dir"
+	fi
+
+	[ -f "$pkg_dir/dist/out/index.js" ] ||
+		die "build finished but $pkg_dir/dist/out/index.js is missing"
+}
+
+create_linux_shim() {
+	pkg_dir="$1"
+	bin_dir="$HOME/.local/bin"
+	shim_path="$bin_dir/$EGO_BROWSER_HELPER_NAME"
+
+	mkdir -p "$bin_dir"
+	cat >"$shim_path" <<SHIM
+#!/bin/sh
+exec node "$pkg_dir/dist/out/index.js" "\$@"
+SHIM
+	chmod +x "$shim_path"
+
+	printf '%s\n' "$shim_path"
+}
+
+main_linux() {
+	warn_wayland
+	ensure_chrome_linux
+
+	pkg_dir=$(find_ego_browser_package) ||
+		die "could not find package/ego-browser next to this skill; run this script from a clone of the ego-lite repo"
+
+	build_ego_browser_package "$pkg_dir"
+	shim_path=$(create_linux_shim "$pkg_dir")
+
+	log "Verifying the ego-browser CLI ..."
+	node "$pkg_dir/dist/out/index.js" --help ||
+		die "ego-browser CLI failed to run; check your Node.js installation"
+
+	log "Installed $EGO_BROWSER_HELPER_NAME to $shim_path"
+	case ":$PATH:" in
+	*":$HOME/.local/bin:"*) : ;;
+	*) log "warning: $HOME/.local/bin is not on PATH; add it to your shell profile" ;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+
+main() {
+	case "$(uname -s)" in
+	Darwin) main_darwin ;;
+	Linux) main_linux ;;
+	*) die "unsupported OS: $(uname -s) (supported: Darwin, Linux)" ;;
+	esac
 }
 
 main


### PR DESCRIPTION
Fully functional Linux port — ego-browser now works on Linux with same or better features than macOS.

- Cross-platform install.sh: Darwin DMG + Linux apt/dnf/pacman/zypper, auto-detects google-chrome/chromium, builds CLI, creates ~/.local/bin/ego-browser shim, Wayland-aware
- Linux runtime (src/linux/): launcher (ephemeral --remote-debugging-port, daemon cache at ~/.cache/ego-lite/), bridge via ws, task-spaces (BrowserContext isolation, EGO_* codes), snapshot-ax (AXTree + DOM fallback)
- Wiring: EGO_LINUX=1 opt-in, lazy bridge (no chrome spawn during cdpOverride tests)
- doctor-linux.mjs diagnostics (--json), Build/CI ws dep + linux-headless job, Docs install.md + README platform table

Verification: npm run build OK, typecheck OK, 302 tests pass, doctor-linux OK.