### PR TITLE
fix(ego-browser): avoid dangling promise in update-notice stalled-probe test

### DIFF
--- a/package/ego-browser/src/update-notice.test.mjs
+++ b/package/ego-browser/src/update-notice.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
 
 import { emitUpdateNotice } from "../dist/src/update-notice.js";
 
@@ -45,10 +46,11 @@ test("version probing stays silent when unsupported, failed, or stalled", async 
     },
     emit,
   );
-  await emitUpdateNotice(
-    { getBrowserVersion: () => new Promise(() => {}) },
-    emit,
-  );
+  // Simulate a stalled probe that outlasts emitUpdateNotice's own race timeout,
+  // but still settles (ref'd, so it keeps the process alive until it does)
+  // instead of dangling forever — Node's test runner fails the run on
+  // promises still pending when the event loop would otherwise be empty.
+  await emitUpdateNotice({ getBrowserVersion: () => delay(1_000) }, emit);
   assert.deepEqual(lines, []);
 });
 


### PR DESCRIPTION
## Problem
CI on `v2.0.0-beta.1` failed at `npm test` in `src/update-notice.test.mjs`:
```
error: 'Promise resolution is still pending but the event loop has already resolved'
```
3 tests were cancelled (`cancelledByParent`).

## Root cause
The "stalled probe" test case simulated a hung `getBrowserVersion()` call with `new Promise(() => {})`. That promise never settles and registers no timer/IO handle, so once the rest of the test file finishes, Node's `node:test` runner sees the event loop as idle while this promise is still pending — and fails the run.

## Fix
Replace the eternally-pending promise with `delay(1_000)` from `node:timers/promises`. It registers a real (ref'd) timer, keeping the process alive until it settles — while still outlasting `emitUpdateNotice`'s own 500ms internal race timeout, so the behavior under test (silently ignoring a stalled probe) is unchanged.

Verified locally: `npm test` (399/399), `npm run style:check`, `npm run validate:site-skills` all pass.
