### PR TITLE
fix(ego-browser): preserve Page refs across actions and rounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,10 @@ jobs:
             release_args+=(--prerelease)
           fi
 
+          if [[ "$release_tag" == v*.*.*-beta.* ]]; then
+            release_args+=(--draft)
+          fi
+
           if [ "$latest" = "true" ]; then
             release_args+=(--latest)
           else

--- a/package/ego-browser/README.md
+++ b/package/ego-browser/README.md
@@ -91,7 +91,7 @@ existing scripts.
 
 - The browser runtime owns tabs, task spaces, CDP transport, snapshots, and event delivery. This package keeps only agent-facing ergonomics.
 - Snapshot helpers use the browser runtime contract: `ego.snapshot({ scope, root, includeActionMarks, includeStableLocator })`; the Page API resolves a subtree `root` from a Page-scoped snapshot ref before invoking it.
-- V2 Page refs are SDK-assigned ids bound to a frame, document, and backend node. Partial snapshots retain omitted refs; full-page snapshots replace the active set. The Page ledger persists mappings and invalidation across Agent rounds. Missing, stale, or unresolvable refs require a fresh snapshot rather than native renumbering or role/name fallback.
+- V2 Page refs are SDK-assigned ids bound to a frame, document, and backend node. Input actions preserve refs to unchanged nodes, allowing consecutive ref actions. Partial snapshots retain omitted refs; full-page snapshots replace the active set. The Page ledger persists mappings and invalidation across Agent rounds. Missing, stale, or unresolvable refs require a fresh snapshot rather than native renumbering or role/name fallback.
 - Page selectors search the top document first. Input actions search frames
   when the top document has no match usable for that action, then require one
   usable frame match.

--- a/package/ego-browser/scripts/real-browser-e2e/cases/index.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/cases/index.mjs
@@ -29,6 +29,13 @@ import {
   pageRefPrepareRoundCase,
   pageRefResumeRoundCase,
 } from "./page-ref-identity.mjs";
+import {
+  pageRefDialogWorkflowCase,
+  pageRefFailedActionPrepareCase,
+  pageRefFailedActionResumeCase,
+  pageRefUploadPrepareCase,
+  pageRefUploadResumeCase,
+} from "./page-ref-workflows.mjs";
 import { pageTextLocatorCase } from "./page-text-locators.mjs";
 import { pageSelectorCompatibilityCase } from "./page-selector-compatibility.mjs";
 import { pagePopupWaiterCase } from "./page-popup-waiter.mjs";
@@ -127,6 +134,17 @@ export const e2eCases = [
   },
   { name: "Page refs across rounds: prepare", body: pageRefPrepareRoundCase },
   { name: "Page refs across rounds: resume", body: pageRefResumeRoundCase },
