### PR TITLE
fix(ego-browser): pin keyboard test platform

### DIFF
--- a/package/ego-browser/src/page-model.test.mjs
+++ b/package/ego-browser/src/page-model.test.mjs
@@ -3296,7 +3296,10 @@ test("Page mouse.wheel scrolls the addressed page", async () => {
 
 test("Page keyboard press and type use the addressed target session", async () => {
   await withFixture(async (fixture) => {
-    const task = taskForRound(fixture, "round-a");
+    // Meta+A's native selectAll editing command is only synthesized on
+    // darwin (see driver/keyboard.ts); pin the platform so this assertion
+    // doesn't depend on the host OS actually running the test.
+    const task = taskForRound(fixture, "round-a", { platform: "darwin" });
     const first = await openTestPage(task, "https://example.test/first");
     await openTestPage(task, "https://example.test/second");
 


### PR DESCRIPTION
## Problem

The Meta+A keyboard test asserts the macOS-specific native selectAll editing command but inherited process.platform from the CI host. It passed locally on macOS and failed consistently on the Ubuntu GitHub Actions runner.

## Fix

Pin the test fixture platform to darwin, matching the behavior under test and the pattern used by neighboring keyboard tests.

Validated with the complete 399-test suite, formatting, vulnerability audit, and site-skill validation.