### PR TITLE
Trust native snapshot frame provenance

### DIFF
--- a/package/ego-browser/src/snapshot-result.test.mjs
+++ b/package/ego-browser/src/snapshot-result.test.mjs
@@ -4,7 +4,6 @@ import assert from "node:assert/strict";
 import {
   compactSnapshotContent,
   compactSnapshotResult,
-  enrichSnapshotRefFrames,
   preparePageSnapshotResult,
   sanitizeSnapshotLocators,
   validateSnapshotLocator,
@@ -378,35 +377,34 @@ test("stable locator validation requires one match for the original backend node
   }
 });
 
-test("snapshot refs inherit their same-process and OOPIF frame ids", async () => {
-  const refs = [
-    { backendNodeId: 10, role: "button", name: "Top" },
-    { backendNodeId: 20, role: "button", name: "Same process" },
-    { backendNodeId: 30, role: "button", name: "OOPIF" },
-  ];
-  const calls = [];
+test("Page snapshots preserve native ref provenance", async () => {
+  const result = {
+    refs: [
+      {
+        refId: 1,
+        backendNodeId: 6,
+        role: "textbox",
+        name: "",
+      },
+      {
+        refId: 17,
+        backendNodeId: 6,
+        role: "textbox",
+        name: "",
+        frameId: "frame-oopif",
+      },
+    ],
+  };
+  const expected = structuredClone(result.refs);
   const services = {
-    async cdp(method, params, sessionId) {
-      calls.push([method, params, sessionId]);
-      assert.equal(method, "Accessibility.getFullAXTree");
-      if (params.frameId === "frame-same") {
-        return {
-          nodes: [
-            {
-              backendDOMNodeId: 20,
-              role: { value: "button" },
-              name: { value: "Same process" },
-            },
-          ],
-        };
-      }
+    async cdp(_method, _params, sessionId) {
       if (sessionId === "session:oopif") {
         return {
           nodes: [
             {
-              backendDOMNodeId: 30,
-              role: { value: "button" },
-              name: { value: "OOPIF" },
+              backendDOMNodeId: 6,
+              role: { value: "textbox" },
+              name: { value: "" },
             },
           ],
         };
@@ -415,69 +413,12 @@ test("snapshot refs inherit their same-process and OOPIF frame ids", async () =>
     },
   };
 
-  await enrichSnapshotRefFrames(
-    services,
-    "session:page",
-    new Map([
-      ["frame-same", "session:page"],
-      ["frame-oopif", "session:oopif"],
-    ]),
-    refs,
-  );
-
-  assert.equal(refs[0].frameId, undefined);
-  assert.equal(refs[1].frameId, "frame-same");
-  assert.equal(refs[2].frameId, "frame-oopif");
-  assert.deepEqual(calls, [
-    ["Accessibility.getFullAXTree", {}, "session:page"],
-    ["Accessibility.getFullAXTree", { frameId: "frame-same" }, "session:page"],
-    ["Accessibility.getFullAXTree", {}, "session:oopif"],
-  ]);
-});
-
-test("snapshot refs stay top-level when a frame repeats their backend node id", async () => {
-  const refs = [
-    { backendNodeId: 21, role: "button", name: "Increment counter" },
-  ];
-  const services = {
-    async cdp(method, params, sessionId) {
-      assert.equal(method, "Accessibility.getFullAXTree");
-      if (sessionId === "session:page" && !params.frameId) {
-        return {
-          nodes: [
-            {
-              backendDOMNodeId: 21,
-              role: { value: "button" },
-              name: { value: "Increment counter" },
-            },
-          ],
-        };
-      }
-      if (sessionId === "session:oopif") {
-        return {
-          nodes: [
-            {
-              backendDOMNodeId: 21,
-              role: { value: "button" },
-              name: { value: "Increment counter" },
-            },
-          ],
-        };
-      }
-      return { nodes: [] };
-    },
-  };
-
-  await enrichSnapshotRefFrames(
+  await preparePageSnapshotResult(
     services,
     "session:page",
     new Map([["frame-oopif", "session:oopif"]]),
-    refs,
+    result,
   );
 
-  assert.equal(
-    refs[0].frameId,
-    undefined,
-    "a renderer-local id collision must not reroute a top-level ref",
-  );
+  assert.deepEqual(result.refs, expected);
 });

--- a/package/ego-browser/src/snapshot-result.ts
+++ b/package/ego-browser/src/snapshot-result.ts
@@ -162,105 +162,6 @@ function renderSnapshotTree(
   return output;
 }
 
-/**
- * Add frame provenance that older native snapshots omit.
- *
- * One AX-tree read per frame is enough to map every unique backend node in the
- * snapshot. Repeated backend ids cannot be disambiguated without native
- * `refId`/`frameId` support, so those refs deliberately remain unscoped.
- */
-export async function enrichSnapshotRefFrames(
-  services: SnapshotServices,
-  pageSessionId: string,
-  iframeSessions: Map<string, string>,
-  refs: SnapshotRef[] = [],
-): Promise<void> {
-  if (!(iframeSessions instanceof Map) || iframeSessions.size === 0) return;
-
-  const refsByBackendNode = new Map<number, SnapshotRef[]>();
-  for (const ref of refs) {
-    if (ref.frameId || !Number.isInteger(ref.backendNodeId)) continue;
-    const matches = refsByBackendNode.get(ref.backendNodeId!) || [];
-    matches.push(ref);
-    refsByBackendNode.set(ref.backendNodeId!, matches);
-  }
-  if (refsByBackendNode.size === 0) return;
-
-  const pageOwner = "";
-  const ownersByRef = new Map(
-    [...refsByBackendNode.values()]
-      .flat()
-      .map((ref) => [ref, new Set<string>()]),
-  );
-  const contexts = [
-    { frameId: pageOwner, sessionId: pageSessionId, params: {} },
-    ...[...iframeSessions].map(([frameId, frameSessionId]) => ({
-      frameId,
-      sessionId: frameSessionId,
-      params: frameSessionId === pageSessionId ? { frameId } : {},
-    })),
-  ];
-
-  for (const context of contexts) {
-    let tree;
-    try {
-      tree = await services.cdp(
-        "Accessibility.getFullAXTree",
-        context.params,
-        context.sessionId,
-      );
-    } catch {
-      // Incomplete ownership data cannot safely disambiguate renderer-local ids.
-      return;
-    }
-    for (const node of tree?.nodes || []) {
-      const backendNodeId = node?.backendDOMNodeId;
-      const matches = refsByBackendNode.get(backendNodeId);
-      if (!matches || node?.ignored) continue;
-      for (const ref of matches) {
-        if (!snapshotRefMatchesAxNode(ref, node)) continue;
-        ownersByRef.get(ref)?.add(context.frameId);
-      }
-    }
-  }
-
-  for (const [ref, owners] of ownersByRef) {
-    if (owners.size !== 1) continue;
-    const [frameId] = owners;
-    if (frameId) ref.frameId = frameId;
-  }
-}
-
-function snapshotRefMatchesAxNode(ref: SnapshotRef, node: any): boolean {
-  if (
-    typeof ref.role === "string" &&
-    normalizeSnapshotRole(axValue(node?.role)) !==
-      normalizeSnapshotRole(ref.role)
-  ) {
-    return false;
-  }
-  return typeof ref.name !== "string" || axValue(node?.name) === ref.name;
-}
-
-function normalizeSnapshotRole(value: unknown): string {
-  const role = String(value || "").toLowerCase();
-  return (
-    {
-      listboxoption: "option",
-      textfield: "textbox",
-    }[role] || role
-  );
-}
-
-function axValue(value: any): string {
-  const raw = value?.value ?? value;
-  return typeof raw === "string" ||
-    typeof raw === "number" ||
-    typeof raw === "boolean"
-    ? String(raw)
-    : "";
-}
-
 /** Return whether one advertised locator resolves uniquely to its source ref. */
 export async function validateSnapshotLocator(
   cdp: CdpAdapter,
@@ -349,19 +250,13 @@ function omitSnapshotLineLocator(
   return text;
 }
 
-/** Add frame provenance and validate stable locators for the Page API. */
+/** Preserve native frame provenance and validate stable locators for the Page API. */
 export async function preparePageSnapshotResult(
   services: SnapshotServices,
   pageSessionId: string,
   iframeSessions: Map<string, string>,
   result: SnapshotResult,
 ): Promise<SnapshotResult> {
-  await enrichSnapshotRefFrames(
-    services,
-    pageSessionId,
-    iframeSessions,
-    result?.refs || [],
-  );
   const adapter: CdpAdapter = {
     sendRaw: (method, params = {}, sessionId) =>
       services.cdp(method, params, sessionId),


### PR DESCRIPTION
## Summary

- preserve the browser-provided refId and frameId mapping
- remove AX-tree-based frame inference that could reroute top-level refs when renderer-local backend node IDs collide
- cover the real browser response shape where top-level and iframe refs have distinct ref IDs but share a backend node ID

## Validation

- node --test --test-concurrency=1 "src/**/*.test.mjs" (412/412 passed)
- node --test src/snapshot-result.test.mjs src/page-ref-registry.test.mjs (10/10 passed)
- Page OOPIF actions real-browser E2E (15/15 assertions passed)
- npm run style:check
- git diff --check

## Note

A full real-browser E2E run was also attempted while a separate Chromium build was running locally. An unrelated page-actions case hit its 45-second timeout and exhausted the shared page budget for downstream cases; the focused OOPIF business scenario passes cleanly.