+  { name: "Page refs in dialog workflows", body: pageRefDialogWorkflowCase },
+  {
+    name: "Page refs after failed actions: prepare",
+    body: pageRefFailedActionPrepareCase,
+  },
+  {
+    name: "Page refs after failed actions: resume",
+    body: pageRefFailedActionResumeCase,
+  },
+  { name: "Page refs after upload: prepare", body: pageRefUploadPrepareCase },
+  { name: "Page refs after upload: resume", body: pageRefUploadResumeCase },
   { name: "Page snapshot lazy iframe", body: pageSnapshotLazyIframeCase },
   {
     name: "Page snapshot sibling iframes",

--- a/package/ego-browser/scripts/real-browser-e2e/cases/page-ref-identity.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/cases/page-ref-identity.mjs
@@ -28,9 +28,10 @@ export function pageRefIdentityCase() {
         assertEqual(refFor(partial, 'Second ref action'), secondRef, scope + ' preserves the second button ref');
         assert(!partial.includes('First ref action'), scope + ' omits the first button');
         await page.click(firstRef);
+        await page.click(secondRef);
         const clicks = await page.evaluate(() => window.__refClicks);
         assertEqual(clicks.first, 1, scope + ' keeps the omitted first ref bound to the first button');
-        assertEqual(clicks.second, 0, scope + ' never redirects that ref to the second button');
+        assertEqual(clicks.second, 1, scope + ' preserves the second ref after clicking the first button');
       } finally {
         await page.close();
       }
@@ -43,9 +44,17 @@ export function pageRefPrepareRoundCase() {
     const task = await taskSpace(taskName);
     const page = await newPageAt(task, baseUrl + '/nav-target');
     await page.evaluate(() => {
-      document.body.innerHTML = '<button id="first" aria-label="First round action">First round action</button><button id="second" aria-label="Second round action">Second round action</button>';
+      document.body.innerHTML = '<button id="first" aria-label="First round action">First round action</button><button id="second" aria-label="Second round action">Second round action</button><input aria-label="Cell address"><output></output>';
       window.__refClicks = { first: 0, second: 0 };
       for (const id of ['first', 'second']) document.getElementById(id).onclick = () => window.__refClicks[id]++;
+      document.querySelector('input').onkeydown = (event) => {
+        if (event.key === 'Enter') document.querySelector('output').textContent = event.target.value;
+      };
+      document.getElementById('first').onclick = () => {
+        window.__refClicks.first++;
+        const input = document.querySelector('input');
+        input.replaceWith(input.cloneNode(true));
+      };
     });
     const initial = await page.snapshot();
     const line = initial.split('\n').find((line) => line.includes('Second round action'));
@@ -54,7 +63,9 @@ export function pageRefPrepareRoundCase() {
     const subtree = await page.snapshot({ scope: 'subtree', root: '@' + match[1] });
     const published = subtree.split('\n').find((line) => line.includes('Second round action')).match(/\[ref=(\d+)/);
     assert(published, 'the final snapshot publishes a ref for the second button');
-    await writeFile(join(tempDir, 'page-ref-round.json'), JSON.stringify({ label: page.label, ref: '@' + published[1] }));
+    const input = initial.split('\n').find((line) => line.includes('Cell address')).match(/\[ref=(\d+)/);
+    assert(input, 'the initial snapshot publishes the cell address input');
+    await writeFile(join(tempDir, 'page-ref-round.json'), JSON.stringify({ label: page.label, ref: '@' + published[1], inputRef: '@' + input[1] }));
   `;
 }
 
@@ -64,11 +75,24 @@ export function pageRefResumeRoundCase() {
     const task = await taskSpace(taskName);
     const page = task.page(saved.label);
     try {
+      await page.waitForTimeout(4_000);
       await page.click(saved.ref);
+      await page.fill(saved.inputRef, 'M2');
+      await page.press(saved.inputRef, 'Enter');
       const clicks = await page.evaluate(() => window.__refClicks);
       assertEqual(clicks.second, 1, 'the published subtree ref still clicks the second button in a new round');
       assertEqual(clicks.first, 0, 'restoring a ref never renumbers it to the first button');
-      await assertRejects(() => page.click(saved.ref), 'Stale ref', 'actions invalidate saved refs');
+      assertEqual(await page.evaluate(() => document.querySelector('output').textContent), 'M2', 'fill and press reuse the same input ref across rounds');
+      await assertRejects(() => page.click(saved.ref), 'Stale ref', 'evaluate still invalidates saved refs');
+
+      await page.snapshot();
+      await page.click('loc=css:#first');
+      await assertRejectsAny(() => page.fill(saved.inputRef, 'wrong node', { timeout: 300 }), 'a replaced input cannot inherit its predecessor ref');
+      assertEqual(await page.evaluate(() => document.querySelector('input').value), 'M2', 'the same-name replacement receives no input');
+
+      await page.snapshot();
+      await page.reload();
+      await assertRejects(() => page.click(saved.ref), 'Stale ref', 'navigation rejects refs from the previous document');
     } finally {
       await page.close();
     }

--- a/package/ego-browser/scripts/real-browser-e2e/cases/page-ref-workflows.mjs
+++ b/package/ego-browser/scripts/real-browser-e2e/cases/page-ref-workflows.mjs
@@ -1,0 +1,181 @@
+export function pageRefDialogWorkflowCase() {
+  return String.raw`
+    const task = await taskSpace(taskName);
+    const page = await newPageAt(task, baseUrl + '/nav-target');
+    try {
+      await page.evaluate(() => {
+        document.body.innerHTML = '<section role="dialog" tabindex="0" aria-label="Edit saved link"><button id="category" aria-label="Choose category">Choose category</button><output id="category-result"></output><input id="name" aria-label="Link name"><input id="url" aria-label="Link URL"><button id="save" aria-label="Save link">Save link</button></section><output id="result"></output>';
+        document.querySelector('#category').onclick = () => {
+          document.querySelector('#category').setAttribute('aria-pressed', 'true');
+          document.querySelector('#category-result').textContent = 'Category selected';
+        };
+        document.querySelector('#save').onclick = () => {
+          document.querySelector('#result').textContent = JSON.stringify({
+            name: document.querySelector('#name').value,
+            url: document.querySelector('#url').value,
+          });
+          document.querySelector('[role="dialog"]').remove();
+        };
+      });
+      const snapshot = await page.snapshot({ scope: 'full_page' });
+      const refFor = (name) => {
+        const line = snapshot.split('\n').find((line) => line.includes('"' + name + '"') && line.includes('[ref='));
+        const match = line && line.match(/\[ref=(\d+)/);
+        assert(match, 'snapshot publishes ' + name + ': ' + snapshot);
+        return '@' + match[1];
+      };
+      const dialogRef = refFor('Edit saved link');
+      const categoryRef = refFor('Choose category');
+      const nameRef = refFor('Link name');
+      const urlRef = refFor('Link URL');
+      const saveRef = refFor('Save link');
+
+      // Redfin's filter and Expedia's calendar keep their root while selection changes.
+      await page.click(categoryRef);
+      assertIncludes(
+        await page.snapshot({ scope: 'subtree', root: dialogRef }),
+        'Category selected',
+        'an input action does not invalidate the unchanged dialog root'
+      );
+
+      // Bookmark forms fill multiple fields and save using refs from one snapshot.
+      await page.fill(nameRef, 'agent-favorites');
+      await page.fill(urlRef, baseUrl + '/nav-target');
+      await page.click(saveRef);
+      const result = await page.evaluate(() => ({
+        saved: JSON.parse(document.querySelector('#result').textContent),
+        dialogOpen: Boolean(document.querySelector('[role="dialog"]')),
+      }));
+      assertEqual(result.saved.name, 'agent-favorites', 'the saved link uses the first ref field');
+      assertEqual(result.saved.url, baseUrl + '/nav-target', 'the saved link uses the second ref field');
+      assertEqual(result.dialogOpen, false, 'the original save ref submits and closes the dialog');
+    } finally {
+      await page.close();
+    }
+  `;
+}
+
+export function pageRefFailedActionPrepareCase() {
+  return String.raw`
+    const task = await taskSpace(taskName);
+    const page = await newPageAt(task, baseUrl + '/nav-target');
+    await page.evaluate(() => {
+      document.body.innerHTML = '<button>Duplicate action</button><button>Duplicate action</button><input aria-label="Bookmark search"><button id="menu" aria-label="Result menu">Result menu</button><output id="query"></output><output id="hover"></output>';
+      window.__duplicateClicks = 0;
+      for (const button of document.querySelectorAll('button:not(#menu)')) {
+        button.onclick = () => window.__duplicateClicks++;
+      }
+      document.querySelector('input').oninput = (event) => {
+        document.querySelector('#query').textContent = event.target.value;
+      };
+      document.querySelector('#menu').onmouseenter = () => {
+        document.querySelector('#hover').textContent = 'Menu ready';
+      };
+    });
+    const snapshot = await page.snapshot();
+    const refFor = (name) => {
+      const line = snapshot.split('\n').find((line) => line.includes('"' + name + '"') && line.includes('[ref='));
+      const match = line && line.match(/\[ref=(\d+)/);
+      assert(match, 'snapshot publishes ' + name + ': ' + snapshot);
+      return '@' + match[1];
+    };
+    const saved = { label: page.label, searchRef: refFor('Bookmark search'), menuRef: refFor('Result menu') };
+
+    // RockAuto ambiguity and bookmark locator misses must not poison published refs.
+    await assertRejects(
+      () => page.click('loc=role:button[name="Duplicate action"]'),
+      'matched 2 elements',
+      'an ambiguous action still reports its locator error'
+    );
+    await assertRejects(
+      () => page.fill('loc=css:#missing-search', 'unused', { timeout: 300 }),
+      'matched 0 elements',
+      'a missing input still reports its locator timeout'
+    );
+    // No snapshot/evaluate after the failed actions: the next CLI invocation consumes these refs.
+    await writeFile(join(tempDir, 'page-ref-failed-action.json'), JSON.stringify(saved));
+  `;
+}
+
+export function pageRefFailedActionResumeCase() {
+  return String.raw`
+    const saved = JSON.parse(await readFile(join(tempDir, 'page-ref-failed-action.json'), 'utf8'));
+    const task = await taskSpace(taskName);
+    const page = task.page(saved.label);
+    try {
+      await page.focus(saved.searchRef);
+      await page.keyboard.type('agent-video-research-picks');
+      await page.hover(saved.menuRef);
+      const result = await page.evaluate(() => ({
+        query: document.querySelector('#query').textContent,
+        hover: document.querySelector('#hover').textContent,
+        duplicateClicks: window.__duplicateClicks,
+      }));
+      assertEqual(result.query, 'agent-video-research-picks', 'the first ref action after failed resolution reaches the original input');
+      assertEqual(result.hover, 'Menu ready', 'raw keyboard input preserves the next ref target');
+      assertEqual(result.duplicateClicks, 0, 'failed resolution never chooses an ambiguous target');
+    } finally {
+      await page.close();
+    }
+  `;
+}
+
+export function pageRefUploadPrepareCase() {
+  return String.raw`
+    const task = await taskSpace(taskName);
+    const page = await newPageAt(task, baseUrl + '/nav-target');
+    await page.evaluate(() => {
+      document.body.innerHTML = '<input aria-label="Cell address"><output id="address"></output><section id="upload-dialog" role="dialog" aria-label="Upload file"><input id="file" type="file" hidden><button id="browse" aria-label="Browse file">Browse file</button></section><output id="uploaded"></output>';
+      document.querySelector('[aria-label="Cell address"]').onkeydown = (event) => {
+        if (event.key === 'Enter') document.querySelector('#address').textContent = event.target.value;
+      };
+      document.querySelector('#browse').onclick = () => document.querySelector('#file').click();
+      document.querySelector('#file').onchange = (event) => {
+        document.querySelector('#uploaded').textContent = event.target.files[0].name;
+        document.querySelector('#upload-dialog').remove();
+      };
+    });
+    const snapshot = await page.snapshot({ scope: 'full_page' });
+    const refFor = (name) => {
+      const line = snapshot.split('\n').find((line) => line.includes('"' + name + '"') && line.includes('[ref='));
+      const match = line && line.match(/\[ref=(\d+)/);
+      assert(match, 'snapshot publishes ' + name + ': ' + snapshot);
+      return '@' + match[1];
+    };
+    const addressRef = refFor('Cell address');
+    const browseRef = refFor('Browse file');
+    const chooserPromise = page.waitForFileChooser({ timeout: 5_000 });
+    await page.click(browseRef);
+    const chooser = await chooserPromise;
+    await chooser.setFiles(uploadPath);
+    await page.waitForSelector('#upload-dialog', { state: 'hidden', timeout: 5_000 });
+    // Sheets retains its background address node after the upload dialog disappears.
+    await writeFile(join(tempDir, 'page-ref-upload.json'), JSON.stringify({
+      label: page.label,
+      addressRef,
+      fileName: (await import('node:path')).basename(uploadPath),
+    }));
+  `;
+}
+
+export function pageRefUploadResumeCase() {
+  return String.raw`
+    const saved = JSON.parse(await readFile(join(tempDir, 'page-ref-upload.json'), 'utf8'));
+    const task = await taskSpace(taskName);
+    const page = task.page(saved.label);
+    try {
+      await page.fill(saved.addressRef, 'M2');
+      await page.press(saved.addressRef, 'Enter');
+      const result = await page.evaluate(() => ({
+        address: document.querySelector('#address').textContent,
+        uploaded: document.querySelector('#uploaded').textContent,
+        dialogOpen: Boolean(document.querySelector('#upload-dialog')),
+      }));
+      assertEqual(result.address, 'M2', 'the pre-upload ref still fills and commits the cell address in a new CLI invocation');
+      assertEqual(result.uploaded, saved.fileName, 'the native file chooser delivered the selected file');
+      assertEqual(result.dialogOpen, false, 'the upload removed its dialog without replacing the address input');
+    } finally {
+      await page.close();
+    }
+  `;
+}

--- a/package/ego-browser/src/page-model.test.mjs
+++ b/package/ego-browser/src/page-model.test.mjs
@@ -5112,6 +5112,87 @@ test("Page actions resolve snapshot refs inside the addressed page", async () =>
   });
 });
 
+test("consecutive clicks preserve sibling refs from one snapshot", async () => {
+  await withFixture(async (fixture) => {
+    const task = taskForRound(fixture, "round-a", {
+      async snapshot() {
+        return {
+          content:
+            'button "First" [ref=19]\nbutton "Second" [ref=22]\nbutton "Third" [ref=23]',
+          refs: [19, 22, 23].map((refId) => ({
+            refId,
+            backendNodeId: refId + 100,
+            role: "button",
+          })),
+        };
+      },
+    });
+    const page = await openTestPage(task, "https://example.test/buttons");
+    await page.snapshot();
+
+    await page.click("@19");
+    await page.click("@22");
+    await page.click("@23");
+
+    assert.deepEqual(
+      fixture.calls
+        .filter(([, method]) => method === "DOM.resolveNode")
+        .map(([, , params]) => params.backendNodeId),
+      [119, 122, 123],
+    );
+  });
+});
+
+test("fill and press reuse a published ref in a new round", async () => {
+  await withFixture(async (fixture) => {
+    const page = await openTestPage(
+      taskForRound(fixture, "round-a"),
+      "https://example.test/input",
+    );
+    await page.snapshot();
+    await fixture.services.sleep(4_000);
+    const restored = taskForRound(fixture, "round-b", {
+      pageRefs: new PageRefRegistry(),
+    }).page(page.label);
+
+    await restored.fill("@21", "M2");
+    await restored.press("@21", "Enter");
+
+    assert(
+      fixture.calls.some(
+        ([, method, params]) =>
+          method === "Input.dispatchKeyEvent" && params.key === "Enter",
+      ),
+    );
+    assert.equal(
+      fixture.calls.filter(([kind]) => kind === "snapshot").length,
+      1,
+      "reusing the same node must not trigger a new snapshot",
+    );
+  });
+});
+
+test("raw keyboard input preserves unchanged refs into the next round", async () => {
+  await withFixture(async (fixture) => {
+    const page = await openTestPage(
+      taskForRound(fixture, "round-a"),
+      "https://example.test/input",
+    );
+    await page.snapshot();
+    await page.keyboard.press("Tab");
+    const restored = taskForRound(fixture, "round-b", {
+      pageRefs: new PageRefRegistry(),
+    }).page(page.label);
+
+    await restored.click("@21");
+    assert.equal(
+      fixture.calls.find(([, method]) => method === "DOM.resolveNode")[2]
+        .backendNodeId,
+      21,
+    );
+  });
+});
+
 test("a new round restores the published ref without renumbering from a fresh snapshot", async () => {
   await withFixture(async (fixture) => {
     fixture.services.snapshot = async () => {
@@ -5187,6 +5268,96 @@ test("ref invalidation survives a new Agent round", async () => {
     );
   });
 });
+
+for (const persistentFailure of [false, true]) {
+  test(`cross-round refs survive an iframe document read failure${persistentFailure ? " after the action times out" : " during the first action"}`, async () => {
+    await withFixture(async (fixture) => {
+      let frameSession = "session:oopif";
+      let failFrameRead = false;
+      const baseCdp = fixture.services.cdp;
+      const overrides = {
+        async cdp(method, params, sessionId) {
+          if (method === "Page.getFrameTree") {
+            if (sessionId === "session:target-1") {
+              return {
+                frameTree: {
+                  frame: { id: "main-frame", loaderId: "main-document" },
+                },
+              };
+            }
+            if (failFrameRead) {
+              failFrameRead = persistentFailure;
+              frameSession = "session:oopif-reconnected";
+              throw Object.assign(
+                new Error("Session with given id not found"),
+                {
+                  sessionId,
+                },
+              );
+            }
+            return {
+              frameTree: {
+                frame: { id: "child-frame", loaderId: "same-document" },
+              },
+            };
+          }
+          return baseCdp(method, params, sessionId);
+        },
+        async snapshot() {
+          return {
+            content: 'textbox "Cell address" [ref=19]',
+            refs: [{ refId: 19, backendNodeId: 42, frameId: "child-frame" }],
+          };
+        },
+        async ensureFrameSessions() {
+          return new Map([["child-frame", frameSession]]);
+        },
+      };
+      const page = await openTestPage(
+        taskForRound(fixture, "round-a", overrides),
+        "https://example.test/iframe",
+      );
+      await page.snapshot();
+      failFrameRead = true;
+      let restored = taskForRound(fixture, "round-b", {
+        ...overrides,
+        pageRefs: new PageRefRegistry(),
+      }).page(page.label);
+
+      if (persistentFailure) {
+        await assert.rejects(
+          () => restored.press("@19", "Enter", { timeout: 100 }),
+          /timed out.*Session with given id not found/,
+        );
+        failFrameRead = false;
+        restored = taskForRound(fixture, "round-c", {
+          ...overrides,
+          pageRefs: new PageRefRegistry(),
+        }).page(page.label);
+      }
+      await restored.press("@19", "Enter");
+
+      assert.equal(
+        fixture.calls.filter(
+          ([, method, params]) =>
+            method === "Input.dispatchKeyEvent" &&
+            params.type === "keyUp" &&
+            params.key === "Enter",
+        ).length,
+        1,
+        "document verification must recover before dispatching input once",
+      );
+      assert(
+        fixture.calls.some(
+          ([, method, params, sessionId]) =>
+            method === "DOM.resolveNode" &&
+            params.backendNodeId === 42 &&
+            sessionId === "session:oopif-reconnected",
+        ),
+      );
+    });
+  });
+}
 
 for (const mode of ["page", "same-process iframe", "OOPIF"]) {
   const frameId = mode === "page" ? undefined : "child-frame";

--- a/package/ego-browser/src/page-model.test.mjs
+++ b/package/ego-browser/src/page-model.test.mjs
@@ -1074,6 +1074,8 @@ test("background target discovery adopts a delayed popup and reports its opener"
       },
     });
 
+    // The ledger write can become visible before discovery publishes its notice.
+    await fixture.services.gate.withSpace(7, () => undefined);
     const adopted = await waitForLedgerTarget(ledger, 7, "target-delayed");
     assert.equal(adopted.label, "p2");
     assert.deepEqual(consumeUnhandledPageNotices(), [

--- a/package/ego-browser/src/page-model.ts
+++ b/package/ego-browser/src/page-model.ts
@@ -2688,11 +2688,7 @@ class Page {
   ): Promise<T> {
     return this.#services.gate.withPage(page, async ({ sessionId }) => {
       await this.#activate(page.targetId);
-      try {
-        return await operation(sessionId);
-      } finally {
-        await this.#invalidateRefs(page);
-      }
+      return operation(sessionId);
     });
   }
 
@@ -2783,7 +2779,6 @@ class Page {
         };
       } finally {
         await fileChooserGuard?.dispose();
-        await this.#invalidateRefs(page);
       }
     });
   }
@@ -2864,15 +2859,14 @@ class Page {
         "Cannot verify Page document; take a new snapshot",
         "transient",
       );
-    // The Page tree excludes out-of-process frames. Read their own sessions;
-    // a vanished frame leaves no document identity, so its refs expire.
-    const frames = await Promise.allSettled(
+    // The Page tree excludes out-of-process frames. A failed session read must
+    // reach the retry boundary, not persistently expire refs in a live frame.
+    const frames = await Promise.all(
       [...new Set(iframeSessions.values())]
         .filter((session) => session !== sessionId)
         .map(readTree),
     );
-    for (const frame of frames)
-      if (frame.status === "fulfilled") visit(frame.value);
+    for (const frame of frames) visit(frame);
     documents.set("", root);
     return documents;
   }

--- a/skills/ego-browser/SKILL.md
+++ b/skills/ego-browser/SKILL.md
@@ -186,10 +186,9 @@ line:
 console.log(await page.snapshot({ scope: "subtree", root: "@12" }));
 ```
 
-For cross-process frames, readable subtree content may not include action refs.
-Use a unique `loc=role:` or `loc=css:` selector when an inner action has no ref.
-If subtree reports a duplicate backend node id across frames, use
-`page.snapshot({ scope: "full_page" })`; the runtime refuses to guess.
+Use the refs returned by the subtree for actions inside the iframe. A subtree
+snapshot does not scope later locator actions; they still prefer actionable
+matches in the top document before searching frames.
 
 `waitForLoadState()` defaults to `load`. `waitForFunction()` follows the
 Playwright argument order; pass `undefined` before options when there is no Page
@@ -248,13 +247,6 @@ node has no ref, construct a selector from its role, text, or surrounding
 context. CSS searches nested open shadow roots. Actions use an actionable match
 in the top document first, then search frames when the top document has none.
 Multiple actionable matches in the selected document or frame are ambiguous.
-
-Snapshot refs are intentionally invalidated after input actions,
-`page.evaluate()`, `page.cdp()`, `page.waitForFunction()`,
-`page.waitForLoadState()`, and successful dialog handling because any of them
-can change the document. Take a new snapshot before using another ref; use a
-stable `loc=...` selector when several actions must run without an intervening
-snapshot.
 
 Select options by value, visible label, or zero-based index. A string matches
 either value or label; pass an array for a multiple select:


### PR DESCRIPTION
Consecutive actions such as `fill(ref, "M2")` followed by `press(ref, "Enter")` currently invalidate an unchanged target after the first action. Preserve Page refs across ordinary input actions and failed selector resolution so subsequent actions can reuse the original node.

- Propagate OOPIF document-read failures to the retry boundary instead of persisting an incomplete document map that invalidates live refs.
- Add regression coverage for consecutive clicks, input reuse across CLI invocations, dialog forms, failed actions, file uploads, and rejection after node replacement or navigation.
- Update the browser skill to use iframe subtree refs and explain that later locator actions retain Page matching rules.
- Make beta tag builds create or update draft prereleases.
- Wait for background popup discovery to finish before checking its notice in the existing unit test; ledger persistence alone does not guarantee that notice publication has completed.

Exact node/document checks and invalidation after explicit page script/CDP operations remain in place. The original Redfin and Drive first-use failures were not reproduced in the follow-up investigation; this change does not claim to resolve those unconfirmed incidents.

Validation:
- `npm test`: 488/488 tests passed.
- `npm run e2e`: 69/69 real-browser cases passed with 1,232 assertions.
- Changed-file formatting checks passed; dependency audit reported zero vulnerabilities.
- Six release-step command checks covered beta draft creation/update and unchanged stable/nightly behavior.
- Six additional real-browser checks verified OOPIF subtree refs, locator scope, and unique-locator behavior.
- The initial CI run exposed the background-discovery test race; the corrected test passed 20 consecutive local runs.
